### PR TITLE
nx-tree-view__trigger font size RSC-173 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.11",
+  "version": "0.50.12",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.11",
+  "version": "0.50.12",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTreeView/NxTreeView.scss
+++ b/lib/src/components/NxTreeView/NxTreeView.scss
@@ -61,7 +61,6 @@
   border: 1px solid transparent;
   cursor: pointer;
   display: flex;
-  font-size: 14px;
   height: 30px;
   line-height: 32px;
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-173

A trial change, the font size for the trigger was set at 14px, I removed the declaration and it falls back to 16px as intended.