### PR TITLE
Rename nx-root-container - RSC-89

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -45,7 +45,7 @@ function Application() {
   return (
     <Router>
       <PageHeader />
-      <div className="nx-page-content-container">
+      <div className="nx-page-content">
         <aside className="nx-page-sidebar" id="gallery-sidebar">
           <GalleryNav />
         </aside>

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -45,7 +45,7 @@ function Application() {
   return (
     <Router>
       <PageHeader />
-      <div className="nx-root-container">
+      <div className="nx-page-content-container">
         <aside className="nx-page-sidebar" id="gallery-sidebar">
           <GalleryNav />
         </aside>

--- a/gallery/src/PageHeader.tsx
+++ b/gallery/src/PageHeader.tsx
@@ -12,8 +12,8 @@ const sonatypeLogo = require('@sonatype/react-shared-components/assets/img/SON_h
 
 function PageHeader() {
   return (
-    <header className="nx-header">
-      <div className="nx-header__inner">
+    <header className="nx-page-header">
+      <div className="nx-page-header__inner">
         <a href="#" className="nx-product">
           <img src={sonatypeLogo} className="nx-product__logo"/>
           <div className="nx-product__name">

--- a/gallery/src/index.html
+++ b/gallery/src/index.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="gallery.css"/>
   </head>
   <body class="nx-body">
-    <div id="ui" class="nx-body-container"></div>
+    <div id="ui" class="nx-page"></div>
     <script src="bundle.js"></script>
   </body>
 </html>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page-header.scss
+++ b/lib/src/base-styles/_nx-page-header.scss
@@ -19,14 +19,14 @@ $main-header-product-version-row-height: 1fr;
   #Main Header
 */
 
-.nx-header {
+.nx-page-header {
   background-color: $nx-off-black;
   flex-shrink: 0; // needed for IE11
   height: $main-header-height;
   width: 100%;
 }
 
-.nx-header__inner {
+.nx-page-header__inner {
   @include container-horizontal;
 
   display: flex;

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -25,7 +25,7 @@
   padding: 0;
 }
 
-.nx-body-container {
+.nx-page {
   @include container-vertical;
 
   align-items: center;
@@ -35,7 +35,7 @@
   min-width: $nx-page-width-min;
 }
 
-.nx-page-content-container {
+.nx-page-content {
   @include container-horizontal;
 
   box-sizing: border-box;

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -35,7 +35,7 @@
   min-width: $nx-page-width-min;
 }
 
-.nx-root-container {
+.nx-page-content-container {
   @include container-horizontal;
 
   box-sizing: border-box;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-89

Simple change to make the intention of this wrapping class clearer. 

`nx-root-container` isn't very clear as a class name, the purpose of this `<div>` is to act as a container for `.nx-page-sidebar` and `.nx-page-main`. I think `.nx-page-content-container` is more clear in its intent.