### PR TITLE
Bugfix empty error table body

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTableBody/NxTableBody.tsx
+++ b/lib/src/components/NxTableBody/NxTableBody.tsx
@@ -45,7 +45,7 @@ const NxTableBody = function NxTableBody(props: Props) {
   return (
     <tbody {...attrs}>
       {isLoading && loadingSpinnerRow}
-      {error && !isLoading && errorRow}
+      {!!error && !isLoading && errorRow}
       {!isLoading && !error && children}
     </tbody>
   );


### PR DESCRIPTION
If the error string is falsey, it would cause the following warning:

> Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a child of <tbody>. Make sure you don't have any extra whitespace between tags on each line of your source code.

The NxLoadWrapper doesn't show the NxLoadError component if the error string is falsey so I want to keep that behavior here but hide the warning.