### PR TITLE
Example pages should dog food nx styles RSC-81 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.42.3",
+  "version": "0.42.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -25,21 +25,21 @@ const NxAlertPage = () =>
       <p>Generic alert.</p>
       <p>Handy for DIY alert variations</p>
       <p>Accepts any prop that is valid on a div as well as the following:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>icon</td>
-            <td>FontAwesome's Icons</td>
-            <td>Yes</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">icon</td>
+            <td className="nx-cell">FontAwesome's Icons</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">
               A FontAwesome icon to use in the alert message
             </td>
           </tr>

--- a/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
+++ b/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
@@ -22,33 +22,33 @@ const NxBackButtonPage = () =>
     <GalleryDescriptionTile>
       <p>A standard UI element for navigating back to a previous page</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>targetPageTitle</td>
-            <td>string</td>
-            <td>No</td>
-            <td>The name of the page to navigate to</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">targetPageTitle</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">The name of the page to navigate to</td>
           </tr>
-          <tr>
-            <td>text</td>
-            <td>string</td>
-            <td>No</td>
-            <td>Optional custom text to override the back button's default text logic</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">text</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">Optional custom text to override the back button's default text logic</td>
           </tr>
-          <tr>
-            <td>href</td>
-            <td>URL</td>
-            <td>Yes</td>
-            <td>The URL to navigate to when the back button is clicked</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">href</td>
+            <td className="nx-cell">URL</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">The URL to navigate to when the back button is clicked</td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -23,48 +23,48 @@ const NxCheckboxPage = () =>
       <p>Custom checkbox input.</p>
       <p>Child VDOM will be used as a label following the checkbox button itself.</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>checkboxId</td>
-            <td>string</td>
-            <td>No</td>
-            <td>An id to identify the checkbox</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">checkboxId</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">An id to identify the checkbox</td>
           </tr>
-          <tr>
-            <td>isChecked</td>
-            <td>boolean</td>
-            <td>Yes</td>
-            <td>Whether the checkbox should be rendered as checked or unchecked</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">isChecked</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">Whether the checkbox should be rendered as checked or unchecked</td>
           </tr>
-          <tr>
-            <td>onChange</td>
-            <td>Function (() => void)</td>
-            <td>No</td>
-            <td>A callback for when the checkbox is toggled</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">onChange</td>
+            <td className="nx-cell">Function (() => void)</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">A callback for when the checkbox is toggled</td>
           </tr>
-          <tr>
-            <td>disabled</td>
-            <td>boolean</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">disabled</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               Whether the checkbox should be rendered as disabled or not.  When disabled, the onChange callback will
               not fire.  Defaults to false
             </td>
           </tr>
-          <tr>
-            <td>children</td>
-            <td>Virtual DOM</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">children</td>
+            <td className="nx-cell">Virtual DOM</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               VDOM rendered as a label. Should be
               {' '}
               <a href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content"

--- a/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
+++ b/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
@@ -20,36 +20,36 @@ const NxLoadErrorPage = () =>
     <GalleryDescriptionTile>
       <p>Error message with optional Retry button</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>error</td>
-            <td>string</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">error</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               A message that represents an error that occurred.  If null or undefined, NxLoadError will not render
               anything
             </td>
           </tr>
-          <tr>
-            <td>titleMessage</td>
-            <td>string</td>
-            <td>No</td>
-            <td>A message to display before the error output. Defaults to 'An error occurred loading data.'</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">titleMessage</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">A message to display before the error output. Defaults to 'An error occurred loading data.'</td>
           </tr>
-          <tr>
-            <td>retryHandler</td>
-            <td>Function</td>
-            <td>No</td>
-            <td>If this is defined, a Retry button will be rendered which executes this function when clicked</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">retryHandler</td>
+            <td className="nx-cell">Function</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">If this is defined, a Retry button will be rendered which executes this function when clicked</td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
+++ b/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
@@ -43,13 +43,17 @@ const NxLoadErrorPage = () =>
             <td className="nx-cell">titleMessage</td>
             <td className="nx-cell">string</td>
             <td className="nx-cell">No</td>
-            <td className="nx-cell">A message to display before the error output. Defaults to 'An error occurred loading data.'</td>
+            <td className="nx-cell">
+              A message to display before the error output. Defaults to 'An error occurred loading data.'
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell">retryHandler</td>
             <td className="nx-cell">Function</td>
             <td className="nx-cell">No</td>
-            <td className="nx-cell">If this is defined, a Retry button will be rendered which executes this function when clicked</td>
+            <td className="nx-cell">
+              If this is defined, a Retry button will be rendered which executes this function when clicked
+            </td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -46,7 +46,9 @@ const NxLoadWrapperPage = () =>
             <td className="nx-cell">loading</td>
             <td className="nx-cell">boolean</td>
             <td className="nx-cell">No</td>
-            <td className="nx-cell">If true, and error is unset, a loading spinner will be rendered via NxLoadingSpinner</td>
+            <td className="nx-cell">
+              If true, and error is unset, a loading spinner will be rendered via NxLoadingSpinner
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell">children</td>

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -24,41 +24,41 @@ const NxLoadWrapperPage = () =>
     <GalleryDescriptionTile>
       <p>A component that will display either a loading spinner, an error message, or the specified child VDOM</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>error</td>
-            <td>string</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">error</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               A message that represents an error that occurred.  If defined, will be rendered via NxLoadError
             </td>
           </tr>
-          <tr>
-            <td>loading</td>
-            <td>boolean</td>
-            <td>No</td>
-            <td>If true, and error is unset, a loading spinner will be rendered via NxLoadingSpinner</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">loading</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">If true, and error is unset, a loading spinner will be rendered via NxLoadingSpinner</td>
           </tr>
-          <tr>
-            <td>children</td>
-            <td>VDOM</td>
-            <td>Yes</td>
-            <td>VDOM to render if loading is false and error is not set</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">children</td>
+            <td className="nx-cell">VDOM</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">VDOM to render if loading is false and error is not set</td>
           </tr>
-          <tr>
-            <td>retryHandler</td>
-            <td>Function</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">retryHandler</td>
+            <td className="nx-cell">Function</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               If this is defined, a Retry button will be rendered in the NxLoadError which executes this function
               when clicked
             </td>

--- a/gallery/src/components/NxRadio/NxRadioPage.tsx
+++ b/gallery/src/components/NxRadio/NxRadioPage.tsx
@@ -23,54 +23,54 @@ const NxRadioPage = () =>
       <p>Custom Radio input.</p>
       <p>Child VDOM will be used as a label following the radio button itself.</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>name</td>
-            <td>string</td>
-            <td>Yes</td>
-            <td>The name of the radio group</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">name</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">The name of the radio group</td>
           </tr>
-          <tr>
-            <td>value</td>
-            <td>string</td>
-            <td>Yes</td>
-            <td>The value attribute for radio input</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">value</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">The value attribute for radio input</td>
           </tr>
-          <tr>
-            <td>isChecked</td>
-            <td>boolean</td>
-            <td>Yes</td>
-            <td>Whether the radio button should be rendered as on or off</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">isChecked</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">Whether the radio button should be rendered as on or off</td>
           </tr>
-          <tr>
-            <td>onChange</td>
-            <td>Function ((currentValue: string) => void)</td>
-            <td>No</td>
-            <td>A callback for when the radio is selected. The value is passed as an argument.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">onChange</td>
+            <td className="nx-cell">Function ((currentValue: string) => void)</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">A callback for when the radio is selected. The value is passed as an argument.</td>
           </tr>
-          <tr>
-            <td>disabled</td>
-            <td>boolean</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">disabled</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               Whether the radio should be rendered as disabled or not.  When disabled, the onChange callback will
               not fire.  Defaults to false
             </td>
           </tr>
-          <tr>
-            <td>children</td>
-            <td>Virtual DOM</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">children</td>
+            <td className="nx-cell">Virtual DOM</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               Additional VDOM that will be rendered as label. Should be
               {' '}
               <a href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content"
@@ -79,23 +79,23 @@ const NxRadioPage = () =>
               </a>
             </td>
           </tr>
-          <tr>
-            <td>radioId</td>
-            <td>string</td>
-            <td>No</td>
-            <td>An id attribute to be added to the radio input</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">radioId</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">An id attribute to be added to the radio input</td>
           </tr>
-          <tr>
-            <td>Label HTML Attributes</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">Label HTML Attributes</td>
+            <td className="nx-cell">
               <a target="_blank"
                  rel="noopener"
                  href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
                 HTML Attributes
               </a>
             </td>
-            <td>No</td>
-            <td>NxRadio supports any html attribute that's normally supported by Label element</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">NxRadio supports any html attribute that's normally supported by Label element</td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
+++ b/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
@@ -39,7 +39,9 @@ const NxStatefulCheckboxPage = () =>
             <td className="nx-cell">defaultChecked</td>
             <td className="nx-cell">boolean</td>
             <td className="nx-cell">Yes</td>
-            <td className="nx-cell">Whether the stateful checkbox should initially be rendered as checked (true) or unchecked (false)</td>
+            <td className="nx-cell">
+              Whether the stateful checkbox should initially be rendered as checked (true) or unchecked (false)
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell">onChange</td>

--- a/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
+++ b/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
@@ -19,48 +19,48 @@ const NxStatefulCheckboxPage = () =>
       <p>Custom stateful checkbox input.</p>
       <p>Child VDOM will be used as a label following the stateful checkbox button itself.</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>checkboxId</td>
-            <td>string</td>
-            <td>No</td>
-            <td>An id to identify the stateful checkbox</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">checkboxId</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">An id to identify the stateful checkbox</td>
           </tr>
-          <tr>
-            <td>defaultChecked</td>
-            <td>boolean</td>
-            <td>Yes</td>
-            <td>Whether the stateful checkbox should initially be rendered as checked (true) or unchecked (false)</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">defaultChecked</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">Whether the stateful checkbox should initially be rendered as checked (true) or unchecked (false)</td>
           </tr>
-          <tr>
-            <td>onChange</td>
-            <td>Function ((boolean) => void)</td>
-            <td>No</td>
-            <td>A callback for when the stateful checkbox is toggled</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">onChange</td>
+            <td className="nx-cell">Function ((boolean) => void)</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">A callback for when the stateful checkbox is toggled</td>
           </tr>
-          <tr>
-            <td>disabled</td>
-            <td>boolean</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">disabled</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               Whether the stateful checkbox should be rendered as disabled or not.
               When disabled, the onChange callback will not fire.  Defaults to false
             </td>
           </tr>
-          <tr>
-            <td>children</td>
-            <td>Virtual DOM</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">children</td>
+            <td className="nx-cell">Virtual DOM</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               VDOM rendered as a label. Should be
               {' '}
               <a href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content"

--- a/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
+++ b/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
@@ -26,44 +26,44 @@ const NxStatefulTextInputPage = () =>
     <GalleryDescriptionTile>
       <p>Standard text input with pristine state tracking and pluggable validation handling</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>type</td>
-            <td>"textarea" | "text" | "password"</td>
-            <td>No</td>
-            <td>What type of text input to render.  Defaults to "text"</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">type</td>
+            <td className="nx-cell">"textarea" | "text" | "password"</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">What type of text input to render.  Defaults to "text"</td>
           </tr>
-          <tr>
-            <td>defaultValue</td>
-            <td>string</td>
-            <td>Yes</td>
-            <td>The initial value rendered in the text input</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">defaultValue</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">The initial value rendered in the text input</td>
           </tr>
-          <tr>
-            <td>validator</td>
-            <td>Function ((string) => string | string[] | null)</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">validator</td>
+            <td className="nx-cell">Function ((string) => string | string[] | null)</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               A function that validates user-inputted changes to the text field value. Accepts the new value
               as a string and returns zero or more validation error messages
             </td>
           </tr>
-          <tr>
-            <td>Input HTML Attributes | Textarea HTML Attributes</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">Input HTML Attributes | Textarea HTML Attributes</td>
+            <td className="nx-cell">
               <code className="nx-code">NxTextInput</code> props
             </td>
-            <td>No</td>
-            <td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               Any attribute supported by <code className="nx-code">NxTextInput</code>
             </td>
           </tr>

--- a/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
@@ -77,7 +77,7 @@ const NxStatefulTreeViewMultiSelectPage = () =>
                 <li className="nx-list__item">
                   <code className="nx-code">Set</code> of ids of the currently selected options
                 </li>
-                <li className="nx-list__item"> className="nx-list__item"
+                <li className="nx-list__item">
                   <code className="nx-code">id</code> of the toggled option
                   or <code className="nx-code">undefined</code> if all/none option was toggled
                 </li>

--- a/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
@@ -73,9 +73,11 @@ const NxStatefulTreeViewMultiSelectPage = () =>
             <td className="nx-cell">Yes</td>
             <td className="nx-cell">
               Called whenever selection change occurs; it will receive two arguments:
-              <ul>
-                <li><code className="nx-code" >Set</code> of ids of the currently selected options</li>
-                <li>
+              <ul className="nx-list nx-list--bulleted">
+                <li className="nx-list__item">
+                  <code className="nx-code">Set</code> of ids of the currently selected options
+                </li>
+                <li className="nx-list__item"> className="nx-list__item"
                   <code className="nx-code">id</code> of the toggled option
                   or <code className="nx-code">undefined</code> if all/none option was toggled
                 </li>

--- a/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
@@ -73,8 +73,8 @@ const NxStatefulTreeViewRadioSelectPage = () =>
             <td className="nx-cell">Yes</td>
             <td className="nx-cell">
               Called whenever selection change occurs; it will receive one argument:
-              <ul>
-                <li>
+              <ul className="nx-list nx-list--bulleted">
+                <li className="nx-list__item">
                   <code className="nx-code">id</code> of the toggled option
                 </li>
               </ul>

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -26,54 +26,54 @@ const NxTextInputPage = () =>
     <GalleryDescriptionTile>
       <p>Standard text input with validation styling</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>type</td>
-            <td>"textarea" | "text" | "password"</td>
-            <td>No</td>
-            <td>What type of text input to render.  Defaults to "text"</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">type</td>
+            <td className="nx-cell">"textarea" | "text" | "password"</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">What type of text input to render.  Defaults to "text"</td>
           </tr>
-          <tr>
-            <td>value</td>
-            <td>string</td>
-            <td>Yes</td>
-            <td>The value rendered in the text input</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">value</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">The value rendered in the text input</td>
           </tr>
-          <tr>
-            <td>isPristine</td>
-            <td>boolean</td>
-            <td>Yes</td>
-            <td>Should be set to true when the user has not yet adjusted the value of the input</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">isPristine</td>
+            <td className="nx-cell">boolean</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">Should be set to true when the user has not yet adjusted the value of the input</td>
           </tr>
-          <tr>
-            <td>validationErrors</td>
-            <td>string[]</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">validationErrors</td>
+            <td className="nx-cell">string[]</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               Zero or more validation error messages.  If empty or not defined, the field is considered to be valid.
               If the field is invalid, it will receive error styling and a tooltip displaying the first error message.
             </td>
           </tr>
-          <tr>
-            <td>onChange</td>
-            <td>Function ((string) => void)</td>
-            <td>No</td>
-            <td>A callback for when the user changes the value of the text box (e.g. by typing a letter)</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">onChange</td>
+            <td className="nx-cell">Function ((string) => void)</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">A callback for when the user changes the value of the text box (e.g. by typing a letter)</td>
           </tr>
-          <tr>
-            <td>onKeyPress</td>
-            <td>Function ((string) => void)</td>
-            <td>No</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">onKeyPress</td>
+            <td className="nx-cell">Function ((string) => void)</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               A callback for when the user presses a key that doesn't necessarily change the input value
               (e.g. by hitting enter)
               <p>
@@ -87,21 +87,21 @@ const NxTextInputPage = () =>
               </p>
             </td>
           </tr>
-          <tr>
-            <td>Input HTML Attributes | Textarea HTML Attributes</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">Input HTML Attributes | Textarea HTML Attributes</td>
+            <td className="nx-cell">
               <a target="_blank"
                  rel="noopener"
                  href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
                 HTML Attributes
               </a>
             </td>
-            <td>No</td>
-            <td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
               NxTextInput supports any html attribute that's normally supported by either HTML Inputs or HTML Textareas.
               The only notable exceptions are:
-              <ul>
-                <li>
+              <ul className="nx-list nx-list--bulleted">
+                <li className="nx-list__item">
                   <code className="nx-code">defaultValue</code> which is left out because it creates what's commonly
                   known as{' '}
                   <a target="_blank"
@@ -110,7 +110,7 @@ const NxTextInputPage = () =>
                     uncontrolled inputs
                   </a>
                 </li>
-                <li>
+                <li className="nx-list__item">
                   The attributes specified above, whose types are as defined here and not as specified in the
                   react propTypes.
                 </li>
@@ -127,27 +127,27 @@ const NxTextInputPage = () =>
         <code className="nx-code">validationErrors</code>) as well as <code className="nx-code">trimmedValue</code>,
         which holds a whitespace-trimmed copy of the <code className="nx-code">value</code>:
       </p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Function</th>
-            <th>Arguments</th>
-            <th>Description</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Function</th>
+            <th className="nx-cell nx-cell--header">Arguments</th>
+            <th className="nx-cell nx-cell--header">Description</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>initialState</td>
-            <td>(initialValue: string)</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">initialState</td>
+            <td className="nx-cell">(initialValue: string)</td>
+            <td className="nx-cell">
               Returns an initialized state with the specified value and <code className="nx-code">isPristine</code>
               set to true.
             </td>
           </tr>
-          <tr>
-            <td>userInput</td>
-            <td>(validator, newValue: string)</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">userInput</td>
+            <td className="nx-cell">(validator, newValue: string)</td>
+            <td className="nx-cell">
               <p>
                 Meant to be used to handle user changes to the text input value. The first argument is an optional
                 validator function that receives the new input value (trimmed) as a string and returns zero or more

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -52,7 +52,9 @@ const NxTextInputPage = () =>
             <td className="nx-cell">isPristine</td>
             <td className="nx-cell">boolean</td>
             <td className="nx-cell">Yes</td>
-            <td className="nx-cell">Should be set to true when the user has not yet adjusted the value of the input</td>
+            <td className="nx-cell">
+              Should be set to true when the user has not yet adjusted the value of the input
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell">validationErrors</td>
@@ -67,7 +69,9 @@ const NxTextInputPage = () =>
             <td className="nx-cell">onChange</td>
             <td className="nx-cell">Function ((string) => void)</td>
             <td className="nx-cell">No</td>
-            <td className="nx-cell">A callback for when the user changes the value of the text box (e.g. by typing a letter)</td>
+            <td className="nx-cell">
+              A callback for when the user changes the value of the text box (e.g. by typing a letter)
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell">onKeyPress</td>
@@ -98,8 +102,8 @@ const NxTextInputPage = () =>
             </td>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
-              NxTextInput supports any html attribute that's normally supported by either HTML Inputs or HTML Textareas.
-              The only notable exceptions are:
+              NxTextInput supports any html attribute that's normally supported by either HTML Inputs or HTML
+              Textareas. The only notable exceptions are:
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
                   <code className="nx-code">defaultValue</code> which is left out because it creates what's commonly

--- a/gallery/src/components/NxThreatBar/NxThreatBarPage.tsx
+++ b/gallery/src/components/NxThreatBar/NxThreatBarPage.tsx
@@ -36,59 +36,59 @@ const NxThreatBarPage = () =>
         are passed, <code className="nx-code">threatLevelCategory</code> takes precedence. If neither are passed,
         the <code className="nx-code">unspecified</code> category is used
       </p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>threatLevelCategory</td>
-            <td>One of 'unspecified', 'none', 'low', 'moderate', 'severe', or 'critical'</td>
-            <td>No</td>
-            <td>A Threat Level Category to base the bar color off of</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">threatLevelCategory</td>
+            <td className="nx-cell">One of 'unspecified', 'none', 'low', 'moderate', 'severe', or 'critical'</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">A Threat Level Category to base the bar color off of</td>
           </tr>
-          <tr>
-            <td>policyThreatLevel</td>
-            <td>number (0 - 10 inclusive)</td>
-            <td>No</td>
-            <td>A Policy Threat Level Number to base the bar color off of</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">policyThreatLevel</td>
+            <td className="nx-cell">number (0 - 10 inclusive)</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">A Policy Threat Level Number to base the bar color off of</td>
           </tr>
         </tbody>
       </table>
 
       <p>The following table shows the mapping between threat level number and threat level category</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Threat Level Number</th>
-            <th>Threat Level Category</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Threat Level Number</th>
+            <th className="nx-cell nx-cell--header">Threat Level Category</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>0</td>
-            <td>none</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">0</td>
+            <td className="nx-cell">none</td>
           </tr>
-          <tr>
-            <td>1</td>
-            <td>low</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">1</td>
+            <td className="nx-cell">low</td>
           </tr>
-          <tr>
-            <td>2 - 3</td>
-            <td>moderate</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">2 - 3</td>
+            <td className="nx-cell">moderate</td>
           </tr>
-          <tr>
-            <td>4 - 7</td>
-            <td>severe</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">4 - 7</td>
+            <td className="nx-cell">severe</td>
           </tr>
-          <tr>
-            <td>8 - 10</td>
-            <td>critical</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">8 - 10</td>
+            <td className="nx-cell">critical</td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
@@ -74,7 +74,8 @@ const NxTreeViewMultiSelectPage = () =>
               Called whenever selection change occurs; it will receive two arguments:{' '}
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
-                  <code className="nx-code" >Set</code> of ids of the currently selected options</li>
+                  <code className="nx-code" >Set</code> of ids of the currently selected options
+                </li>
                 <li className="nx-list__item">
                   <code className="nx-code">id</code> of the toggled option
                   or <code className="nx-code">undefined</code> if all/none option was toggled

--- a/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
@@ -72,9 +72,10 @@ const NxTreeViewMultiSelectPage = () =>
             <td className="nx-cell">Yes</td>
             <td className="nx-cell">
               Called whenever selection change occurs; it will receive two arguments:{' '}
-              <ul>
-                <li><code className="nx-code" >Set</code> of ids of the currently selected options</li>
-                <li>
+              <ul className="nx-list nx-list--bulleted">
+                <li className="nx-list__item">
+                  <code className="nx-code" >Set</code> of ids of the currently selected options</li>
+                <li className="nx-list__item">
                   <code className="nx-code">id</code> of the toggled option
                   or <code className="nx-code">undefined</code> if all/none option was toggled
                 </li>

--- a/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
+++ b/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
@@ -22,21 +22,21 @@ const NxVulnerabilityDetailsPage = () =>
     <GalleryDescriptionTile>
       <p>Renders vulnerability details from vulnerabilityDetails JSON</p>
       <p>Props:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Required</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Prop</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Required</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>vulnerabilityDetails</td>
-            <td>Object</td>
-            <td>Yes</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell">vulnerabilityDetails</td>
+            <td className="nx-cell">Object</td>
+            <td className="nx-cell">Yes</td>
+            <td className="nx-cell">
               see <code className="nx-code">VulnerabilityDetails</code> interface
               and <code className="nx-code">vulnerabilityDetailsJson</code> example below
             </td>

--- a/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
+++ b/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
@@ -19,22 +19,22 @@ const FormValidationPage = () =>
         This page demonstrates the typical overall approach to communicating form validation matters to the user.
         There are several things to note here:
       </p>
-      <ul>
-        <li>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
           Fields are not marked invalid while they are pristine. This is handled by
           the <code className="nx-code">NxTextInput</code> state helpers.
         </li>
-        <li>
+        <li className="nx-list__item">
           Optional text fields are declared to the user using
           the <code className="nx-code">nx-label--optional</code> class which adds the <q>- optional</q> text.
           All fields not marked optional are required. This does not apply to checkbox groups where selecting
           nothing is generally just as valid as any other selection.
         </li>
-        <li>
+        <li className="nx-list__item">
           Until all required fields have values, and all values pass validation, the Submit button is disabled
           and provides a tooltip on hover explaining why.
         </li>
-        <li>
+        <li className="nx-list__item">
           Non-pristine fields which are invalid get a red border and a red tooltip displaying the validation error.
           This tooltip is visible until the field becomes valid, as opposed to being hover-triggered. This behavior
           is implemented by <code className="nx-code">NxTextInput</code>

--- a/gallery/src/pages/Home.tsx
+++ b/gallery/src/pages/Home.tsx
@@ -45,7 +45,9 @@ const Home = () =>
               A description of the component and its parameters, as well as an example of how to use the component.
               See also the <code className="nx-code">GalleryDescriptionTile</code> component
             </li>
-            <li className="nx-list__item">Code that demonstrates the component (import the example component and invoke it)</li>
+            <li className="nx-list__item">
+              Code that demonstrates the component (import the example component and invoke it)
+            </li>
             <li className="nx-list__item">
               Code snippet of the example component (use the <code className="nx-code">CodeExample</code> component)
             </li>
@@ -68,10 +70,12 @@ const Home = () =>
         <li className="nx-list__item">
           Import the description page you created earlier
         </li>
-        <li className="nx-list__item">Place the entry in the proper category (creating a new category if necessary)</li>
         <li className="nx-list__item">
-          It is important to note that the key that you use for your entry will be used
-          by <code className="nx-code">react-router</code> to auto-populate the left-hand navigation, page title and URL
+          Place the entry in the proper category (creating a new category if necessary)
+        </li>
+        <li className="nx-list__item">
+          It is important to note that the key that you use for your entry will be used by
+          <code className="nx-code">react-router</code> to auto-populate the left-hand navigation, page title and URL
         </li>
       </ul>
     </GalleryTile>

--- a/gallery/src/pages/Home.tsx
+++ b/gallery/src/pages/Home.tsx
@@ -29,29 +29,29 @@ const Home = () =>
   <>
     <GalleryTile title="How to add a new component to the Gallery" >
       <h3>Create a page describing the component</h3>
-      <ul>
-        <li>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
           For each component or style that you want to add to the Gallery, create a subdirectory
           underneath <code className="nx-code">src/components</code> or <code className="nx-code">src/styles</code>
           with the name of the component or style
         </li>
-        <li>
+        <li className="nx-list__item">
           Under the subdirectory, create 2 Typescript files to describe the behavior of your component or style. One
           file will be <code className="nx-code">[ComponentName]Example.tsx</code>, which has a working example of the
           component with how different parameters are handled. The second file will
           be <code className="nx-code">[ComponentName]Page.tsx</code>, which should contain 3 things:
-          <ul>
-            <li>
+          <ul className="nx-list nx-list--bulleted">
+            <li className="nx-list__item">
               A description of the component and its parameters, as well as an example of how to use the component.
               See also the <code className="nx-code">GalleryDescriptionTile</code> component
             </li>
-            <li>Code that demonstrates the component (import the example component and invoke it)</li>
-            <li>
+            <li className="nx-list__item">Code that demonstrates the component (import the example component and invoke it)</li>
+            <li className="nx-list__item">
               Code snippet of the example component (use the <code className="nx-code">CodeExample</code> component)
             </li>
           </ul>
         </li>
-        <li>
+        <li className="nx-list__item">
           See also <code className="nx-code">NxCheckboxPage.tsx</code>
           and <code className="nx-code">NxCheckboxExample.tsx</code> as an example of how to create a
           component example.
@@ -64,12 +64,12 @@ const Home = () =>
         the <code className="nx-code">pageConfig.ts</code> file
       </p>
       <CodeExample content={pageConfigExample}/>
-      <ul>
-        <li>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
           Import the description page you created earlier
         </li>
-        <li>Place the entry in the proper category (creating a new category if necessary)</li>
-        <li>
+        <li className="nx-list__item">Place the entry in the proper category (creating a new category if necessary)</li>
+        <li className="nx-list__item">
           It is important to note that the key that you use for your entry will be used
           by <code className="nx-code">react-router</code> to auto-populate the left-hand navigation, page title and URL
         </li>

--- a/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
+++ b/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
@@ -23,20 +23,20 @@ const NxContainerHelpersPage = () =>
         The <code className="nx-code">container-vertical</code> and
         <code className="nx-code">container-horizontal</code> SCSS mixins are provided to facilitate these patterns.
       </p>
-      <ul>
-        <li>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
           Elements should specify margin as desired in the directions in which they may have siblings, i.e. top
           and bottom for block elements or left and right for inline elements. They <em>should not</em> specify margin
           in the cross axis. Note that vertical sibling margins do collapse, but horizontal sibling margins do not.
         </li>
-        <li>
+        <li className="nx-list__item">
           Container elements should specify padding on all four sides as desired. Containers should also remove the
           top margin of their first child and the bottom margin of their last child (or left and right margins
           respectively for containers of inline or horizontal-flex items). This means that it is fully left up to
           the container how far its children will be from its borders. No more mix of padding and the last child's
           margin at the bottom.
         </li>
-        <li>
+        <li className="nx-list__item">
           Elements with no visible border or padding box (e.g. no background, no border) should generally not use
           padding, but should instead stick to margin for their spacing from other content. By consistently
           sticking to margin here, we remain compatible with #2 above and also with margin collapsing rules.
@@ -51,8 +51,8 @@ const NxContainerHelpersPage = () =>
       <p>
         These guidelines do have a few caveats that developers must be aware of:
       </p>
-      <ul>
-        <li>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
           Bare text nodes don't count in the <code className="nx-code">:first-child</code> and
           <code className="nx-code">:last-child</code> selectors that are used to implement
           guideline #2. Therefore they can cause those selectors to select the wrong thing. As a result, bare
@@ -60,13 +60,13 @@ const NxContainerHelpersPage = () =>
           react components that take children but which support those children being a mix of inline and block
           elements, such as <code className="nx-code">NxAlert</code>.
         </li>
-        <li>
+        <li className="nx-list__item">
           Any CSS styles that cause the visual order of elements to not follow the document order of elements
           can similarly cause <code className="nx-code">:first-child</code> and
           <code className="nx-code">:last-child</code> problems. Floats are the most obvious offender here.
           Again, use with caution.
         </li>
-        <li>
+        <li className="nx-list__item">
           The specificity on the <code className="nx-code">{'>'} :first-child</code> selector isn't that high as it
           turns out, and component style can sometimes inadvertently override it.
         </li>

--- a/gallery/src/styles/NxCounter/NxCounterPage.tsx
+++ b/gallery/src/styles/NxCounter/NxCounterPage.tsx
@@ -24,24 +24,24 @@ const NxCounterPage = () =>
         Some basic positioning CSS examples have been provided. To right justify the counter within its container use
         <code className="nx-code">nx-pull-right</code>.
       </p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Class</th>
-            <th>Location</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Class</th>
+            <th className="nx-cell nx-cell--header">Location</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><code className="nx-code">.nx-counter</code></td>
-            <td>Top level</td>
-            <td>Basic counter styling. Supports # of # and text string.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-counter</code></td>
+            <td className="nx-cell">Top level</td>
+            <td className="nx-cell">Basic counter styling. Supports # of # and text string.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-counter--active</code></td>
-            <td>Modifier of <code className="nx-code">.nx-counter</code></td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-counter--active</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-counter</code></td>
+            <td className="nx-cell">
               An active state, used in lists or tree-views when the parent also has an active state.
             </td>
           </tr>

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -66,7 +66,9 @@ const NxListPage = () =>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-list--definition-list</code></td>
             <td className="nx-cell">Modifier of <code className="nx-code">.nx-list</code></td>
-            <td className="nx-cell">Definition lists have two elements: a label and the data associated with that label.</td>
+            <td className="nx-cell">
+              Definition lists have two elements: a label and the data associated with that label.
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-list__item--with-modifier-icon</code></td>
@@ -89,7 +91,9 @@ const NxListPage = () =>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-error</code></td>
             <td className="nx-cell">Modifier of <code className="nx-code">.nx-list__item</code></td>
-            <td className="nx-cell">Not strictly speaking a modifier, this is added to a list item when the list is in an error state.</td>
+            <td className="nx-cell">
+              Not strictly speaking a modifier, this is added to a list item when the list is in an error state.
+            </td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -13,18 +13,18 @@ const NxListPage = () =>
   <>
     <GalleryDescriptionTile>
       <p>Lists take many forms:</p>
-      <ul>
-        <li>Simple data lists</li>
-        <li>Lists with clickable list items</li>
-        <li>Lists with bullets</li>
-        <li>Definition Lists</li>
-        <li>Lists with actions</li>
-        <li>Lists with items that have multiple lines of text</li>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">Simple data lists</li>
+        <li className="nx-list__item">Lists with clickable list items</li>
+        <li className="nx-list__item">Lists with bullets</li>
+        <li className="nx-list__item">Definition Lists</li>
+        <li className="nx-list__item">Lists with actions</li>
+        <li className="nx-list__item">Lists with items that have multiple lines of text</li>
       </ul>
       <p>Lists can also have modified states depending on their content:</p>
-      <ul>
-        <li>Lists with no data</li>
-        <li>Error states</li>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">Lists with no data</li>
+        <li className="nx-list__item">Error states</li>
       </ul>
       <p>
         The basic layout is a container <code className="nx-code">&lt;div&gt;</code> wrapping a

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -36,60 +36,60 @@ const NxListPage = () =>
         when clicked an event occurs - usually navigation. Clickable lists have hover and disabled states. They share
         error and empty states with default lists.
       </p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Class</th>
-            <th>Location</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Class</th>
+            <th className="nx-cell nx-cell--header">Location</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><code className="nx-code">.nx-list</code></td>
-            <td>Top-Level</td>
-            <td>The parent list class. It has no bullets.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-list</code></td>
+            <td className="nx-cell">Top-Level</td>
+            <td className="nx-cell">The parent list class. It has no bullets.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-list--clickable</code></td>
-            <td>Modifier of <code className="nx-code">.nx-list</code></td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-list--clickable</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list</code></td>
+            <td className="nx-cell">
               This modifier causes list items to respond to hover events. There is normally a chevron icon on the
               right to make it clear to the user that clicking will navigate away from the page.
             </td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-list--bulleted</code></td>
-            <td>Modifier of <code className="nx-code">.nx-list</code></td>
-            <td>If you need a list with bullets.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-list--bulleted</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list</code></td>
+            <td className="nx-cell">If you need a list with bullets.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-list--definition-list</code></td>
-            <td>Modifier of <code className="nx-code">.nx-list</code></td>
-            <td>Definition lists have two elements: a label and the data associated with that label.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-list--definition-list</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list</code></td>
+            <td className="nx-cell">Definition lists have two elements: a label and the data associated with that label.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-list__item--with-modifier-icon</code></td>
-            <td>Modifier of <code className="nx-code">.nx-list__item</code></td>
-            <td>Use this when you want to have a button on the far right.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-list__item--with-modifier-icon</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list__item</code></td>
+            <td className="nx-cell">Use this when you want to have a button on the far right.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-list__subtext</code></td>
-            <td>Element</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-list__subtext</code></td>
+            <td className="nx-cell">Element</td>
+            <td className="nx-cell">
               When you want a separate line below the main list item use a <code className="nx-code">&lt;p&gt;</code>
               with <code className="nx-code">.nx-list__subtext</code>
             </td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-list__item--empty</code></td>
-            <td>Modifier of <code className="nx-code">.nx-list__item</code></td>
-            <td>Used when there are no list items returned.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-list__item--empty</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list__item</code></td>
+            <td className="nx-cell">Used when there are no list items returned.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-error</code></td>
-            <td>Modifier of <code className="nx-code">.nx-list__item</code></td>
-            <td>Not strictly speaking a modifier, this is added to a list item when the list is in an error state.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-error</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list__item</code></td>
+            <td className="nx-cell">Not strictly speaking a modifier, this is added to a list item when the list is in an error state.</td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
+++ b/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
@@ -23,34 +23,34 @@ const NxPageTitlePage = () =>
         Note: <code className="nx-code">.nx-page-title</code> replaces
         <code className="nx-code">.nx-tile--top-tile</code> and <code className="nx-code">.nx-tile--title-only</code>.
       </p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Class</th>
-            <th>Location</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Class</th>
+            <th className="nx-cell nx-cell--header">Location</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><code className="nx-code">.nx-page-title</code></td>
-            <td>Top level</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-page-title</code></td>
+            <td className="nx-cell">Top level</td>
+            <td className="nx-cell">
               This is the basic wrapper class. The title text is almost always contained in an
               <code className="nx-code">&lt;h1&gt;</code>.
             </td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-page-title__page-icon</code></td>
-            <td>Element</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-page-title__page-icon</code></td>
+            <td className="nx-cell">Element</td>
+            <td className="nx-cell">
               Class for an icon that appears to the left of the page title.
             </td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-page-title__description</code></td>
-            <td>Element</td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-page-title__description</code></td>
+            <td className="nx-cell">Element</td>
+            <td className="nx-cell">
               If there is page level descriptive text it should be wrapped in a containing
               <code className="nx-code">&lt;div&gt;</code> with this class.
             </td>

--- a/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
+++ b/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
@@ -45,7 +45,9 @@ const NxTextInputStylesPage = () =>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-text-input--long</code></td>
             <td className="nx-cell">Any <code className="nx-code">.nx-text-input</code> element</td>
-            <td className="nx-cell">Use this class to make the text input particularly wide (395px vs the default 219px)</td>
+            <td className="nx-cell">
+              Use this class to make the text input particularly wide (395px vs the default 219px)
+            </td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
+++ b/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
@@ -22,30 +22,30 @@ const NxTextInputStylesPage = () =>
         the <a href="#pages/NxTextInput">NxTextInput React Component</a>.
       </p>
       <p>Classes:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Class</th>
-            <th>Location</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Class</th>
+            <th className="nx-cell nx-cell--header">Location</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><code className="nx-code">.nx-text-input</code></td>
-            <td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-text-input</code></td>
+            <td className="nx-cell">
               Any text-oriented <code className="nx-code">{'<input>'}</code> type or
               <code className="nx-code">{'<textarea>'}</code>
             </td>
-            <td>
+            <td className="nx-cell">
               Gives the input typical Sonatype input styling with 1px grey borders on the top, right, and bottom,
               and a 3px grey border on the left
             </td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-text-input--long</code></td>
-            <td>Any <code className="nx-code">.nx-text-input</code> element</td>
-            <td>Use this class to make the text input particularly wide (395px vs the default 219px)</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-text-input--long</code></td>
+            <td className="nx-cell">Any <code className="nx-code">.nx-text-input</code> element</td>
+            <td className="nx-cell">Use this class to make the text input particularly wide (395px vs the default 219px)</td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -18,69 +18,69 @@ const NxTilePage = () =>
         It can also be paired with <code className="nx-code">.nx-alert</code> to create tiles with alert coloring.
       </p>
       <p>They're all showcased in the table below:</p>
-      <table className="gallery-props-table">
+      <table className="nx-table nx-table--gallery-props">
         <thead>
-          <tr>
-            <th>Class</th>
-            <th>Location</th>
-            <th>Details</th>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Class</th>
+            <th className="nx-cell nx-cell--header">Location</th>
+            <th className="nx-cell nx-cell--header">Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><code className="nx-code">.nx-tile</code></td>
-            <td>Top-Level</td>
-            <td>The parent tile class.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Top-Level</td>
+            <td className="nx-cell">The parent tile class.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-tile__actions</code></td>
-            <td>Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td>Used for actions (buttons or dropdowns) that appear in a tile header.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile__actions</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Used for actions (buttons or dropdowns) that appear in a tile header.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-tile-header</code></td>
-            <td>Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td>Used for tile titles, it has title and optional sub-title elements.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile-header</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Used for tile titles, it has title and optional sub-title elements.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-tile-header__title</code></td>
-            <td>Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td>Used for the main title inside an <code className="nx-code">.nx-tile-header</code>.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile-header__title</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
+            <td className="nx-cell">Used for the main title inside an <code className="nx-code">.nx-tile-header</code>.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-tile-header__subtitle</code></td>
-            <td>Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td>Used for the subtitle inside an <code className="nx-code">.nx-tile-header</code>.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile-header__subtitle</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
+            <td className="nx-cell">Used for the subtitle inside an <code className="nx-code">.nx-tile-header</code>.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-tile-header--hrule</code></td>
-            <td>Modifier of <code className="nx-code">.nx-tile-header</code></td>
-            <td>Used for displaying an horizontal rule between the header and the content.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile-header--hrule</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile-header</code></td>
+            <td className="nx-cell">Used for displaying an horizontal rule between the header and the content.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-tile-content</code></td>
-            <td>Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td>Used for the tile content.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile-content</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Used for the tile content.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-tile-footer</code></td>
-            <td>Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td>Used for footer contents (buttons for example)</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile-footer</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Used for footer contents (buttons for example)</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-alert</code></td>
-            <td>Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td>Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-alert</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-alert--info</code></td>
-            <td>Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td>Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-alert--info</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
           </tr>
-          <tr>
-            <td><code className="nx-code">.nx-alert--error</code></td>
-            <td>Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td>Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
+          <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-alert--error</code></td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
+            <td className="nx-cell">Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -45,12 +45,16 @@ const NxTilePage = () =>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-tile-header__title</code></td>
             <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell">Used for the main title inside an <code className="nx-code">.nx-tile-header</code>.</td>
+            <td className="nx-cell">
+              Used for the main title inside an <code className="nx-code">.nx-tile-header</code>.
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-tile-header__subtitle</code></td>
             <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell">Used for the subtitle inside an <code className="nx-code">.nx-tile-header</code>.</td>
+            <td className="nx-cell">
+              Used for the subtitle inside an <code className="nx-code">.nx-tile-header</code>.
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-tile-header--hrule</code></td>
@@ -70,17 +74,23 @@ const NxTilePage = () =>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-alert</code></td>
             <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
+            <td className="nx-cell">
+              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-alert--info</code></td>
             <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
+            <td className="nx-cell">
+              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
+            </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-alert--error</code></td>
             <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.</td>
+            <td className="nx-cell">
+              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
+            </td>
           </tr>
         </tbody>
       </table>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.42.3",
+  "version": "0.42.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -11,7 +11,7 @@
   @include container-vertical;
   margin: $nx-spacing-sm 0 $nx-spacing-md 0;
 
-  > ul, > ol {
+  &, > ul, > ol {
     list-style: none;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-81

This is a big PR, but mostly it's repetition.

Converted unclassed lists to `nx-list--bulleted`.

Converted unclassed tables to `nx-table--gallery-props`.

I left the custom class in place in case the design group (who are actively looking at the RSC now) decide on custom styles for the documentation portions of the example screens. If they don't then it's trivial to remove the custom classes.

I also tweaked the `nx-list` styles to handle the instance where `nx-list` is applied directly to a `<ul>` as opposed to a wrapping `<div>`.