### PR TITLE
Adjust default line height - RSC-93

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.44.9",
+  "version": "0.45.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.44.9",
+  "version": "0.45.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -63,7 +63,7 @@
     @include regular();
 
     border: none;
-    line-height: 1.5;
+    line-height: $nx-line-height;
     list-style: disc outside;
     margin: $nx-spacing-sm 10px $nx-spacing-sm 36px;
     overflow: visible;

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -63,6 +63,7 @@
     @include regular();
 
     border: none;
+    line-height: 1.5;
     list-style: disc outside;
     margin: $nx-spacing-sm 10px $nx-spacing-sm 36px;
     overflow: visible;

--- a/lib/src/base-styles/_nx-typography.scss
+++ b/lib/src/base-styles/_nx-typography.scss
@@ -39,7 +39,7 @@
   @include regular();
 
   font-size: $nx-font-size-s;
-  line-height: 18px;
+  line-height: 1.5;
 }
 
 .nx-h1 {

--- a/lib/src/base-styles/_nx-typography.scss
+++ b/lib/src/base-styles/_nx-typography.scss
@@ -47,7 +47,7 @@
   @include container-horizontal;
 
   font-size: $nx-font-size-heading-level-1;
-  line-height: 35px;
+  line-height: 1.35;
   margin-bottom: $nx-spacing-l;
 }
 
@@ -56,7 +56,7 @@
   @include container-horizontal;
 
   font-size: $nx-font-size-heading-level-2;
-  line-height: 24px;
+  line-height: 1.20;
   margin-bottom: $nx-spacing-md;
 }
 
@@ -65,7 +65,7 @@
   @include container-horizontal;
 
   font-size: $nx-font-size-heading-level-3;
-  line-height: 21px;
+  line-height: 1.17;
   margin-bottom: $nx-spacing-xs;
 }
 
@@ -74,14 +74,13 @@
   @include container-horizontal;
 
   font-size: $nx-font-size-heading-level-4;
-  line-height: 16px;
+  line-height: 1.17;
   margin-bottom: 8px;
   text-transform: uppercase;
 }
 
 .nx-p {
   font-size: $nx-font-size-s;
-  line-height: 16px;
   margin-bottom: $nx-spacing-md;
 }
 

--- a/lib/src/base-styles/_nx-typography.scss
+++ b/lib/src/base-styles/_nx-typography.scss
@@ -39,7 +39,7 @@
   @include regular();
 
   font-size: $nx-font-size-s;
-  line-height: 1.5;
+  line-height: $nx-line-height;
 }
 
 .nx-h1 {

--- a/lib/src/scss-shared/_nx-variables.scss
+++ b/lib/src/scss-shared/_nx-variables.scss
@@ -39,6 +39,9 @@ $nx-font-size-heading-level-2: 20px;
 $nx-font-size-heading-level-3: 18px;
 $nx-font-size-heading-level-4: 14px;
 
+// Line-height
+$nx-line-height: 1.5;
+
 // Form variables
 $nx-form-element-height: 32px;
 $nx-form-element-width-normal: 219px;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-93

Per directions from Derrek the default line-height on `nx-body` was changed to `1.5`. Then I changed the `h#` to unitless values and changed `nx-p` and bulleted list items to use the default values.

There is a small difference in the line-heights of bulleted list items and paragraphs, and very little difference elsewhere.