### PR TITLE
Remove custom line-height from nx-cell

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -66,7 +66,6 @@
   color: $nx-text-color;
   display: table-cell;
   height: 39px; // 38px cell, 1px top border
-  line-height: 16px;
   padding: $nx-spacing-xs $nx-spacing-sm;
   position: relative;
   text-align: left;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-154

An additional ticket will be created to go through the entire RSC and reconsider all remaining custom line-heights.  Many of them are likely incorrect, but cleaning that up is considered a post-1.0 task