### PR TITLE
Example page for font size mixin RSC-225

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.2.1",
+  "version": "1.1.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -122,9 +122,9 @@ const pageConfig: PageConfig = {
     'nx-tile': NxTilePage
   },
   'Styles - Mixins & Helpers': {
+    'Custom app font size': NxFontSizePage,
     'nx-clickable': NxClickablePage,
     'nx-container-helpers': NxContainerHelpersPage,
-    'Custom app font-size': NxFontSizePage,
     'nx-scrollable': NxScrollablePage,
     'nx-truncate-ellipsis': NxTruncatePage
   },

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -64,6 +64,7 @@ import NxTruncatePage from './styles/NxTruncateEllipsis/NxTruncatePage';
 import NxCodePage from './styles/NxCode/NxCodePage';
 import StylingComponentsPage from './pages/StylingComponents';
 import AdditionalResourcePage from './pages/AdditionalResources';
+import NxFontSizePage from './styles/NxFontSize/NxFontSizePage';
 
 const pageConfig: PageConfig = {
   'React Components': {
@@ -123,6 +124,7 @@ const pageConfig: PageConfig = {
   'Styles - Mixins & Helpers': {
     'nx-clickable': NxClickablePage,
     'nx-container-helpers': NxContainerHelpersPage,
+    'nx-font-size': NxFontSizePage,
     'nx-scrollable': NxScrollablePage,
     'nx-truncate-ellipsis': NxTruncatePage
   },

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -124,7 +124,7 @@ const pageConfig: PageConfig = {
   'Styles - Mixins & Helpers': {
     'nx-clickable': NxClickablePage,
     'nx-container-helpers': NxContainerHelpersPage,
-    'nx-font-size': NxFontSizePage,
+    'Custom app font-size': NxFontSizePage,
     'nx-scrollable': NxScrollablePage,
     'nx-truncate-ellipsis': NxTruncatePage
   },

--- a/gallery/src/styles/NxFontSize/NxFontSizeHtmlExample.html
+++ b/gallery/src/styles/NxFontSize/NxFontSizeHtmlExample.html
@@ -1,0 +1,10 @@
+<!--
+
+    Copyright (c) 2019-present Sonatype, Inc.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+
+-->
+<body class="nx-body project-body--custom-font-size">
+</body>

--- a/gallery/src/styles/NxFontSize/NxFontSizeHtmlExample.html
+++ b/gallery/src/styles/NxFontSize/NxFontSizeHtmlExample.html
@@ -9,7 +9,7 @@
 <div class="nx-body project-body--custom-font-size">
   <p class="nx-p">Normally this text would be 16px, but it should be 12px.</p>
   <p class="nx-p">
-    Note: for illustration purposes we have used the mixin to style a &lt;div&gt;, but it should be
+    Note: for illustration purposes we have used the mixin to style a &lt;div&gt;, but in actual usage it should be
     applied to the &lt;body&gt; tag.
   </p>
 </div>

--- a/gallery/src/styles/NxFontSize/NxFontSizeHtmlExample.html
+++ b/gallery/src/styles/NxFontSize/NxFontSizeHtmlExample.html
@@ -6,5 +6,10 @@
     distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
 -->
-<body class="nx-body project-body--custom-font-size">
-</body>
+<div class="nx-body project-body--custom-font-size">
+  <p class="nx-p">Normally this text would be 16px, but it should be 12px.</p>
+  <p class="nx-p">
+    Note: for illustration purposes we have used the mixin to style a &lt;div&gt;, but it should be
+    applied to the &lt;body&gt; tag.
+  </p>
+</div>

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import './NxFontSizeScssExample.scss';
 
 const nxFontSizeHtmlExampleCode = require('!!raw-loader!./NxFontSizeHtmlExample.html').default;
 const nxFontSizeScssExampleCode = require('!!raw-loader!./NxFontSizeScssExample.scss').default;

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -15,14 +15,14 @@ const NxFontSizePage = () =>
   <>
     <GalleryDescriptionTile>
       <p className="nx-p">
-        <code className="nx-code">nx-font-size()</code> is a mixin that can be applied to the
+        <code className="nx-code">font-size()</code> is a mixin that can be applied to the
         {' '}<code className="nx-code">&lt;body&gt;</code> tag of your project to adjust the default RSC font size to
         better match your project. The default font size in RSC is 16px.
       </p>
       <p className="nx-p">
         The mixin takes a single variable which is the desired font-size with unit. For example:
-        {' '}<code className="nx-code">@include nx-font-size(14px);</code> or
-        {' '}<code className="nx-code">@include nx-font-size(1.1em);</code>.
+        {' '}<code className="nx-code">@include font-size(14px);</code> or
+        {' '}<code className="nx-code">@include font-size(1.1em);</code>.
       </p>
       <p className="nx-p">
         The mixin adjusts the default text size as well as several user agent set form element font sizes.

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -35,14 +35,10 @@ const NxFontSizePage = () =>
       </p>
     </GalleryDescriptionTile>
     <GalleryExampleTile title="Sample HTML"
-                        codeExamples={nxFontSizeHtmlExampleCode}
+                        codeExamples={[{ content: nxFontSizeHtmlExampleCode, language: 'html' },
+                          { content: nxFontSizeScssExampleCode, language: 'scss' }]}
                         htmlExample={nxFontSizeHtmlExampleCode}>
       In the example below the &lt;body&gt; tag has a custom CSS class applied which is referenced in the SCSS.
-    </GalleryExampleTile>
-    <GalleryExampleTile title="Mixin usage"
-                        codeExamples={nxFontSizeScssExampleCode}
-                        htmlExample={nxFontSizeScssExampleCode}>
-      The mixin is called and the font-size will be changed to 14px.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
+const nxFontSizeHtmlExampleCode = require('!!raw-loader!./NxFontSizeHtmlExample.html').default;
+const nxFontSizeScssExampleCode = require('!!raw-loader!./NxFontSizeScssExample.scss').default;
+
+const NxFontSizePage = () =>
+  <>
+    <GalleryDescriptionTile>
+      <p className="nx-p">
+        <code className="nx-code">nx-font-size()</code> is a mixin that can be applied to the
+        {' '}<code className="nx-code">&lt;body&gt;</code> tag of your project to adjust the default RSC font size to
+        better match your project. The default font size in RSC is 16px.
+      </p>
+      <p className="nx-p">
+        The mixin takes a single variable which is the desired font-size with unit. For example:
+        {' '}<code className="nx-code">@include nx-font-size(14px);</code> or
+        {' '}<code className="nx-code">@include nx-font-size(1.1em);</code>.
+      </p>
+      <p className="nx-p">
+        The mixin adjusts the default text size as well as several user agent set form element font sizes.
+      </p>
+      <p className="nx-p">
+        This mixin is primarily intended for use when RSC is incorporated into existing/legacy projects. If you're
+        using it on a new project then you should confirm with your designer, or the design group that custom font
+        sizes are a design requirement.
+      </p>
+    </GalleryDescriptionTile>
+    <GalleryExampleTile title="Sample HTML"
+                        codeExamples={nxFontSizeHtmlExampleCode}
+                        htmlExample={nxFontSizeHtmlExampleCode}>
+      In the example below the &lt;body&gt; tag has a custom CSS class applied which is referenced in the SCSS.
+    </GalleryExampleTile>
+    <GalleryExampleTile title="Mixin usage"
+                        codeExamples={nxFontSizeScssExampleCode}
+                        htmlExample={nxFontSizeScssExampleCode}>
+      The mixin is called and the font-size will be changed to 14px.
+    </GalleryExampleTile>
+  </>;
+
+export default NxFontSizePage;

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -25,7 +25,8 @@ const NxFontSizePage = () =>
         {' '}<code className="nx-code">@include font-size(1.1em);</code>.
       </p>
       <p className="nx-p">
-        The mixin adjusts the default text size as well as several user agent set form element font sizes.
+        The mixin adjusts the default text size as well as several form elements which have default font size values
+        set by the browser.
       </p>
       <p className="nx-p">
         This mixin is primarily intended for use when RSC is incorporated into existing/legacy projects. If you're

--- a/gallery/src/styles/NxFontSize/NxFontSizeScssExample.scss
+++ b/gallery/src/styles/NxFontSize/NxFontSizeScssExample.scss
@@ -7,5 +7,5 @@
 
 -->
 .project-body--custom-font-size {
-  @include nx-font-size(14px);
+  @include font-size(14px);
 }

--- a/gallery/src/styles/NxFontSize/NxFontSizeScssExample.scss
+++ b/gallery/src/styles/NxFontSize/NxFontSizeScssExample.scss
@@ -1,11 +1,13 @@
-<!--
+/*
 
     Copyright (c) 2019-present Sonatype, Inc.
     This program and the accompanying materials are made available under
     the terms of the Eclipse Public License 2.0 which accompanies this
     distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
 
--->
+*/
+@import '~@sonatype/react-shared-components/scss-shared/nx-text-helpers';
+
 .project-body--custom-font-size {
-  @include font-size(14px);
+  @include font-size(12px);
 }

--- a/gallery/src/styles/NxFontSize/NxFontSizeScssExample.scss
+++ b/gallery/src/styles/NxFontSize/NxFontSizeScssExample.scss
@@ -1,0 +1,11 @@
+<!--
+
+    Copyright (c) 2019-present Sonatype, Inc.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+
+-->
+.project-body--custom-font-size {
+  @include nx-font-size(14px);
+}

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.2.1",
+  "version": "1.1.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -33,7 +33,7 @@
 
 // for specificity reasons this should be called using a custom class on the <body> tag
 // e.g. `<body className="nx-body nx-body--my-app">`
-@mixin nx-font-size($custom-font-size) {
+@mixin font-size($custom-font-size) {
   &.nx-body,
 
   // buttons

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -33,7 +33,7 @@
 
 // for specificity reasons this should be called using a custom class on the <body> tag
 // e.g. `<body className="nx-body nx-body--my-app">`
-@mixin font-size($custom-font-size) {
+@mixin nx-font-size($custom-font-size) {
   &.nx-body,
 
   // buttons


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-225

Create an example page for the `nx-font-size` mixin that explains its purpose and use.

I also renamed it to `nx-font-size` to match other mixins. We probably want to make this consistent will all of them.