### PR TITLE
nx-p font size RSC-164

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.6",
+  "version": "0.50.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.5",
+  "version": "0.50.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -24,9 +24,9 @@ const nxErrorAlertExampleCode = require('!!raw-loader!./NxErrorAlertExample').de
 const NxAlertPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Generic alert.</p>
-      <p>Handy for DIY alert variations</p>
-      <p>Accepts any prop that is valid on a div as well as the following:</p>
+      <p className="nx-p">Generic alert.</p>
+      <p className="nx-p">Handy for DIY alert variations</p>
+      <p className="nx-p">Accepts any prop that is valid on a div as well as the following:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">
@@ -55,9 +55,9 @@ const NxAlertPage = () =>
     </GalleryTile>
 
     <GalleryTile title="NxErrorAlert, NxInfoAlert, NxWarningAlert">
-      <p>Standard sonatype alerts.</p>
-      <p>They come in three variations: Error, Info, and Warning.</p>
-      <p>Accepts any prop that is valid on a div</p>
+      <p className="nx-p">Standard sonatype alerts.</p>
+      <p className="nx-p">They come in three variations: Error, Info, and Warning.</p>
+      <p className="nx-p">Accepts any prop that is valid on a div</p>
     </GalleryTile>
 
     <GalleryTile title="Success Alert Example">

--- a/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
+++ b/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
@@ -20,8 +20,8 @@ const textSourceCode = require('!!raw-loader!./NxBackButtonTextExample').default
 const NxBackButtonPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>A standard UI element for navigating back to a previous page</p>
-      <p>Props:</p>
+      <p className="nx-p">A standard UI element for navigating back to a previous page</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -27,8 +27,8 @@ export default function NxButtonPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p><code className="nx-code">.nx-btn</code> is the standard class for all buttons.</p>
-        <p>
+        <p className="nx-p"><code className="nx-code">.nx-btn</code> is the standard class for all buttons.</p>
+        <p className="nx-p">
           When a button is not contained in a <code className="nx-code">footer</code>, then an enclosing
           <code className="nx-code">.nx-btn-bar</code> is generally required to ensure that the buttons are spaced
           appropriately from other content.

--- a/gallery/src/components/NxCheckbox/NxCheckboxExample.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxExample.tsx
@@ -16,7 +16,7 @@ function NxCheckboxExample() {
 
   return (
     <>
-      <p>Subscribed: {isSubscribed.toString()}</p>
+      <p className="nx-p">Subscribed: {isSubscribed.toString()}</p>
       <div>
         <NxCheckbox checkboxId="subscribe-check" onChange={onChange} isChecked={isSubscribed}>
           Subscribe

--- a/gallery/src/components/NxCheckbox/NxCheckboxInlineExample.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxInlineExample.tsx
@@ -14,7 +14,7 @@ function NxCheckboxInlineExample() {
 
   return (
     <>
-      <p>Subscribed: {isSubscribed.toString()}</p>
+      <p className="nx-p">Subscribed: {isSubscribed.toString()}</p>
 
       <div>
         Some text

--- a/gallery/src/components/NxCheckbox/NxCheckboxNowrapExample.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxNowrapExample.tsx
@@ -14,7 +14,7 @@ function NxCheckboxNowrapExample() {
 
   return (
     <>
-      <p>Subscribed: {isSubscribed.toString()}</p>
+      <p className="nx-p">Subscribed: {isSubscribed.toString()}</p>
 
       <div style={{width: '40px', border: '1px solid red'}}>
         Some text

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -20,9 +20,9 @@ const nowrapExampleCode = require('!!raw-loader!./NxCheckboxNowrapExample').defa
 const NxCheckboxPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Custom checkbox input.</p>
-      <p>Child VDOM will be used as a label following the checkbox button itself.</p>
-      <p>Props:</p>
+      <p className="nx-p">Custom checkbox input.</p>
+      <p className="nx-p">Child VDOM will be used as a label following the checkbox button itself.</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -24,8 +24,8 @@ const nxDropdownNavigationExampleCode = require('!!raw-loader!./NxDropdownNaviga
 const NxDropdownPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Dropdown component.</p>
-      <p>Props:</p>
+      <p className="nx-p">Dropdown component.</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">
@@ -53,10 +53,8 @@ const NxDropdownPage = () =>
             <td className="nx-cell">"primary" | "secondary" | "tertiary"</td>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
-              <p>
-                What type of button to render for the dropdown.
-                Defaults to <code className="nx-code">"tertiary"</code>
-              </p>
+              What type of button to render for the dropdown.
+              Defaults to <code className="nx-code">"tertiary"</code>
             </td>
           </tr>
           <tr className="nx-table-row">
@@ -70,10 +68,8 @@ const NxDropdownPage = () =>
             <td className="nx-cell">boolean</td>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
-              <p>
-                Controls if the component should be rendered as disabled.
-                Defaults to <code className="nx-code">false</code>
-              </p>
+              Controls if the component should be rendered as disabled.
+              Defaults to <code className="nx-code">false</code>
             </td>
           </tr>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
+++ b/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
@@ -20,7 +20,7 @@ const nxFilterInputFullExampleCode = require('!!raw-loader!./NxFilterInputFullEx
 const NxFilterInputPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         An input to be used for filtering purposes
       </p>
 

--- a/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
+++ b/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
@@ -22,13 +22,13 @@ const NxFontAwesomeIconPage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p>
+        <p className="nx-p">
           <code className="nx-code">NxFontAwesomeIcon</code> is a wrapper around
           the <code className="nx-code">FontAwesomeIcon</code> component. It passes through its props
           to <code className="nx-code">FontAwesomeIcon</code> and adds the <code className="nx-code">.nx-icon</code> CSS
           class.
         </p>
-        <p>
+        <p className="nx-p">
           See the <code className="nx-code">FontAwesomeIcon</code>{' '}
           <a href="https://github.com/FortAwesome/react-fontawesome#features" target="_blank">documentation</a>
           {' '}for details on available props

--- a/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
+++ b/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
@@ -19,8 +19,8 @@ const retryLongMessageSourceCode = require('!!raw-loader!./NxLoadErrorRetryExamp
 const NxLoadErrorPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Error message with optional Retry button</p>
-      <p>Props:</p>
+      <p className="nx-p">Error message with optional Retry button</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -22,8 +22,8 @@ const errorRetrySourceCode = require('!!raw-loader!./NxLoadWrapperErrorRetryExam
 const NxLoadWrapperPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>A component that will display either a loading spinner, an error message, or the specified child VDOM</p>
-      <p>Props:</p>
+      <p className="nx-p">A component that will display either a loading spinner, an error message, or the specified child VDOM</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -22,7 +22,9 @@ const errorRetrySourceCode = require('!!raw-loader!./NxLoadWrapperErrorRetryExam
 const NxLoadWrapperPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">A component that will display either a loading spinner, an error message, or the specified child VDOM</p>
+      <p className="nx-p">
+        A component that will display either a loading spinner, an error message, or the specified child VDOM
+      </p>
       <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>

--- a/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
+++ b/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
@@ -15,8 +15,8 @@ const sourceCode = require('!!raw-loader!./NxLoadingSpinnerExample').default;
 const NxLoadingSpinnerPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Loading Spinner with caption</p>
-      <p>Props: none</p>
+      <p className="nx-p">Loading Spinner with caption</p>
+      <p className="nx-p">Props: none</p>
     </GalleryDescriptionTile>
     <GalleryExampleTile title="General Example"
                         codeExamples={sourceCode}

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -26,7 +26,7 @@ export default function NxModalPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p>
+        <p className="nx-p">
           <code className="nx-code">NxModal</code> is the preferred way to handle modals. Invoking
           an <code className="nx-code">NxModal</code> will create 2 separate <code className="nx-code">div</code>
           elements. One div will have the <code className="nx-code">nx-modal</code> class, along with any classes passed
@@ -74,9 +74,7 @@ export default function NxModalPage() {
               <td className="nx-cell"><code className="nx-code">.nx-modal--wide</code></td>
               <td className="nx-cell">The <code className="nx-code">NxModal</code> component</td>
               <td className="nx-cell">
-                <p>
-                  Applies an extra-wide style, for modals with large contents.
-                </p>
+                Applies an extra-wide style, for modals with large contents.
               </td>
             </tr>
           </tbody>
@@ -136,7 +134,7 @@ export default function NxModalPage() {
         <CodeExample content={NxModalAlertSourceCode}/>
       </GalleryTile>
       <GalleryTile title="NxModal with stacked modal example">
-        <p>
+        <p className="nx-p">
           <code>NxModal</code> also supports stacked or nested modals. A second modal can be generated from inside of
           an <code>NxModal</code>.
         </p>
@@ -144,7 +142,7 @@ export default function NxModalPage() {
         <CodeExample content={NxModalStackedSourceCode}/>
       </GalleryTile>
       <GalleryTile title="NxModal Example with form">
-        <p>
+        <p className="nx-p">
           <code>NxModal</code> also supports inclusion and styling of form elements
         </p>
         <NxModalFormExample/>

--- a/gallery/src/components/NxModal/NxModalSimpleExample.tsx
+++ b/gallery/src/components/NxModal/NxModalSimpleExample.tsx
@@ -25,7 +25,7 @@ export default function NxModalSimpleExample() {
             </h2>
           </header>
           <div className="nx-modal-content">
-            <p>This is some content inside a modal.</p>
+            <p className="nx-p">This is some content inside a modal.</p>
           </div>
           <footer className="nx-modal-footer">
             <div className="nx-btn-bar">

--- a/gallery/src/components/NxModal/NxModalStackedExample.tsx
+++ b/gallery/src/components/NxModal/NxModalStackedExample.tsx
@@ -27,10 +27,10 @@ export default function NxModalStackedExample() {
             </h2>
           </header>
           <div className="nx-modal-content">
-            <p>
+            <p className="nx-p">
               This is some content inside a modal.
             </p>
-            <p>
+            <p className="nx-p">
               This is some more content inside a modal.
             </p>
           </div>
@@ -53,7 +53,7 @@ export default function NxModalStackedExample() {
             </h2>
           </header>
           <div className="nx-modal-content">
-            <p>This is the second modal.</p>
+            <p className="nx-p">This is the second modal.</p>
           </div>
           <footer className="nx-modal-footer">
             <div className="nx-btn-bar">

--- a/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderExample.tsx
+++ b/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderExample.tsx
@@ -14,7 +14,7 @@ export default () => {
   return (
     <>
       <NxPolicyThreatSlider onChange={setState} value={state} />
-      <p>Selected range: [{state[0]}, {state[1]}]</p>
+      <p className="nx-p">Selected range: [{state[0]}, {state[1]}]</p>
     </>
   );
 };

--- a/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
+++ b/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
@@ -16,7 +16,7 @@ export default function NxPolicyThreatSliderPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p>A slider for selecting a range of policy threats (e.g. values between 0 and 10)</p>
+        <p className="nx-p">A slider for selecting a range of policy threats (e.g. values between 0 and 10)</p>
         <table className="nx-table nx-table--gallery-props">
           <thead>
             <tr className="nx-table-row">

--- a/gallery/src/components/NxRadio/NxRadioPage.tsx
+++ b/gallery/src/components/NxRadio/NxRadioPage.tsx
@@ -20,9 +20,9 @@ const nowrapExampleCode = require('!!raw-loader!./NxRadioNowrapExample').default
 const NxRadioPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Custom Radio input.</p>
-      <p>Child VDOM will be used as a label following the radio button itself.</p>
-      <p>Props:</p>
+      <p className="nx-p">Custom Radio input.</p>
+      <p className="nx-p">Child VDOM will be used as a label following the radio button itself.</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
+++ b/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
@@ -15,9 +15,9 @@ const exampleCode = require('!!raw-loader!./NxStatefulCheckboxExample').default;
 const NxStatefulCheckboxPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Custom stateful checkbox input.</p>
-      <p>Child VDOM will be used as a label following the stateful checkbox button itself.</p>
-      <p>Props:</p>
+      <p className="nx-p">Custom stateful checkbox input.</p>
+      <p className="nx-p">Child VDOM will be used as a label following the stateful checkbox button itself.</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
+++ b/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
@@ -15,8 +15,8 @@ const nxStatefulDropdownExampleCode = require('!!raw-loader!./NxStatefulDropdown
 const NxStatefulDropdownPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Dropdown component.</p>
-      <p>Props:</p>
+      <p className="nx-p">Dropdown component.</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">
@@ -38,10 +38,8 @@ const NxStatefulDropdownPage = () =>
             <td className="nx-cell">"primary" | "secondary" | "tertiary"</td>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
-              <p>
-                What type of button to render for the dropdown.
-                Defaults to <code className="nx-code">"tertiary"</code>
-              </p>
+              What type of button to render for the dropdown.
+              Defaults to <code className="nx-code">"tertiary"</code>
             </td>
           </tr>
           <tr className="nx-table-row">
@@ -55,10 +53,8 @@ const NxStatefulDropdownPage = () =>
             <td className="nx-cell">boolean</td>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
-              <p>
-                Controls if the component should be rendered as disabled.
-                Defaults to <code className="nx-code">false</code>
-              </p>
+              Controls if the component should be rendered as disabled.
+              Defaults to <code className="nx-code">false</code>
             </td>
           </tr>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
+++ b/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
@@ -20,11 +20,11 @@ const NxStatefulSubmitMaskCode = require('!!raw-loader!./NxStatefulSubmitMaskExa
 const NxStatefulSubmitMaskPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         This is a wrapper around <code className="nx-code">NxSubmitMask</code> which manages the display and then
         hiding of the success phase of the mask.
       </p>
-      <p>
+      <p className="nx-p">
         The externally visible "success" state, specified by setting the <code className="nx-code">success</code> prop
         to true, encompasses two interally-managed states: the actual, visible success state, and then the automatic
         removal of the mask after the success state has been visible for a brief time.  Since this component manages
@@ -80,7 +80,7 @@ const NxStatefulSubmitMaskPage = () =>
           </tr>
         </tbody>
       </table>
-      <p>
+      <p className="nx-p">
         The examples on this page each start in a non-success state for five seconds before being updated to the
         success state
       </p>

--- a/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
+++ b/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
@@ -24,8 +24,8 @@ const disabledSourceCode = require('!!raw-loader!./NxStatefulTextInputDisabledEx
 const NxStatefulTextInputPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Standard text input with pristine state tracking and pluggable validation handling</p>
-      <p>Props:</p>
+      <p className="nx-p">Standard text input with pristine state tracking and pluggable validation handling</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
@@ -19,7 +19,7 @@ const nxStatefulTreeViewMultiSelectExampleCode = require('!!raw-loader!./NxState
 const NxStatefulTreeViewMultiSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         Stateful Multi select component using tree view with checkboxes. It handles tree view toggling and filter state.
       </p>
 
@@ -38,13 +38,13 @@ const NxStatefulTreeViewMultiSelectPage = () =>
             <td className="nx-cell">Array of {'{id:String, name:String}'}</td>
             <td className="nx-cell">Yes</td>
             <td className="nx-cell">
-              <p>
+              <p className="nx-p">
                 An array of objects that corresponds to the possible options of the component (the checkboxes).
                 These objects need to at least have an <code className="nx-code">id: string</code> property and a{' '}
                 <code className="nx-code">name: string</code> property. If an empty array is passed in, the component
                 will be disabled.
               </p>
-              <p>
+              <p className="nx-p">
                 <code className="nx-code">id</code> will be the value provided to the{' '}
                 <code className="nx-code">onChange</code> callback, and{' '}
                 <code className="nx-code">name</code> will be used to render the option.

--- a/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
@@ -19,7 +19,7 @@ const nxStatefulTreeViewRadioSelectExampleCode = require('!!raw-loader!./NxState
 const NxStatefulTreeViewRadioSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         Stateful Radio select component using tree view with radios. It handles tree view toggling and filter state.
       </p>
 
@@ -38,13 +38,13 @@ const NxStatefulTreeViewRadioSelectPage = () =>
             <td className="nx-cell">Array of {'{id:String, name:String}'}</td>
             <td className="nx-cell">Yes</td>
             <td className="nx-cell">
-              <p>
+              <p className="nx-p">
                 An array of objects that corresponds to the possible options of the component (the radios).
                 These objects need to at least have an <code className="nx-code">id: string | null</code> property{' '}
                 and a <code className="nx-code">name: string</code> property. If an empty array is passed in,{' '}
                 the component will be disabled.
               </p>
-              <p>
+              <p className="nx-p">
                 <code className="nx-code">id</code> will be the value provided to the{' '}
                 <code className="nx-code">onChange</code> callback, and{' '}
                 <code className="nx-code">name</code> will be used to render the option.

--- a/gallery/src/components/NxSubmitMask/NxSubmitMaskFullscreenExample.tsx
+++ b/gallery/src/components/NxSubmitMask/NxSubmitMaskFullscreenExample.tsx
@@ -18,7 +18,7 @@ function NxSubmitMaskFullscreenExample() {
 
   return (
     <div onKeyUp={handleKeyUp} className="gallery-submit-mask-area">
-      <p>
+      <p className="nx-p">
         Note: once the mask is visible in this example, press ESC to dismiss it.
         (This is just part of this example, not built-in mask behavior. It only works as long as the button has focus)
       </p>

--- a/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
+++ b/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
@@ -24,12 +24,12 @@ const NxSubmitMaskCode = require('!!raw-loader!./NxSubmitMaskExample').default,
 const NxSubmitMaskPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         NxSubmitMask creates a mask that is meant to cover a form or similar element while submission of that form
         is in progress, in order to indicate to the user that the submission is in-progress, and, typically, when it
         has completed.
       </p>
-      <p>
+      <p className="nx-p">
         Handling the brief display of the "success" part of the mask is left up to the caller, as it is often
         intertwined with other business logic (for example closing a modal) and may be best managed in redux or similar.
         A constant, <code className="nx-code">SUBMIT_MASK_SUCCESS_VISIBLE_TIME_MS</code>, is exported in order to

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -35,7 +35,7 @@ export default function NxTablePage() {
       <GalleryDescriptionTile>
         <h5>NxTable</h5>
 
-        <p>
+        <p className="nx-p">
           The top-level component to use when displaying tables of data.
           It can have <code className="nx-code">&lt;NxTableHead&gt;</code> and
           <code className="nx-code">&lt;NxTableBody&gt;</code> components as children.
@@ -45,7 +45,7 @@ export default function NxTablePage() {
 
         <h5>NxTableHead</h5>
 
-        <p>
+        <p className="nx-p">
           Equivalent to the <code className="nx-code">&lt;thead&gt;</code> element.
           The <code className="nx-code">&lt;NxTableRow&gt;</code> component is the only valid child.
           Descendant <code className="nx-code">&lt;NxTableCell&gt;</code> components will have the
@@ -56,7 +56,7 @@ export default function NxTablePage() {
 
         <h5>NxTableBody</h5>
 
-        <p>
+        <p className="nx-p">
           Equivalent to the <code className="nx-code">&lt;tbody&gt;</code> element.
           It should have <code className="nx-code">&lt;NxTableRow&gt;</code> for children.
         </p>
@@ -100,7 +100,7 @@ export default function NxTablePage() {
 
         <h5>NxTableRow</h5>
 
-        <p>
+        <p className="nx-p">
           Equivalent to the <code className="nx-code">&lt;tr&gt;</code> element.
           It automatically assigns <code className="nx-code">isHeader</code> on the children
           if that prop is set on this row.
@@ -111,7 +111,7 @@ export default function NxTablePage() {
 
         <h5>NxTableCell</h5>
 
-        <p>
+        <p className="nx-p">
           Equivalent to the <code className="nx-code">&lt;th&gt;</code> or
           <code className="nx-code">&lt;td&gt;</code> element.
         </p>

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -26,8 +26,8 @@ const disabledSourceCode = require('!!raw-loader!./NxTextInputDisabledExample').
 const NxTextInputPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Standard text input with validation styling</p>
-      <p>Props:</p>
+      <p className="nx-p">Standard text input with validation styling</p>
+      <p className="nx-p">Props:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">
@@ -96,9 +96,11 @@ const NxTextInputPage = () =>
             <td className="nx-cell">Function ((string) => void)</td>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
-              A callback for when the user presses a key that doesn't necessarily change the input value
-              (e.g. by hitting enter)
-              <p>
+              <p className="nx-p">
+                A callback for when the user presses a key that doesn't necessarily change the input value
+                (e.g. by hitting enter)
+              </p>
+              <p className="nx-p">
                 The value given to the callback will be that of the key name, as described in the spec
                 for{' '}
                 <a target="_blank"
@@ -142,7 +144,7 @@ const NxTextInputPage = () =>
         </tbody>
       </table>
       <h3>State Helpers</h3>
-      <p>
+      <p className="nx-p">
         <code className="nx-code">@sonatype/react-shared-components/components/NxTextInput/stateHelpers.ts</code>{' '}
         includes the following recommended state helper functions, which each return an object containining the
         "stateful" parts of the NxTextInput props{' '}
@@ -171,7 +173,7 @@ const NxTextInputPage = () =>
             <td className="nx-cell">userInput</td>
             <td className="nx-cell">(validator, newValue: string)</td>
             <td className="nx-cell">
-              <p>
+              <p className="nx-p">
                 Meant to be used to handle user changes to the text input value. The first argument is an optional
                 validator function that receives the new input value (trimmed) as a string and returns zero or more
                 validation error messages. The next argument is the new (raw, untrimmed) value of the text box after
@@ -179,7 +181,7 @@ const NxTextInputPage = () =>
                 <code className="nx-code">value</code>, and with <code className="nx-code">validationErrors</code> as
                 computed by the validator function.
               </p>
-              <p>
+              <p className="nx-p">
                 This function is curried, so that it can be partially applied over the
                 <code className="nx-code">validator</code>.
               </p>

--- a/gallery/src/components/NxThreatBar/NxThreatBarPage.tsx
+++ b/gallery/src/components/NxThreatBar/NxThreatBarPage.tsx
@@ -26,11 +26,11 @@ const nxThreatBarByCategoryListCode =
 const NxThreatBarPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         <code className="nx-code">NxThreatBar</code> is used at the left edge of a table cell or list item
         to indicate via color the threat level of the information to follow.
       </p>
-      <p>
+      <p className="nx-p">
         There are two scales to choose from: threat level by category, and policy threat
         level by number. When using this component, it is expected that just one of the props will be passed. If both
         are passed, <code className="nx-code">threatLevelCategory</code> takes precedence. If neither are passed,
@@ -61,7 +61,7 @@ const NxThreatBarPage = () =>
         </tbody>
       </table>
 
-      <p>The following table shows the mapping between threat level number and threat level category</p>
+      <p className="nx-p">The following table shows the mapping between threat level number and threat level category</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxThreatBar/NxThreatBarPage.tsx
+++ b/gallery/src/components/NxThreatBar/NxThreatBarPage.tsx
@@ -61,7 +61,9 @@ const NxThreatBarPage = () =>
         </tbody>
       </table>
 
-      <p className="nx-p">The following table shows the mapping between threat level number and threat level category</p>
+      <p className="nx-p">
+        The following table shows the mapping between threat level number and threat level category.
+      </p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/components/NxTooltip/NxTooltipPage.tsx
+++ b/gallery/src/components/NxTooltip/NxTooltipPage.tsx
@@ -20,7 +20,7 @@ export default function NxTooltipPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p>
+        <p className="nx-p">
           A tooltip component that can wrap other components in order to apply a tooltip to them. The wrapped component
           must be able to receive a ref which it must forward to its top-most native DOM element.
         </p>

--- a/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
+++ b/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
@@ -24,7 +24,7 @@ const nxTreeViewCode = require('!!raw-loader!./NxTreeViewExample').default,
 const NxTreeViewPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         A set of default styles and basic React for an expanding tree view.
       </p>
 

--- a/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
@@ -18,7 +18,7 @@ const nxTreeViewMultiSelectExampleCode = require('!!raw-loader!./NxTreeViewMulti
 const NxTreeViewMultiSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         Multi select component using tree view with checkboxes.
       </p>
 
@@ -37,13 +37,13 @@ const NxTreeViewMultiSelectPage = () =>
             <td className="nx-cell">Array of {'{id:String, name:String}'}</td>
             <td className="nx-cell">Yes</td>
             <td className="nx-cell">
-              <p>
+              <p className="nx-p">
                 An array of objects that corresponds to the possible options of the component (the checkboxes).
                 These objects need to at least have an <code className="nx-code">id: string</code> property and a{' '}
                 <code className="nx-code">name: string</code> property. If an empty array is passed in, the component
                 will be disabled.
               </p>
-              <p>
+              <p className="nx-p">
                 <code className="nx-code">id</code> will be the value provided to the{' '}
                 <code className="nx-code">onChange</code> callback, and{' '}
                 <code className="nx-code">name</code> will be used to render the option.

--- a/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
@@ -18,7 +18,7 @@ const nxTreeViewRadioSelectExampleCode = require('!!raw-loader!./NxTreeViewRadio
 const NxTreeViewRadioSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         A tree view radio group component.
       </p>
 
@@ -37,13 +37,13 @@ const NxTreeViewRadioSelectPage = () =>
             <td className="nx-cell">Array of {'{id:string, name:string}'}</td>
             <td className="nx-cell">Yes</td>
             <td className="nx-cell">
-              <p>
+              <p className="nx-p">
                 An array of objects that corresponds to the possible options of the component (the checkboxes).
                 These objects need to at least have an <code className="nx-code">id: string</code> property and a{' '}
                 <code className="nx-code">name: string</code> property. If an empty array is passed in, the component
                 will be disabled.
               </p>
-              <p>
+              <p className="nx-p">
                 <code className="nx-code">id</code> will be the value provided to the{' '}
                 <code className="nx-code">onChange</code> callback, and{' '}
                 <code className="nx-code">name</code> will be used to render the option.

--- a/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
+++ b/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
@@ -29,8 +29,8 @@ const NxVulnerabilityDetailsPage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p>Renders vulnerability details from vulnerabilityDetails JSON</p>
-        <p>Props:</p>
+        <p className="nx-p">Renders vulnerability details from vulnerabilityDetails JSON</p>
+        <p className="nx-p">Props:</p>
         <table className="nx-table nx-table--gallery-props">
           <thead>
             <tr className="nx-table-row">
@@ -52,11 +52,11 @@ const NxVulnerabilityDetailsPage = () => {
             </tr>
           </tbody>
         </table>
-        <p>
+        <p className="nx-p">
           VulnerabilityDetails PropType can be imported separately
           as <code className="nx-code">vulnerabilityDetailsPropType</code>.
         </p>
-        <p>
+        <p className="nx-p">
           Note that markdown fields in <code className="nx-code">vulnerabilityDetails</code> JSON are expected to use
           {' '}
           <a className="nx-text-link"

--- a/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
+++ b/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
@@ -14,7 +14,7 @@ const FormValidationCode = require('!!raw-loader!./FormValidationExample').defau
 const FormValidationPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         This page demonstrates the typical overall approach to communicating form validation matters to the user.
         There are several things to note here:
       </p>

--- a/gallery/src/styles/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertPage.tsx
@@ -17,7 +17,7 @@ const nxAlertInfoCode = require('./NxAlertInfoExample.html').default,
 const NxAlertPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Standard name spaced alert styles.</p>
+      <p className="nx-p">Standard name spaced alert styles.</p>
     </GalleryDescriptionTile>
 
     <GalleryTile title="Information alert">

--- a/gallery/src/styles/NxBtn/NxBtnPage.tsx
+++ b/gallery/src/styles/NxBtn/NxBtnPage.tsx
@@ -24,8 +24,8 @@ const nxBtnPrimaryCode = require('!!raw-loader!./NxBtnPrimaryExample').default,
 const NxBtnPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p><code className="nx-code">.nx-btn</code> is the standard class for all buttons.</p>
-      <p>
+      <p className="nx-p"><code className="nx-code">.nx-btn</code> is the standard class for all buttons.</p>
+      <p className="nx-p">
         When a button is not contained in a <code className="nx-code">footer</code>, then an enclosing
         <code className="nx-code">.nx-btn-bar</code> is generally required to ensure that the buttons are spaced
         appropriately from other content.

--- a/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
+++ b/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
@@ -20,7 +20,7 @@ const NxContainerHelpersPage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p>
+        <p className="nx-p">
           The following general guidelines are recommended for the usage of padding and margin.
           The <code className="nx-code">container-vertical</code> and
           <code className="nx-code">container-horizontal</code> SCSS mixins are provided to facilitate these patterns.
@@ -44,13 +44,13 @@ const NxContainerHelpersPage = () => {
             sticking to margin here, we remain compatible with #2 above and also with margin collapsing rules.
           </li>
         </ul>
-        <p>
+        <p className="nx-p">
           The mixins facilitate point #2 above. The <code className="nx-code">container-vertical</code> mixin removes
           top margin from the first child and bottom margin from the last child, while the{' '}
           <code className="nx-code">container-horizontal</code> mixin removes the left margin from the first child and
           right margin from the last child.
         </p>
-        <p>
+        <p className="nx-p">
           These guidelines do have a few caveats that developers must be aware of:
         </p>
         <ul className="nx-list nx-list--bulleted">

--- a/gallery/src/styles/NxCounter/NxCounterPage.tsx
+++ b/gallery/src/styles/NxCounter/NxCounterPage.tsx
@@ -16,11 +16,11 @@ const nxCounterCode = require('!!raw-loader!./NxCounterExample').default;
 const NxCounterPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         Basic style for small indicator token which typically displays a single #, a '# of #' string, or a short text
         string.
       </p>
-      <p>
+      <p className="nx-p">
         Some basic positioning CSS examples have been provided. To right justify the counter within its container use
         <code className="nx-code">nx-pull-right</code>.
       </p>

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
@@ -18,12 +18,12 @@ const NxFormLayoutCode = require('!!raw-loader!./NxFormLayoutExample').default,
 const NxFormLayoutPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         This page demonstrates the HTML and SCSS required for displaying form and form elements in an application.
         Note that all standard HTML elements in a form have corresponding SCSS classes. It's important that these
         classes are used correctly as they reset browser default form styles.
       </p>
-      <p>
+      <p className="nx-p">
         This page does not demonstrate validation which is a part of the form element components which can be found
         in the menu to the left.
       </p>

--- a/gallery/src/styles/NxGrid/NxGridPage.tsx
+++ b/gallery/src/styles/NxGrid/NxGridPage.tsx
@@ -12,15 +12,15 @@ import NxGridExamples from './NxGridExamples';
 const NxGridPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         Described below are some basic grid patterns. These patterns rely on Flexbox to form simple grid patterns.
         CSS Grid was examined but the lack of IE11 support forced us to pass it up.
       </p>
-      <p>
+      <p className="nx-p">
         Grids consist of rows and cells. There are optional title containers, as well as a keylines that can be used
         for styling and spacing.
       </p>
-      <p>
+      <p className="nx-p">
         When you are creating a custom column with a specific width you should use the provided
         <code className="nx-code">.nx-grid-col-width</code> mixin. The only required parameter is the width and unit.
         For example: <code className="nx-code">@include nx-grid-col-width(200px);</code> will generate
@@ -29,7 +29,7 @@ const NxGridPage = () =>
         flex: 0 0 200px;<br/>
         max-width: 200px;
       </pre>
-      <p>The <code className="nx-code">max-width</code> attribute is required by IE11.</p>
+      <p className="nx-p">The <code className="nx-code">max-width</code> attribute is required by IE11.</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row nx-table-row--header">

--- a/gallery/src/styles/NxIcon/NxIconPage.tsx
+++ b/gallery/src/styles/NxIcon/NxIconPage.tsx
@@ -15,11 +15,11 @@ const nxIconExampleCode = require('!!raw-loader!./NxIconExample').default;
 const NxIconPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         <code className="nx-code">.nx-icon</code> is a class that gives standard layout, namely left and right margin,
         to icons in a way that is compatible with the <code className="nx-code">nx-container-helpers</code>.
       </p>
-      <p>
+      <p className="nx-p">
         When using <code className="nx-code">.nx-icon</code> manually, be careful to set up heights and widths in
         ways that work in all supported browsers. For instance, note that in the example below, only the height OR the
         width need to be specified for Chrome and Firefox due to the instrinsic aspect ratio from

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -12,7 +12,7 @@ import NxListExamples from './NxListExamples';
 const NxListPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>Lists take many forms:</p>
+      <p className="nx-p">Lists take many forms:</p>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">Simple data lists</li>
         <li className="nx-list__item">Lists with clickable list items</li>
@@ -21,17 +21,17 @@ const NxListPage = () =>
         <li className="nx-list__item">Lists with actions</li>
         <li className="nx-list__item">Lists with items that have multiple lines of text</li>
       </ul>
-      <p>Lists can also have modified states depending on their content:</p>
+      <p className="nx-p">Lists can also have modified states depending on their content:</p>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">Lists with no data</li>
         <li className="nx-list__item">Error states</li>
       </ul>
-      <p>
+      <p className="nx-p">
         The basic layout is a container <code className="nx-code">&lt;div&gt;</code> wrapping a
         <code className="nx-code">&lt;ul&gt;</code>. If the list has a title it is placed inside
         the <code className="nx-code">&lt;div&gt;</code> before the &lt;ul&gt;.
       </p>
-      <p>
+      <p className="nx-p">
         There are also lists that are "clickable", the list items in these lists indicate hover and click states and
         when clicked an event occurs - usually navigation. Clickable lists have hover and disabled states. They share
         error and empty states with default lists.

--- a/gallery/src/styles/NxPageTitle/NxPageTitleExample.tsx
+++ b/gallery/src/styles/NxPageTitle/NxPageTitleExample.tsx
@@ -14,8 +14,8 @@ const NxPageTitleExample = () =>
       <NxFontAwesomeIcon icon={faAtom} className="nx-page-title__page-icon" />
       <h1 className="nx-h1">Page Title</h1>
       <div className="nx-page-title__description">
-        <p>This is a page description.</p>
-        <p>
+        <p className="nx-p">This is a page description.</p>
+        <p className="nx-p">
           jeans sign papier-mache assassin San Francisco rifle physical 3D-printed denim tanto courier concrete dolphin
           rebar free-market. tank-traps papier-mache dead free-market tanto drone concrete dolphin sunglasses weathered
           dead jeans office vehicle nodal point. motion film meta- monofilament knife vinyl post- bridge jeans city

--- a/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
+++ b/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
@@ -15,11 +15,11 @@ const nxPageTitleCode = require('!!raw-loader!./NxPageTitleExample').default;
 const NxPageTitlePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         nx-page-title is used at the top of a page, it always has a title, and can also have an icon
         and descriptive text.
       </p>
-      <p>
+      <p className="nx-p">
         Note: <code className="nx-code">.nx-page-title</code> replaces
         <code className="nx-code">.nx-tile--top-tile</code> and <code className="nx-code">.nx-tile--title-only</code>.
       </p>

--- a/gallery/src/styles/NxScrollable/NxScrollableExample.tsx
+++ b/gallery/src/styles/NxScrollable/NxScrollableExample.tsx
@@ -8,27 +8,27 @@ import React from 'react';
 
 const NxScrollableExample = () =>
   <div className="nx-scrollable">
-    <p>
+    <p className="nx-p">
       range-rover shoes render-farm denim apophenia computer construct dead corrupted singularity apophenia euro-pop
       engine soul-delay. motion long-chain hydrocarbons film lights human shanty town voodoo god A.I. courier j-pop
       kanji weathered range-rover warehouse. crypto- nodal point sentient order-flow woman artisanal network tiger-team
       knife render-farm network faded render-farm bomb. jeans free-market crypto- beef noodles nodal point spook modem
     </p>
-    <p>
+    <p className="nx-p">
       soul-delay hotdog engine chrome -ware BASE jump Shibuya. boy industrial grade digital wristwatch franchise
       render-farm knife corporation neon into long-chain hydrocarbons geodesic tank-traps dead.
       render-farm render-farm corrupted computer hotdog face forwards digital 3D-printed faded meta- singularity
       disposable tiger-team cardboard. gang systema franchise dolphin tower physical bicycle 8-bit semiotics chrome RAF
       render-farm shrine Kowloon.
     </p>
-    <p>
+    <p className="nx-p">
       market savant hotdog garage neon sub-orbital rain faded tiger-team assassin gang woman faded girl. wonton soup
       gang crypto- Kowloon pre- rain dolphin denim corporation wristwatch corporation drone lights receding. corrupted
       sub-orbital tiger-team neon paranoid face forwards boy BASE jump saturation point skyscraper weathered marketing
       pen cyber-. rebar soul-delay shoes ablative fetishism human drugs city -space shoes saturation point nano- boy
       8-bit. nano- alcohol pre- rifle corporation sensory receding Kowloon numinous tattoo lights gang physical network.
     </p>
-    <p>
+    <p className="nx-p">
       tube pre- sprawl futurity film meta- bicycle office systemic monofilament weathered weathered knife Tokyo.
       bicycle meta- crypto- footage Legba neon monofilament 3D-printed shanty town into corporation beef noodles drone
       sentient. weathered ablative warehouse BASE jump -space disposable wristwatch beef noodles vinyl saturation point

--- a/gallery/src/styles/NxTable/NxTableStylePage.tsx
+++ b/gallery/src/styles/NxTable/NxTableStylePage.tsx
@@ -12,7 +12,9 @@ import NxTableExamples from './NxTableExamples';
 const NxTableStylePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">This is the styling and layout for a basic table. There are few variations demonstrated here:</p>
+      <p className="nx-p">
+        This is the styling and layout for a basic table. There are few variations demonstrated here:
+      </p>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list-item">Basic table layout</li>
         <li className="nx-list-item">Tables with clickable rows</li>

--- a/gallery/src/styles/NxTable/NxTableStylePage.tsx
+++ b/gallery/src/styles/NxTable/NxTableStylePage.tsx
@@ -12,14 +12,14 @@ import NxTableExamples from './NxTableExamples';
 const NxTableStylePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>This is the styling and layout for a basic table. There are few variations demonstrated here:</p>
+      <p className="nx-p">This is the styling and layout for a basic table. There are few variations demonstrated here:</p>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list-item">Basic table layout</li>
         <li className="nx-list-item">Tables with clickable rows</li>
         <li className="nx-list-item">Empty tables</li>
         <li className="nx-list-item">A table with an error.</li>
       </ul>
-      <p>
+      <p className="nx-p">
         Components for column sorting, column filtering, and tables with fixed headers and
         scrolling content sections are pending.
       </p>

--- a/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
+++ b/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
@@ -15,12 +15,12 @@ const sourceCode = require('!!raw-loader!./NxTextInputStylesExample').default;
 const NxTextInputStylesPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         Base styles for Sonatype text inputs.  Only the styles intended for "static" usage are shown
         here. For styles that involve business logic, such as validation, see
         the <a href="#pages/NxTextInput">NxTextInput React Component</a>.
       </p>
-      <p>Classes:</p>
+      <p className="nx-p">Classes:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
+++ b/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
@@ -18,11 +18,11 @@ const nxThreatNumberTableExampleCode = require('!!raw-loader!./NxThreatNumberTab
 const NxThreatNumberPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>
+      <p className="nx-p">
         When an IQ Policy Threat Number is displayed adjacent to an <code className="nx-code">NxThreatBar</code>,
         style the number with <code className="nx-code">nx-threat-number</code>
       </p>
-      <p>
+      <p className="nx-p">
         Note that if a threat bar is used inside <code className="nx-code">nx-cell</code> the {''}
         <code className="nx-code">nx-cell--threat-bar</code> modifier must be applied to the table cell. If that cell
         might have multi-line content, that content would need to be wrapped in a custom class to restore the padding

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -12,12 +12,12 @@ import NxTilesExamples from './NxTilesExamples';
 const NxTilePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p>The base building block of our pages.</p>
-      <p>
+      <p className="nx-p">The base building block of our pages.</p>
+      <p className="nx-p">
         There are three default classes that can be used within an <code className="nx-code">.nx-tile</code>.
         It can also be paired with <code className="nx-code">.nx-alert</code> to create tiles with alert coloring.
       </p>
-      <p>They're all showcased in the table below:</p>
+      <p className="nx-p">They're all showcased in the table below:</p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.6",
+  "version": "0.50.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.5",
+  "version": "0.50.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-typography.scss
+++ b/lib/src/base-styles/_nx-typography.scss
@@ -79,7 +79,6 @@
 }
 
 .nx-p {
-  font-size: $nx-font-size-s;
   margin-bottom: $nx-spacing-md;
 }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-164

Remove the `font-size-s` attribute from `nx-p` so that it picks up the default font-size of 16px

Updated all existing instances of `p>` tags in the gallery to us the `nx-p` class.