### PR TITLE
nx-code RSC-115

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.4",
+  "version": "0.50.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -105,6 +105,7 @@ const pageConfig: PageConfig = {
   'Styles - HTML Elements': {
     'nx-alert': NxAlertPage,
     'nx-btn': NxBtnPage,
+    'nx-code': NxCodePage,
     'nx-counter': NxCounterPage,
     'nx-grid': NxGridPage,
     'nx-icon': NxIconPage,
@@ -118,7 +119,6 @@ const pageConfig: PageConfig = {
   },
   'Styles - Mixins & Helpers': {
     'nx-clickable': NxClickablePage,
-    'nx-code': NxCodePage,
     'nx-container-helpers': NxContainerHelpersPage,
     'nx-truncate-ellipsis': NxTruncatePage
   },

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -120,7 +120,7 @@ const pageConfig: PageConfig = {
     'nx-clickable': NxClickablePage,
     'nx-code': NxCodePage,
     'nx-container-helpers': NxContainerHelpersPage,
-    'nx-truncate-ellipsis': NxTruncatePage,
+    'nx-truncate-ellipsis': NxTruncatePage
   },
   'Layout Examples': {
     //'Form Layout Styles': NxFormLayoutPage,

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -117,10 +117,10 @@ const pageConfig: PageConfig = {
     'nx-tile': NxTilePage
   },
   'Styles - Mixins & Helpers': {
-    'nx-container-helpers': NxContainerHelpersPage,
     'nx-clickable': NxClickablePage,
+    'nx-code': NxCodePage,
+    'nx-container-helpers': NxContainerHelpersPage,
     'nx-truncate-ellipsis': NxTruncatePage,
-    'nx-code': NxCodePage
   },
   'Layout Examples': {
     //'Form Layout Styles': NxFormLayoutPage,

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -58,6 +58,7 @@ import NxScrollablePage from './styles/NxScrollable/NxScrollablePage';
 import TooltipConfigPropsPage from './jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage';
 import PolicyThreatLevelUtilsPage from './jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage';
 import ValidationUtilsPage from './jsUtilPages/ValidationUtils/ValidationUtilsPage';
+import NxCodePage from './styles/NxCode/NxCodePage';
 
 const pageConfig: PageConfig = {
   'React Components': {
@@ -111,7 +112,8 @@ const pageConfig: PageConfig = {
     'nx-tile': NxTilePage
   },
   'Styles - Mixins': {
-    'nx-container-helpers': NxContainerHelpersPage
+    'nx-container-helpers': NxContainerHelpersPage,
+    'nx-code': NxCodePage
   },
   'Layout Examples': {
     //'Form Layout Styles': NxFormLayoutPage,

--- a/gallery/src/styles/NxCode/NxCodeExample.tsx
+++ b/gallery/src/styles/NxCode/NxCodeExample.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import './NxCodeExample.scss';
+
+const NxCodeExample = () =>
+  <>
+    <p className="nx-p"><code className="nx-code">&lt;HTML&gt;</code></p>
+    <p className="nx-p"><code className="nx-code">.scss-class</code></p>
+  </>
+export default NxCodeExample;

--- a/gallery/src/styles/NxCode/NxCodeExample.tsx
+++ b/gallery/src/styles/NxCode/NxCodeExample.tsx
@@ -5,11 +5,11 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import './NxCodeExample.scss';
 
 const NxCodeExample = () =>
   <>
     <p className="nx-p"><code className="nx-code">&lt;HTML&gt;</code></p>
     <p className="nx-p"><code className="nx-code">.scss-class</code></p>
-  </>
+  </>;
+
 export default NxCodeExample;

--- a/gallery/src/styles/NxCode/NxCodeExample.tsx
+++ b/gallery/src/styles/NxCode/NxCodeExample.tsx
@@ -8,8 +8,10 @@ import React from 'react';
 
 const NxCodeExample = () =>
   <>
-    <p className="nx-p"><code className="nx-code">&lt;HTML&gt;</code></p>
-    <p className="nx-p"><code className="nx-code">.scss-class</code></p>
+    <p className="nx-p">
+      When you wrap HTML tags <code className="nx-code">&lt;HTML&gt;</code> remember to escape &lt;&gt;.
+    </p>
+    <p className="nx-p">Note that <code className="nx-code">.nx-code</code> always appears inline.</p>
   </>;
 
 export default NxCodeExample;

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -26,7 +26,7 @@ const NxCodePage = () => {
       </GalleryDescriptionTile>
       <GalleryExampleTile title="Styling code snippets"
                           codeExamples={nxCodeExampleCode}
-                          description="">
+                          description="A couple of simple inline examples.">
         <NxCodeExample />
       </GalleryExampleTile>
     </>

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -17,7 +17,7 @@ const NxCodePage = () => {
     <>
       <GalleryDescriptionTile>
         <p className="nx-p">
-          Using the <code className="nx-code">&lt;code&gt;</code> HTML tag with the 
+          Using the <code className="nx-code">&lt;code&gt;</code> HTML tag with the
           <code className="nx-code">.nx-code</code> className applies a monospace font and other styling to make your
           code snippets stand out.
         </p>

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -13,15 +13,11 @@ import NxCodeExample from './NxCodeExample';
 const nxCodeExampleCode = require('!!raw-loader!./NxCodeExample').default;
 
 const NxCodePage = () => {
-  const codeExamples = [
-    nxCodeExampleCode
-  ];
-
   return (
     <>
       <GalleryDescriptionTile>
         <p className="nx-p">
-          Using the &lt;code&gt; HTML tag and the <code className="nx-code">.nx-code</code> className you apply a
+          Using the &lt;code&gt; HTML tag with the <code className="nx-code">.nx-code</code> className applies a
           monospace font and other styling to make your code snippets stand out.
         </p>
         <p className="nx-p">
@@ -29,7 +25,7 @@ const NxCodePage = () => {
         </p>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="Styling code snippets"
-                          codeExamples={codeExamples}
+                          codeExamples={nxCodeExampleCode}
                           description="">
         <NxCodeExample />
       </GalleryExampleTile>

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
+import NxCodeExample from './NxCodeExample';
+
+const nxCodeExampleCode = require('!!raw-loader!./NxCodeExample').default;
+
+const NxCodePage = () => {
+  const codeExamples = [
+    nxCodeExampleCode
+  ];
+
+  return (
+    <>
+      <GalleryDescriptionTile>
+        <p className="nx-p">
+          Using the &lt;code&gt; HTML tag and the <code className="nx-code">.nx-code</code> className you apply a
+          monospace font and other styling to make your code snippets stand out.
+        </p>
+        <p className="nx-p">
+          <code className="nx-code">.nx-code</code> is used extensively throughout the RSC Gallery.
+        </p>
+      </GalleryDescriptionTile>
+      <GalleryExampleTile title="Styling code snippets"
+                          codeExamples={codeExamples}
+                          description="">
+        <NxCodeExample />
+      </GalleryExampleTile>
+    </>
+  );
+};
+
+export default NxCodePage;

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -17,8 +17,9 @@ const NxCodePage = () => {
     <>
       <GalleryDescriptionTile>
         <p className="nx-p">
-          Using the <code className="nx-code">&lt;code&gt;</code> HTML tag with the <code className="nx-code">.nx-code</code> className applies a
-          monospace font and other styling to make your code snippets stand out.
+          Using the <code className="nx-code">&lt;code&gt;</code> HTML tag with the 
+          <code className="nx-code">.nx-code</code> className applies a monospace font and other styling to make your
+          code snippets stand out.
         </p>
         <p className="nx-p">
           <code className="nx-code">.nx-code</code> is used extensively throughout the RSC Gallery.

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.4",
+  "version": "0.50.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -36,6 +36,7 @@
   border: $nx-border;
   border-radius: 4px;
   color: $nx-invalid-color;
+  font-family: monospace;
   font-size: $nx-font-size-s;
   padding: 2px 4px;
   white-space: nowrap;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-115

Just the simple `<code className="nx-code">` version here though I do think there is value in adding a "block" version in v1.x