### PR TITLE
Fix gallery-nav-link alignment/cut-off issue - RSC-156

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -25,7 +25,6 @@
 }
 
 .nx-tree-view__child.gallery-nav-link {
-  font-size: 14px;
   height: 32px;
   line-height: 32px;
   margin-right: 0;
@@ -37,7 +36,6 @@
   border-radius: 6px;
   box-sizing: border-box;
   display: inline-block;
-  font-size: 14px;
   height: 32px;
   margin-bottom: 4px;
   padding-left: 45px;

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -25,7 +25,7 @@
 }
 
 .nx-tree-view__child.gallery-nav-link {
-  font-size: 16px;
+  font-size: 14px;
   height: 32px;
   line-height: 32px;
   margin-right: 0;

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-156

This PR makes the font size of the container equal to that of its contents, removing the problematic baseline alignment problems that come when it isn't