### PR TITLE
Allow tree-shaking to eliminate unused files from bundle - RSC-112

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.45.8",
+  "version": "0.45.9",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.45.9",
+  "version": "0.45.10",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.45.8",
+  "version": "0.45.9",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {
@@ -87,5 +87,8 @@
   "versionedSources": [
     "../gallery/package.json"
   ],
-  "sideEffects": ["index.js", "*.scss"]
+  "sideEffects": [
+    "index.js",
+    "*.scss"
+  ]
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.45.9",
+  "version": "0.45.10",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -86,5 +86,6 @@
   },
   "versionedSources": [
     "../gallery/package.json"
-  ]
+  ],
+  "sideEffects": ["index.js", "*.scss"]
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-112

See the [webpack docs](https://webpack.js.org/guides/tree-shaking/).  Consuming projects must have their webpack build set up appropriately to take advantage of this.  Notably, tree shaking only happens during prod builds, and only happens if the consuming project uses ES2015 imports during the _webpack_ build stage.  As an example of what I mean by that, `sonatype-application-builder` is currently configured to transpile ES2015 imports to commonjs imports during the typescript compilation phase.  By the time webpack gets to it, it's already commonjs and thus tree-shaking can't be done.  I will create a PR to fix that project once this is merged.