### PR TITLE
NxFilterInput redesign RSC-124

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -91,6 +91,7 @@
   flex-grow: 1;
   font-size: $nx-font-size;
   line-height: $nx-line-height;
+  padding: 0;
 
   &:focus {
     outline: none;

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -34,10 +34,5 @@
     color: $nx-text-color-light;
     margin-left: 0;
     margin-right: 8px;
-
-    &.fa-times {
-      cursor: pointer;
-      width: 1em;
-    }
   }
 }

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -11,56 +11,42 @@
   @include container-horizontal;
 
   display: inline-block;
-  vertical-align: middle;
   white-space: nowrap;
 
-  .nx-filter-text-input {
-    border-left: 0;
-    box-sizing: content-box;
-    margin-left: 0;
+  &:focus {
+    outline: 0;
   }
 
-  .nx-filter-input__add-on {
-    border: $nx-border;
-    border-right: none;
-    box-sizing: content-box;
-    display: inline-block;
-    padding: 4px 4px 4px 2px;
-    vertical-align: top;
-    width: 20px;
+  &:focus-within {
+    .nx-text-input__box {
+      border-color: #43cbf5;
+    }
+  }
 
-    .nx-icon {
-      color: $nx-text-color-light;
-      height: 10px;
-      margin-top: 5px;
-      margin-left: 5px;
+  &:hover {
+    .nx-text-input__box {
+      border-color: #2c2c2c;
+    }
+  }
 
-      &.fa-times {
-        cursor: pointer;
+  &.nx-filter-input--disabled {
+    .nx-text-input__box {
+      background-color: #e9e9e9;
+      border-color: #949494;
 
-        height: 14px;
-        margin-top: 4px;
-        margin-left: 6px;
+      .nx-icon--filter-icons {
+        color: #949494;
       }
     }
   }
 
-  .nx-filter-input--disabled {
-    .nx-filter-input__add-on {
-      background-color: $nx-off-white;
+  .nx-icon--filter-icons {
+    color: $nx-text-color-light;
+    height: 1em;
+    margin-right: 8px;
 
-      .nx-icon {
-        color: $nx-text-color-disabled;
-      }
-    }
-
-    .nx-filter-text-input {
-      background-color: $nx-off-white;
-      border-color: $nx-grey-3;
-
-      &::placeholder {
-        color: $nx-text-color-disabled;
-      }
+    &.fa-times {
+      cursor: pointer;
     }
   }
 }

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -19,12 +19,6 @@
     }
   }
 
-  &:hover {
-    .nx-text-input__box {
-      border-color: #2c2c2c;
-    }
-  }
-
   &.nx-filter-input--disabled {
     .nx-text-input__box {
       background-color: #e9e9e9;

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -13,10 +13,6 @@
   display: inline-block;
   white-space: nowrap;
 
-  &:focus {
-    outline: 0;
-  }
-
   &:focus-within {
     .nx-text-input__box {
       border-color: #43cbf5;

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -42,11 +42,12 @@
 
   .nx-icon--filter-icons {
     color: $nx-text-color-light;
-    height: 1em;
+    margin-left: 0;
     margin-right: 8px;
 
     &.fa-times {
       cursor: pointer;
+      width: 1em;
     }
   }
 }

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -7,8 +7,6 @@
 @import '../../scss-shared/nx-variables';
 @import '../../scss-shared/nx-container-helpers';
 
-$nx-filter-input-height: 20px;
-
 .nx-filter-input {
   @include container-horizontal;
 
@@ -17,28 +15,19 @@ $nx-filter-input-height: 20px;
   white-space: nowrap;
 
   .nx-filter-text-input {
-    border: $nx-border;
     border-left: 0;
-    font-size: 14px;
-    height: $nx-filter-input-height;
-    margin-left: 0;
-    padding: 4px 6px;
     box-sizing: content-box;
-
-    &:focus {
-      outline: none;
-    }
+    margin-left: 0;
   }
 
   .nx-filter-input__add-on {
     border: $nx-border;
     border-right: none;
+    box-sizing: content-box;
     display: inline-block;
-    height: $nx-filter-input-height;
     padding: 4px 4px 4px 2px;
     vertical-align: top;
     width: 20px;
-    box-sizing: content-box;
 
     .nx-icon {
       color: $nx-text-color-light;

--- a/lib/src/components/NxFilterInput/NxFilterInput.tsx
+++ b/lib/src/components/NxFilterInput/NxFilterInput.tsx
@@ -39,7 +39,7 @@ const NxFilterInput = forwardRef<HTMLDivElement, Props>(
                  value={value}
                  onChange={inputOnChange}
                  placeholder={placeholder || undefined}
-                 className="nx-filter-text-input"
+                 className="nx-text-input nx-filter-text-input"
                  disabled={disabled || undefined} />
         </div>
       );

--- a/lib/src/components/NxFilterInput/NxFilterInput.tsx
+++ b/lib/src/components/NxFilterInput/NxFilterInput.tsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { faFilter, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import './NxFilterInput.scss';
+
 import NxFontAwesomeIcon from '../NxFontAwesomeIcon/NxFontAwesomeIcon';
 import { Props, propTypes } from './types';
 export { Props } from './types';
@@ -29,18 +30,17 @@ const NxFilterInput = forwardRef<HTMLDivElement, Props>(
 
       return (
         <div {...otherProps} className={classes} ref={ref}>
-          <span className="nx-filter-input__add-on"
-                onClick={value && onClear || undefined}>
-            <NxFontAwesomeIcon icon={icon} />
-          </span>
-          <input type="text"
-                 autoComplete="off"
-                 id={inputId || undefined}
-                 value={value}
-                 onChange={inputOnChange}
-                 placeholder={placeholder || undefined}
-                 className="nx-text-input nx-filter-text-input"
-                 disabled={disabled || undefined} />
+          <div className="nx-text-input__box">
+            <NxFontAwesomeIcon icon={icon} onClick={value && onClear || undefined} className="nx-icon--filter-icons" />
+            <input type="text"
+                  autoComplete="off"
+                  id={inputId || undefined}
+                  value={value}
+                  onChange={inputOnChange}
+                  placeholder={placeholder || undefined}
+                  className="nx-text-input__input nx-filter-text-input"
+                  disabled={disabled || undefined} />
+          </div>
         </div>
       );
     }

--- a/lib/src/components/NxFilterInput/NxFilterInput.tsx
+++ b/lib/src/components/NxFilterInput/NxFilterInput.tsx
@@ -35,13 +35,13 @@ const NxFilterInput = forwardRef<HTMLDivElement, Props>(
               <NxFontAwesomeIcon icon={icon} className="nx-icon--filter-icons" />
             </span>
             <input type="text"
-                  autoComplete="off"
-                  id={inputId || undefined}
-                  value={value}
-                  onChange={inputOnChange}
-                  placeholder={placeholder || undefined}
-                  className="nx-text-input__input nx-filter-text-input"
-                  disabled={disabled || undefined} />
+                   autoComplete="off"
+                   id={inputId || undefined}
+                   value={value}
+                   onChange={inputOnChange}
+                   placeholder={placeholder || undefined}
+                   className="nx-text-input__input nx-filter-text-input"
+                   disabled={disabled || undefined} />
           </div>
         </div>
       );

--- a/lib/src/components/NxFilterInput/NxFilterInput.tsx
+++ b/lib/src/components/NxFilterInput/NxFilterInput.tsx
@@ -31,7 +31,9 @@ const NxFilterInput = forwardRef<HTMLDivElement, Props>(
       return (
         <div {...otherProps} className={classes} ref={ref}>
           <div className="nx-text-input__box">
-            <NxFontAwesomeIcon icon={icon} onClick={value && onClear || undefined} className="nx-icon--filter-icons" />
+            <span className="nx-filter-input__add-on" onClick={value && onClear || undefined}>
+              <NxFontAwesomeIcon icon={icon} className="nx-icon--filter-icons" />
+            </span>
             <input type="text"
                   autoComplete="off"
                   id={inputId || undefined}

--- a/lib/src/components/NxFilterInput/NxFilterInput.tsx
+++ b/lib/src/components/NxFilterInput/NxFilterInput.tsx
@@ -16,7 +16,7 @@ export { Props } from './types';
 
 const NxFilterInput = forwardRef<HTMLDivElement, Props>(
     function NxFilterInput(props, ref) {
-      const { value, placeholder, onChange, onClear, className, inputId, disabled, ...otherProps } = props,
+      const { value, placeholder, onChange, className, inputId, disabled, ...otherProps } = props,
           classes = classnames('nx-filter-input', className, {
             'nx-filter-input--disabled': disabled
           });

--- a/lib/src/components/NxFilterInput/NxFilterInput.tsx
+++ b/lib/src/components/NxFilterInput/NxFilterInput.tsx
@@ -6,7 +6,7 @@
  */
 import React, { forwardRef, FormEvent } from 'react';
 import classnames from 'classnames';
-import { faFilter, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
 import './NxFilterInput.scss';
 
@@ -19,8 +19,7 @@ const NxFilterInput = forwardRef<HTMLDivElement, Props>(
       const { value, placeholder, onChange, onClear, className, inputId, disabled, ...otherProps } = props,
           classes = classnames('nx-filter-input', className, {
             'nx-filter-input--disabled': disabled
-          }),
-          icon = value ? faTimes : faFilter;
+          });
 
       function inputOnChange(e: FormEvent<HTMLInputElement>) {
         if (onChange) {
@@ -31,9 +30,7 @@ const NxFilterInput = forwardRef<HTMLDivElement, Props>(
       return (
         <div {...otherProps} className={classes} ref={ref}>
           <div className="nx-text-input__box">
-            <span className="nx-filter-input__add-on" onClick={value && onClear || undefined}>
-              <NxFontAwesomeIcon icon={icon} className="nx-icon--filter-icons" />
-            </span>
+            <NxFontAwesomeIcon icon={faFilter} className="nx-icon--filter-icons" />
             <input type="text"
                    autoComplete="off"
                    id={inputId || undefined}

--- a/lib/src/components/NxFilterInput/__tests__/NxFilterInput.test.tsx
+++ b/lib/src/components/NxFilterInput/__tests__/NxFilterInput.test.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import * as enzymeUtils from '../../../__testutils__/enzymeUtils';
-import { faFilter, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
 import NxFilterInput, { Props } from '../NxFilterInput';
 import NxFontAwesomeIcon from '../../NxFontAwesomeIcon/NxFontAwesomeIcon';
@@ -19,43 +19,11 @@ describe('NxFilterInput', function() {
     expect(component).toHaveClassName('nx-filter-input');
   });
 
-  describe('when value prop is truthy', function() {
-    it('renders the clear icon in the add-on', function() {
-      const icon = shallowComponent({ value: 'test value' }).find(NxFontAwesomeIcon);
-      expect(icon).toExist();
-      expect(icon).toHaveProp('icon', faTimes);
-    });
-
-    it('calls onClear if the icon is clicked', function() {
-      const onClear = jest.fn(),
-          iconWrapper = shallowComponent({
-            value: 'test value',
-            onClear
-          }).find('.nx-filter-input__add-on');
-
-      expect(iconWrapper).toExist();
-      iconWrapper.simulate('click');
-      expect(onClear).toHaveBeenCalled();
-    });
-  });
-
   describe('when value prop is an empty string', function() {
     it('renders the filter icon in the add-on', function() {
       const icon = shallowComponent().find(NxFontAwesomeIcon);
       expect(icon).toExist();
       expect(icon).toHaveProp('icon', faFilter);
-    });
-
-    it('does not call onClear if the icon is clicked', function() {
-      const onClear = jest.fn(),
-          iconWrapper = shallowComponent({
-            value: '',
-            onClear
-          }).find('.nx-filter-input__add-on');
-
-      expect(iconWrapper).toExist();
-      iconWrapper.simulate('click');
-      expect(onClear).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/src/components/NxFilterInput/__tests__/NxFilterInput.test.tsx
+++ b/lib/src/components/NxFilterInput/__tests__/NxFilterInput.test.tsx
@@ -5,10 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import * as enzymeUtils from '../../../__testutils__/enzymeUtils';
-import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
 import NxFilterInput, { Props } from '../NxFilterInput';
-import NxFontAwesomeIcon from '../../NxFontAwesomeIcon/NxFontAwesomeIcon';
 
 describe('NxFilterInput', function() {
   const minimalProps = { value: '' },
@@ -17,14 +15,6 @@ describe('NxFilterInput', function() {
   it('renders component with minimal props', function() {
     const component = shallowComponent();
     expect(component).toHaveClassName('nx-filter-input');
-  });
-
-  describe('when value prop is an empty string', function() {
-    it('renders the filter icon in the add-on', function() {
-      const icon = shallowComponent().find(NxFontAwesomeIcon);
-      expect(icon).toExist();
-      expect(icon).toHaveProp('icon', faFilter);
-    });
   });
 
   it('calls onChange whenever a change occurs in the input', function() {

--- a/lib/src/components/NxFilterInput/__tests__/NxFilterInput.test.tsx
+++ b/lib/src/components/NxFilterInput/__tests__/NxFilterInput.test.tsx
@@ -69,7 +69,7 @@ describe('NxFilterInput', function() {
 
   it('passes unknown props to the div element', function() {
     const props = { className: 'extra-class', id: 'some-id' },
-        componentDiv = shallowComponent(props).find('div');
+        componentDiv = shallowComponent(props).find('div.nx-filter-input');
 
     expect(componentDiv).toHaveClassName('extra-class');
     expect(componentDiv).toHaveProp('id', 'some-id');

--- a/lib/src/scss-shared/_nx-colors.scss
+++ b/lib/src/scss-shared/_nx-colors.scss
@@ -74,7 +74,7 @@ $nx-header-border: #f1f3fa;
 $nx-heading-color: #2C2C2C;
 $nx-text-color: #2c2c2c;
 $nx-text-color-light: #474747;
-$nx-text-color-disabled: $nx-grey-4;
+$nx-text-color-disabled: #949494;
 $nx-text-color-error: $nx-fail-color;
 
 $nx-link-color: $nx-color-blue-44;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-124

This ticket just covers the basic styling changes from Derrek. In the course of the work we discovered that `NxFilterInput` isn't built on top of `NxTextInput` and that it probably should be. That's a much larger task and so it was broken out into RSC-165.

Because `NxFilterInput` cannot show all of the user states specified in the design we have opted (after discussing with Derrek) to use a default border colour of `#2c2c2c`.