### PR TITLE
Create mixin for adding a custom default font-size to projects RSC-182

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -45,7 +45,7 @@
   .nx-text-input__input,
   .nx-radio,
   .nx-checkbox {
-    font-size: #{$custom-font-size};
+    font-size: $custom-font-size;
   }
 }
 

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -32,7 +32,7 @@
 }
 
 // for specificity reasons this should be called using a custom class on the <body> tag
-// e.g. `<body className="nx-body nx-body--custom-font-size">`
+// e.g. `<body className="nx-body nx-body--my-app">`
 @mixin font-size($custom-font-size) {
   &.nx-body,
 

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -31,6 +31,24 @@
   white-space: nowrap;
 }
 
+// Should be called on a custom class attached to the <body> tag
+@mixin font-size($custom-font-size) {
+  &.nx-body,
+
+  // buttons
+  .nx-btn,
+  .nx-dropdown-link,
+  .nx-dropdown-button,
+
+  // form elements
+  .nx-label,
+  .nx-text-input__input,
+  .nx-radio,
+  .nx-checkbox {
+    font-size: #{$custom-font-size};
+  }
+}
+
 %nx-code {
   background-color: $nx-grey-1;
   border: $nx-border;

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -31,7 +31,8 @@
   white-space: nowrap;
 }
 
-// Should be called on a custom class attached to the <body> tag
+// for specificity reasons this should be called using a custom class on the <body> tag
+// e.g. `<body className="nx-body nx-body--custom-font-size">`
 @mixin font-size($custom-font-size) {
   &.nx-body,
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-182

The mixin should be `@include`d in the project's `<body>` tag. I changed the default `<body>` font as well as all other classes that are set to that size in order to override browser agent settings.

Screenshot below shows the default font-size changed to `8px` using the mixin:

<img width="1137" alt="Screen Shot 2020-07-08 at 2 09 26 PM" src="https://user-images.githubusercontent.com/1991443/86961312-059cb080-c12f-11ea-9563-37f6dcd28d4f.png">

I believe that we could expand upon this to resize the headings to proportionally match the custom size.
