### PR TITLE
Track latest release during CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,7 @@ dockerizedBuildPipeline(
       sh '''
         tag="v$VERSION"
         git tag "$tag" && git push origin "$tag"
+        git push origin master:latest-release
       '''
     }
   },

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.45.15",
+  "version": "0.45.16",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.45.15",
+  "version": "0.45.16",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This is the first step towards avoiding publishing RSC to npmjs for versions where the gallery was the only thing that changed (the gallery isn't part of what gets published, so we are effectively publishing duplicate versions of the library whenever gallery-only changes are merged).

My plan is to 
1. Create a `latest-published` branch which will always point to the most recent successfully published commit.
2. Add conditional logic so that new master builds only publish to npmjs if there are differences in the `lib` dir between `latest-published` and `master`.

This PR implements 1.