### PR TITLE
Better fix for nested nx lists - RSC-81 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.44.8",
+  "version": "0.44.9",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.44.5",
+  "version": "0.44.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxList/NxListBulletedExample.tsx
+++ b/gallery/src/styles/NxList/NxListBulletedExample.tsx
@@ -17,9 +17,34 @@ const NxListWithBullets = () =>
       </li>
       <li className="nx-list__item">
         Item 2
+        <ul>
+          <li className="nx-list__item">
+            item 1
+          </li>
+          <li className="nx-list__item">
+            Item 2
+          </li>
+          <li className="nx-list__item">
+            item 3
+            <ul>
+              <li className="nx-list__item">
+                item 1
+              </li>
+              <li className="nx-list__item">
+                Item 2
+              </li>
+              <li className="nx-list__item">
+                item 3
+              </li>
+            </ul>
+          </li>
+          <li className="nx-list__item">
+            Item 4
+          </li>
+        </ul>
       </li>
       <li className="nx-list__item">
-        item 3
+        Item 3
       </li>
     </ul>
   </div>;

--- a/gallery/src/styles/NxList/NxListBulletedExample.tsx
+++ b/gallery/src/styles/NxList/NxListBulletedExample.tsx
@@ -11,13 +11,13 @@ const NxListWithBullets = () =>
     <h4 className="nx-list__title">
       List title
     </h4>
-    <ul>
+    <ul className="nx-list nx-list--bulleted">
       <li className="nx-list__item">
         item 1
       </li>
       <li className="nx-list__item">
         Item 2
-        <ul>
+        <ul className="nx-list nx-list--bulleted">
           <li className="nx-list__item">
             item 1
           </li>
@@ -26,7 +26,7 @@ const NxListWithBullets = () =>
           </li>
           <li className="nx-list__item">
             item 3
-            <ul>
+            <ul className="nx-list nx-list--bulleted">
               <li className="nx-list__item">
                 item 1
               </li>

--- a/gallery/src/styles/NxList/NxListDefaultExample.tsx
+++ b/gallery/src/styles/NxList/NxListDefaultExample.tsx
@@ -7,13 +7,28 @@
 import React from 'react';
 
 const NxDefaultList = () =>
-  <div className="nx-list">
-    <h4 className="nx-list__title">
-      List title
-    </h4>
-    <ul>
+  <>
+    <div className="nx-list">
+      <h4 className="nx-list__title">
+        List title
+      </h4>
+      <ul>
+        <li className="nx-list__item">
+          item 1
+        </li>
+        <li className="nx-list__item">
+          Item 2
+        </li>
+        <li className="nx-list__item">
+          item 3 - this list item should be truncated at the right end edge. youtube weathered network network systemic
+          systema claymore mine voodoo god garage monofilament realism order-flow corporation car footage vinyl.
+        </li>
+      </ul>
+    </div>
+
+    <ul className="nx-list">
       <li className="nx-list__item">
-        item 1
+        Item 1 - nx-list can also be applied directly to a &lt;ul&gt; or &lt;ol&gt;.
       </li>
       <li className="nx-list__item">
         Item 2
@@ -23,6 +38,6 @@ const NxDefaultList = () =>
         systema claymore mine voodoo god garage monofilament realism order-flow corporation car footage vinyl.
       </li>
     </ul>
-  </div>;
+  </>;
 
 export default NxDefaultList;

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.44.8",
+  "version": "0.44.9",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.44.5",
+  "version": "0.44.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -10,8 +10,9 @@
 .nx-list {
   @include container-vertical;
   margin: $nx-spacing-sm 0 $nx-spacing-md 0;
+  padding: 0;
 
-  &, > ul, > ol {
+  ul, ol {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -64,6 +65,22 @@
     overflow: visible;
     padding: 6px 10px 6px 0;
     white-space: normal;
+  }
+
+  .nx-list__item {
+    list-style-type: disc;
+
+    ul {
+      margin-top: $nx-spacing-sm;
+    }
+
+    .nx-list__item {
+      list-style-type: circle;
+
+      .nx-list__item {
+        list-style-type: square;
+      }
+    }
   }
 }
 

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -70,7 +70,7 @@
   .nx-list__item {
     list-style-type: disc;
 
-    ul {
+    .nx-list {
       margin-top: $nx-spacing-sm;
     }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-81

As part of the work to use `nx-table` and `nx-list` in our example documentation I created an overly broad class to deal with the issue where `nx-list` is applied to a `<ul>` or `<ol>` instead of a wrapping `<div>`, in particular where lists are nested within lists. This resulted in a display bug in IQ. This PR fixes that class, improves the styling of nested, bulleted lists, and provides examples for nested tables. 
