### PR TITLE
nx-truncate-ellipsis RSC-115

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -58,6 +58,7 @@ import NxScrollablePage from './styles/NxScrollable/NxScrollablePage';
 import TooltipConfigPropsPage from './jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage';
 import PolicyThreatLevelUtilsPage from './jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage';
 import ValidationUtilsPage from './jsUtilPages/ValidationUtils/ValidationUtilsPage';
+import NxTruncatePage from './styles/NxTruncateEllipsis/NxTruncatePage';
 
 const pageConfig: PageConfig = {
   'React Components': {
@@ -89,7 +90,8 @@ const pageConfig: PageConfig = {
     NxStatefulTreeViewMultiSelect: NxStatefulTreeViewMultiSelect,
     NxTreeViewRadioSelect: NxTreeViewRadioSelectPage,
     NxStatefulTreeViewRadioSelect: NxStatefulTreeViewRadioSelectPage,
-    NxVulnerabilityDetails: NxVulnerabilityDetailsPage
+    NxVulnerabilityDetails: NxVulnerabilityDetailsPage,
+    NxTruncateEllipsis: NxTruncatePage
   },
   'Guidelines': {
     'Form Validation Guidelines': FormValidationPage,
@@ -111,7 +113,8 @@ const pageConfig: PageConfig = {
     'nx-tile': NxTilePage
   },
   'Styles - Mixins': {
-    'nx-container-helpers': NxContainerHelpersPage
+    'nx-container-helpers': NxContainerHelpersPage,
+    'nx-truncate-ellipsis': NxTruncatePage
   },
   'Layout Examples': {
     //'Form Layout Styles': NxFormLayoutPage,

--- a/gallery/src/styles/NxTruncateEllipsis/NxTruncateExample.scss
+++ b/gallery/src/styles/NxTruncateEllipsis/NxTruncateExample.scss
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+ @import '~@sonatype/react-shared-components/scss-shared/nx-text-helpers';
+
+.nx-truncate-example1 {
+  @include nx-truncate-ellipsis;
+  max-width: 400px;
+}
+
+.nx-truncate-example2 {
+  @include nx-truncate-ellipsis;
+  max-width: 600px;
+}
+
+// styling added for clarity
+.nx-truncation-examples {
+  .nx-truncate-example1, .nx-truncate-example2 {
+    border: 1px solid #949494;
+    margin-bottom: $nx-spacing-md;
+    padding: $nx-spacing-md;
+  }
+}

--- a/gallery/src/styles/NxTruncateEllipsis/NxTruncateExample.tsx
+++ b/gallery/src/styles/NxTruncateEllipsis/NxTruncateExample.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import './NxTruncateExample.scss';
+
+const NxTruncateExample = () =>
+  <div className="nx-truncation-examples">
+    <div className="nx-truncate-example1">
+      This is a very long sentence which is going to truncate with an ellipsis when it hits the end of the bounding box
+      because this style is amazing.
+    </div>
+
+    <div className="nx-truncate-example2">
+      This is a very long sentence which is going to truncate with an ellipsis when it hits the end of the bounding box
+      because this style is amazing.
+    </div>
+  </div>
+
+export default NxTruncateExample;

--- a/gallery/src/styles/NxTruncateEllipsis/NxTruncateExample.tsx
+++ b/gallery/src/styles/NxTruncateEllipsis/NxTruncateExample.tsx
@@ -18,6 +18,6 @@ const NxTruncateExample = () =>
       This is a very long sentence which is going to truncate with an ellipsis when it hits the end of the bounding box
       because this style is amazing.
     </div>
-  </div>
+  </div>;
 
 export default NxTruncateExample;

--- a/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
+++ b/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
+import NxTruncateExample from './NxTruncateExample';
+
+const nxTruncateExampleCode = require('!!raw-loader!./NxTruncateExample').default,
+    nxTruncateExampleSCSS = require('!!raw-loader!./NxTruncateExample.scss').default;
+
+const NxTruncatePage = () => {
+  const codeExamples = [
+    nxTruncateExampleCode,
+    { content: nxTruncateExampleSCSS, language: 'scss' }
+  ];
+
+  return (
+    <>
+      <GalleryDescriptionTile>
+        <p className="nx-p">
+          The <code className="nx-code">.nx-truncate-ellipsis</code> mixin is a simple way to add ellipsis truncation to
+          any object. The mixin automatically adds the three required CSS attributes, but the end user must provide the
+          <code className="nx-code">max-width:</code> value to their SCSS for truncation to work properly. Since this
+          value is likley to be custom no default has be set.
+        </p>
+      </GalleryDescriptionTile>
+      <GalleryExampleTile title="General Example"
+                          codeExamples={codeExamples}
+                          description="In this example a border and some padding have been added for clarity.">
+        <NxTruncateExample />
+      </GalleryExampleTile>
+    </>
+  );
+};
+
+export default NxTruncatePage;

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.49.0",
+  "version": "0.49.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -28,7 +28,7 @@
 
 .nx-list__item {
   @include semi-bold();
-  @include truncate-ellipsis();
+  @include nx-truncate-ellipsis();
   @include container-vertical;
 
   border-top: 1px solid transparent;

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -71,7 +71,7 @@ $nx-tile-background-color: $nx-white;
 }
 
 .nx-tile-header__title {
-  @include truncate-ellipsis;
+  @include nx-truncate-ellipsis;
   grid-column-start: 1;
   grid-column-end: 1;
   grid-row-start: 1;
@@ -80,7 +80,7 @@ $nx-tile-background-color: $nx-white;
   -ms-grid-column: 1;
 
   h1, h2 {
-    @include truncate-ellipsis;
+    @include nx-truncate-ellipsis;
     margin: 0;
   }
 }

--- a/lib/src/components/NxDropdown/NxDropdown.scss
+++ b/lib/src/components/NxDropdown/NxDropdown.scss
@@ -26,7 +26,7 @@ $nx-dropdown-width: 250px;
   width: $nx-dropdown-width;
 
   .nx-dropdown__toggle-label {
-    @include truncate-ellipsis();
+    @include nx-truncate-ellipsis();
     flex-grow: 1;
   }
 
@@ -69,7 +69,7 @@ $nx-dropdown-width: 250px;
 
 .nx-dropdown-link, .nx-dropdown-button {
   @include container-horizontal;
-  @include truncate-ellipsis();
+  @include nx-truncate-ellipsis();
   @include regular();
 
   border: none;

--- a/lib/src/components/NxTreeView/NxTreeView.scss
+++ b/lib/src/components/NxTreeView/NxTreeView.scss
@@ -98,7 +98,7 @@
 
 .nx-tree-view__text {
   @include container-horizontal;
-  @include truncate-ellipsis;
+  @include nx-truncate-ellipsis;
 
   align-items: center;
   color: $nx-text-color-light;
@@ -110,7 +110,7 @@
   }
 
   span {
-    @include truncate-ellipsis;
+    @include nx-truncate-ellipsis;
     flex-grow: 1;
   }
 

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -25,7 +25,7 @@
   font-weight: 600;
 }
 
-@mixin truncate-ellipsis {
+@mixin nx-truncate-ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-115

Added an example page for the `.nx-truncation-ellipsis` mixin. 

As part of this I added the `.nx-` prefix to the mixin to make it consistent with our other styles. I then refactored existing instances of the mixin in the RSC.