### PR TITLE
update sidebar RSC-151

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.19",
+  "version": "0.50.20",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "0.50.18",
+  "version": "0.50.19",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -15,6 +15,8 @@
 
 .gallery-nav {
   .nx-tree-view__trigger {
+    padding-left: $nx-spacing-xs;
+
     .nx-tree-view__text {
       @include semi-bold();
 
@@ -27,15 +29,17 @@
   height: 100%;
   line-height: $nx-line-height;
   margin-right: 0;
-  margin-bottom: 4px;
+  margin-bottom: 0;
   margin-left: 0;
 }
 
 .gallery-link {
+  @include regular();
+
   border-radius: 6px;
   box-sizing: border-box;
   display: inline-block;
-  padding: $nx-spacing-xxs $nx-spacing-xs $nx-spacing-xxs $nx-spacing-xl;
+  padding: $nx-spacing-xxs $nx-spacing-xs $nx-spacing-xxs 36px;
   text-decoration: none;
   width: 100%;
 

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -18,15 +18,14 @@
     .nx-tree-view__text {
       @include semi-bold();
 
-      color: #393939;
-      font-size: 16px;
+      color: #2c2c2c;
     }
   }
 }
 
 .nx-tree-view__child.gallery-nav-link {
-  height: 32px;
-  line-height: 32px;
+  height: 100%;
+  line-height: $nx-line-height;
   margin-right: 0;
   margin-bottom: 4px;
   margin-left: 0;
@@ -36,9 +35,7 @@
   border-radius: 6px;
   box-sizing: border-box;
   display: inline-block;
-  height: 32px;
-  margin-bottom: 4px;
-  padding-left: 45px;
+  padding: $nx-spacing-xxs $nx-spacing-xs $nx-spacing-xxs $nx-spacing-xl;
   text-decoration: none;
   width: 100%;
 
@@ -47,15 +44,15 @@
   }
 
   &.active {
-    @include bold;
+    @include semi-bold;
 
-    background-color: #1a2eac;
+    background-color: #000066;
     color: #fff;
     cursor: default;
     text-decoration: none;
 
     &:hover {
-      background-color: #1a2eac;
+      background-color: #000066;
       color: #fff;
     }
   }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.19",
+  "version": "0.50.20",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "0.50.18",
+  "version": "0.50.19",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-151

There were some discrepancies between what was described in the ticket and what was shown in the Zeplin file which I noted. I used the Zeplin file as the source of truth.

Current styling is in line with the Zeplin file now, however there is a new caret icon which is a change that should be attached to `NxTreeView` not the sidebar.