### PR TITLE
nxTextInput redesign fixes RSC-109

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.7",
+  "version": "0.50.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxTextInput/NxTextInputDisabledExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputDisabledExample.tsx
@@ -23,7 +23,7 @@ export default function NxTextInputDisabledExample() {
                      disabled/>
       </div>
       <div>
-        <NxTextInput placeholder="Disabled invalidvalid input"
+        <NxTextInput placeholder="Disabled invalid input"
                      value=""
                      isPristine={false}
                      validatable={true}

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.7",
+  "version": "0.50.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -12,11 +12,7 @@
 
   width: $nx-form-element-width-normal;
 
-  &:focus {
-    outline: 0;
-  }
-
-  &.pristine, &.pristine.valid {
+  &, &.pristine, &.pristine.valid {
     &:focus-within {
       .nx-text-input__box {
         border-color: #43cbf5;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-109

Fixes comments from testing, primarily that the `:focus` styles should have precedence of the `complete` styles.