### PR TITLE
SRE-10 trigger downstream publish to s3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,9 @@ dockerizedBuildPipeline(
   testResults: ['lib/junit.xml'],
   onSuccess: {
     githubStatusUpdate('success')
+    build job:'publish-gallery-to-s3', propagate: false, wait: false, parameters: [
+      run(name: 'Producer', runId: "${currentBuild.fullProjectName}${currentBuild.displayName}")
+    ]
   },
   onFailure: {
     githubStatusUpdate('failure')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ dockerizedBuildPipeline(
   testResults: ['lib/junit.xml'],
   onSuccess: {
     githubStatusUpdate('success')
-    build job:'publish-gallery-to-s3', propagate: false, wait: false, parameters: [
+    build job:'/uxui/publish-gallery-to-s3', propagate: false, wait: false, parameters: [
       run(name: 'Producer', runId: "${currentBuild.fullProjectName}${currentBuild.displayName}")
     ]
   },

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.44.6",
+  "version": "0.44.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.44.7",
+  "version": "0.44.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.44.7",
+  "version": "0.44.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.44.6",
+  "version": "0.44.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I kinda already have a 👍 from Jenkins, because the branch build:

https://jenkins.ci.sonatype.dev/job/uxui/job/sonatype-react-shared-components/job/SRE-10_trigger_downstream_publish_to_s3/4/console

succeeded and triggered:

https://jenkins.ci.sonatype.dev/job/uxui/job/publish-gallery-to-s3/37/console

which also succeeded.

@rpokorny I had to bump the version because Jenkins won't build otherwise, but I just wanted to point out that this PR is all about Jenkins.  There are no changes to the actual components in the gallery.