### PR TITLE
nx-code font size RSC-174

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.11",
+  "version": "0.50.12",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.12",
+  "version": "0.50.13",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.12",
+  "version": "0.50.13",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.11",
+  "version": "0.50.12",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -34,10 +34,9 @@
 %nx-code {
   background-color: $nx-grey-1;
   border: $nx-border;
-  border-radius: 4px;
+  border-radius: $nx-border-radius;
   color: $nx-invalid-color;
   font-family: monospace;
-  font-size: $nx-font-size-s;
-  padding: 2px 4px;
+  padding: 1px 4px;
   white-space: nowrap;
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-174

Brought the `nx-code` font styles in line with the default be removing the font-size declaration. This had the benefit of making the code examples easier to read so I decreased the top/bottom padding by 1px.

I also changed the border radius to our new default value