### PR TITLE
NxStatefullDropdown example bugs RSC-163

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownExample.tsx
+++ b/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownExample.tsx
@@ -21,14 +21,27 @@ function NxStatefulDropdownExample() {
 
   return (
     <NxStatefulDropdown label={labelElement}>
-      <div className="nx-list nx-list--clickable">
-        <h4 className="nx-list__title">Filters</h4>
-        <ul>
-          <li className="nx-list__item" onClick={onClick}>Faux Filter 1</li>
-          <li className="nx-list__item" onClick={onClick}>Cool Filter</li>
-          <li className="nx-list__item" onClick={onClick}>Unused Filter</li>
-        </ul>
-      </div>
+      <a onClick={onClick} className="nx-dropdown-button">
+        Nav Link1
+      </a>
+      <a onClick={onClick} className="nx-dropdown-button">
+        Nav Link2
+      </a>
+      <a onClick={onClick} className="nx-dropdown-button">
+        Nav Link3
+      </a>
+      <button onClick={onClick} className="nx-dropdown-button">
+        Nav Link4 - this link should trigger truncation
+      </button>
+      <button onClick={onClick} className="nx-dropdown-button">
+        Nav Link5
+      </button>
+      <button onClick={onClick} className="nx-dropdown-button">
+        Nav Link6
+      </button>
+      <button className="disabled nx-dropdown-button">
+        Nav Link7 Disabled
+      </button>
     </NxStatefulDropdown>
   );
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.49.1",
+  "version": "0.49.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxDropdown/NxDropdown.scss
+++ b/lib/src/components/NxDropdown/NxDropdown.scss
@@ -26,6 +26,7 @@ $nx-dropdown-width: 250px;
   width: $nx-dropdown-width;
 
   .nx-dropdown__toggle-label {
+    @include container-horizontal;
     @include truncate-ellipsis();
     flex-grow: 1;
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-163

Added `container-horizontal` to the toggle which fixed the icon issue.

Changed the content to reflect the use cases from the designs of `NxDropdown`.