### PR TITLE
Publish only for master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,9 +92,11 @@ dockerizedBuildPipeline(
   testResults: ['lib/junit.xml'],
   onSuccess: {
     githubStatusUpdate('success')
-    build job:'/uxui/publish-gallery-to-s3', propagate: false, wait: false, parameters: [
-      run(name: 'Producer', runId: "${currentBuild.fullProjectName}${currentBuild.displayName}")
-    ]
+    if (env.BRANCH_NAME == 'master') {
+      build job:'/uxui/publish-gallery-to-s3', propagate: false, wait: false, parameters: [
+        run(name: 'Producer', runId: "${currentBuild.fullProjectName}${currentBuild.displayName}")
+      ]
+    }
   },
   onFailure: {
     githubStatusUpdate('failure')

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.45.10",
+  "version": "0.45.11",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.45.10",
+  "version": "0.45.11",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I think I had originally meant for publish to be in the same deploy block that only publishes to npmjs from master, but then changed my mind and moved it to the onSuccess block.  Anyway, this PR add the check to publish only from master and here's a Jenkins job that ran successfully for my PR branch but did NOT kick off a publish job:

https://jenkins.ci.sonatype.dev/job/uxui/job/sonatype-react-shared-components/job/publish-only-for-master/2/