### PR TITLE
Iday testing library

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -33,6 +33,8 @@
   "author": "Sonatype, Inc.",
   "license": "EPL-2.0",
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.11.1",
+    "@testing-library/react": "^10.4.7",
     "@types/enzyme": "=3.9.1",
     "@types/enzyme-adapter-react-16": "=1.0.5",
     "@types/jest": "=24.0.11",

--- a/lib/src/components/NxAlert/NxAlert.tsx
+++ b/lib/src/components/NxAlert/NxAlert.tsx
@@ -27,8 +27,8 @@ const NxAlert = forwardRef<HTMLDivElement, NxAlertProps>(
           classes = classnames('nx-alert', className);
 
       return (
-        <div { ...otherProps } ref={ref} className={classes}>
-          <NxFontAwesomeIcon icon={icon}/>
+        <div role="alert" { ...otherProps } ref={ref} className={classes}>
+          { icon && <NxFontAwesomeIcon icon={icon}/> }
           { ensureElement(children) }
         </div>
       );
@@ -43,10 +43,15 @@ export default NxAlert;
  * @param children VDOM nodes to be included after the icon.
  */
 export const NxErrorAlert = forwardRef<HTMLDivElement, Props>(
-    function NxErrorAlert(props, ref) {
+    function NxErrorAlert({children, ...props}, ref) {
       const classes = classnames('nx-alert--error', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faExclamationCircle} />;
+      return (
+        <NxAlert {...props} className={classes} ref={ref}>
+          <NxFontAwesomeIcon icon={faExclamationCircle} aria-label="Error"/>
+          {children}
+        </NxAlert>
+      );
     }
 );
 
@@ -57,10 +62,15 @@ NxErrorAlert.propTypes = propTypes;
  * @param children VDOM nodes to be included after the icon.
  */
 export const NxInfoAlert = forwardRef<HTMLDivElement, Props>(
-    function NxInfoAlert(props, ref) {
+    function NxInfoAlert({children, ...props}, ref) {
       const classes = classnames('nx-alert--info', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faInfoCircle} />;
+      return (
+        <NxAlert { ...props } ref={ref} className={classes}>
+          <NxFontAwesomeIcon icon={faInfoCircle} aria-label="Information" />
+          {children}
+        </NxAlert>
+      );
     }
 );
 NxInfoAlert.propTypes = propTypes;
@@ -70,10 +80,15 @@ NxInfoAlert.propTypes = propTypes;
  * @param children VDOM nodes to be included after the icon.
  */
 export const NxWarningAlert = forwardRef<HTMLDivElement, Props>(
-    function NxWarningAlert(props, ref) {
+    function NxWarningAlert({children, ...props}, ref) {
       const classes = classnames('nx-alert--warning', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faExclamationTriangle} />;
+      return (
+        <NxAlert {...props} ref={ref} className={classes}>
+          <NxFontAwesomeIcon icon={faExclamationTriangle} aria-label="Warning" />
+          {children}
+        </NxAlert>
+      );
     }
 );
 
@@ -84,10 +99,15 @@ NxWarningAlert.propTypes = propTypes;
  * @param children VDOM nodes to be included after the icon.
  */
 export const NxSuccessAlert = forwardRef<HTMLDivElement, Props>(
-    function NxSuccessAlert(props, ref) {
+    function NxSuccessAlert({children, ...props}, ref) {
       const classes = classnames('nx-alert--success', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faCheckCircle} />;
+      return (
+        <NxAlert {...props} ref={ref} className={classes}>
+          <NxFontAwesomeIcon icon={faCheckCircle} aria-label="Success" />
+          {children}
+        </NxAlert>
+      );
     }
 );
 

--- a/lib/src/components/NxAlert/__tests__/NxAlert.iday.test.tsx
+++ b/lib/src/components/NxAlert/__tests__/NxAlert.iday.test.tsx
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { faBiohazard } from '@fortawesome/free-solid-svg-icons';
+import NxAlert, { NxErrorAlert, NxWarningAlert, NxInfoAlert, NxSuccessAlert } from '../NxAlert';
+
+describe('NxAlert', function() {
+  const MESSAGE = 'A message to show in an alert';
+
+  it('renders an accessible alert with a message', function() {
+    render(<NxAlert>{MESSAGE}</NxAlert>);
+
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toHaveTextContent(MESSAGE);
+  });
+
+  it('renders the classNames given to it', function() {
+    const customClassNames = 'test-classname ufo';
+    render(<NxAlert className={customClassNames}>{MESSAGE}</NxAlert>);
+
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toHaveClass(customClassNames);
+  });
+
+  it('renders the children passed to it', function() {
+    render(
+      <NxAlert>
+        <p data-testid='test-p'>Test Paragraph</p>
+        <div data-testid='test-div'>Test Div</div>
+      </NxAlert>
+    );
+
+    const alert = screen.getByRole('alert');
+    const p = screen.getByTestId('test-p');
+    const div = screen.getByTestId('test-div');
+
+    expect(alert).toContainElement(p);
+    expect(alert).toContainElement(div);
+    expect(p).toHaveTextContent('Test Paragraph');
+    expect(div).toHaveTextContent('Test Div');
+  });
+
+  it('wraps children in a span if they are just a text node', function() {
+    render(<NxAlert>{MESSAGE}</NxAlert>);
+
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toContainHTML(`<span>${MESSAGE}</span>`);
+  });
+
+  it('renders the icon passed to it', function () {
+    render(<NxAlert icon={faBiohazard} />);
+
+    const alert = screen.getByRole('alert');
+    const img = screen.getByRole('img', { hidden: true });
+
+    expect(alert).toContainElement(img);
+    expect(img).toHaveClass('fa-biohazard');
+  });
+
+  it('passes additional props to the div', function() {
+    render(<NxAlert id="foo" title="baz" />);
+
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toHaveAttribute('id', 'foo');
+    expect(alert).toHaveAttribute('title', 'baz');
+  });
+
+  describe('NxErrorAlert', function() {
+    it('renders an NxAlert', function() {
+      render(<NxErrorAlert>{MESSAGE}</NxErrorAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert');
+    });
+
+    it('uses the appropriate error classes', function () {
+      render(<NxErrorAlert>{MESSAGE}</NxErrorAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert--error');
+    });
+
+    it('renders the appropriate error icon', function () {
+      render(<NxErrorAlert>{MESSAGE}</NxErrorAlert>);
+
+      const alert = screen.getByRole('alert');
+      const icon = screen.getByLabelText('Error');
+
+      expect(alert).toContainElement(icon);
+      expect(icon).toHaveClass('fa-exclamation-circle');
+    });
+
+    it('renders the children passed into it', function () {
+      render(<NxErrorAlert>{MESSAGE}</NxErrorAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveTextContent(MESSAGE);
+    });
+
+    it('passes any other props to the div', function () {
+      render(<NxErrorAlert id="foo" title="baz">{MESSAGE}</NxErrorAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveAttribute('id', 'foo');
+      expect(alert).toHaveAttribute('title', 'baz');
+    });
+  });
+
+  describe('NxWarningAlert', function() {
+    it('renders an NxAlert', function () {
+      render(<NxWarningAlert>{MESSAGE}</NxWarningAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert');
+    });
+
+    it('uses the appropriate error classes', function () {
+      render(<NxWarningAlert>{MESSAGE}</NxWarningAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert--warning');
+    });
+
+    it('renders the appropriate warning icon', function () {
+      render(<NxWarningAlert>{MESSAGE}</NxWarningAlert>);
+
+      const alert = screen.getByRole('alert');
+      const icon = screen.getByLabelText('Warning');
+
+      expect(alert).toContainElement(icon);
+      expect(icon).toHaveClass('fa-exclamation-triangle');
+    });
+
+    it('renders the children passed into it', function () {
+      render(<NxWarningAlert>{MESSAGE}</NxWarningAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveTextContent(MESSAGE);
+    });
+
+    it('passes any other props to the div', function () {
+      render(<NxWarningAlert id="foo" title="baz">{MESSAGE}</NxWarningAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveAttribute('id', 'foo');
+      expect(alert).toHaveAttribute('title', 'baz');
+    });
+  });
+
+  describe('NxInfoAlert', function() {
+    it('renders an NxAlert', function () {
+      render(<NxInfoAlert>{MESSAGE}</NxInfoAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert');
+    });
+
+    it('uses the appropriate error classes', function () {
+      render(<NxInfoAlert>{MESSAGE}</NxInfoAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert--info');
+    });
+
+    it('renders the appropriate info icon', function () {
+      render(<NxInfoAlert>{MESSAGE}</NxInfoAlert>);
+
+      const alert = screen.getByRole('alert');
+      const icon = screen.getByLabelText('Information');
+
+      expect(alert).toContainElement(icon);
+      expect(icon).toHaveClass('fa-info-circle');
+    });
+
+    it('renders the children passed into it', function () {
+      render(<NxInfoAlert>{MESSAGE}</NxInfoAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveTextContent(MESSAGE);
+    });
+
+    it('passes any other props to the div', function () {
+      render(<NxInfoAlert id="foo" title="baz">{MESSAGE}</NxInfoAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveAttribute('id', 'foo');
+      expect(alert).toHaveAttribute('title', 'baz');
+    });
+  });
+
+  describe('NxSuccessAlert', function () {
+    it('renders an NxAlert', function () {
+      render(<NxSuccessAlert>{MESSAGE}</NxSuccessAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert');
+    });
+
+    it('uses the appropriate error classes', function () {
+      render(<NxSuccessAlert>{MESSAGE}</NxSuccessAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveClass('nx-alert--success');
+    });
+
+    it('renders the appropriate info icon', function () {
+      render(<NxSuccessAlert>{MESSAGE}</NxSuccessAlert>);
+
+      const alert = screen.getByRole('alert');
+      const icon = screen.getByLabelText('Success');
+
+      expect(alert).toContainElement(icon);
+      expect(icon).toHaveClass('fa-check-circle');
+    });
+
+    it('renders the children passed into it', function () {
+      render(<NxSuccessAlert>{MESSAGE}</NxSuccessAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveTextContent(MESSAGE);
+    });
+
+    it('passes any other props to the div', function () {
+      render(<NxSuccessAlert id="foo" title="baz">{MESSAGE}</NxSuccessAlert>);
+
+      const alert = screen.getByRole('alert');
+
+      expect(alert).toHaveAttribute('id', 'foo');
+      expect(alert).toHaveAttribute('title', 'baz');
+    });
+  });
+});

--- a/lib/src/components/NxAlert/__tests__/NxAlert.test.tsx
+++ b/lib/src/components/NxAlert/__tests__/NxAlert.test.tsx
@@ -93,7 +93,7 @@ describe('NxAlert', function() {
       it('renders the appropriate error icon', function() {
         const nxErrorAlert = getNxErrorAlert();
         expect(nxErrorAlert).toMatchSelector(NxAlert);
-        expect(nxErrorAlert).toHaveProp('icon', faExclamationCircle);
+        expect(nxErrorAlert).toContainReact(<NxFontAwesomeIcon icon={faExclamationCircle} aria-label="Error" />);
       });
 
       it('renders the children passed into it', function() {
@@ -119,7 +119,7 @@ describe('NxAlert', function() {
       it('renders the appropriate alert icon', function() {
         const nxWarningAlert = getNxWarningAlert();
         expect(nxWarningAlert).toMatchSelector(NxAlert);
-        expect(nxWarningAlert).toHaveProp('icon', faExclamationTriangle);
+        expect(nxWarningAlert).toContainReact(<NxFontAwesomeIcon icon={faExclamationTriangle} aria-label="Warning" />);
       });
 
       it('uses the appropriate warning classes', function() {
@@ -157,7 +157,7 @@ describe('NxAlert', function() {
       it('renders the appropriate info icon', function() {
         const nxInfoAlert = getNxInfoAlert();
         expect(nxInfoAlert).toMatchSelector(NxAlert);
-        expect(nxInfoAlert).toHaveProp('icon', faInfoCircle);
+        expect(nxInfoAlert).toContainReact(<NxFontAwesomeIcon icon={faInfoCircle} aria-label="Information" />);
       });
 
       it('renders the children passed into it', function() {

--- a/lib/src/components/NxAlert/types.ts
+++ b/lib/src/components/NxAlert/types.ts
@@ -17,7 +17,7 @@ export const propTypes = {
 } as PropTypes.ValidationMap<Props>;
 
 export type NxAlertProps = HTMLAttributes<HTMLDivElement> & {
-  icon: IconDefinition;
+  icon?: IconDefinition;
 };
 
 export const nxAlertPropTypes: PropTypes.ValidationMap<NxAlertProps> = {

--- a/lib/src/components/NxBackButton/__tests__/NxBackButton.iday.test.tsx
+++ b/lib/src/components/NxBackButton/__tests__/NxBackButton.iday.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import NxBackButton from '../NxBackButton';
+
+describe('NxBackButton', function () {
+  it('renders the link', function () {
+    render(<NxBackButton href="/foo" />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveAttribute('href', '/foo');
+  });
+
+  it('renders the specified text within the link', function () {
+    render(<NxBackButton href="/foo" text="Link Text" />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveTextContent('Link Text');
+  });
+
+  it('ignores the targetPageTitle when the text prop is set', function () {
+    render(<NxBackButton href="/foo" text="Link Text" targetPageTitle="BarBaz" />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveTextContent('Link Text')
+  });
+
+  it('renders text based on the targetPageTitle if no text was specified', function () {
+    render(<NxBackButton href="/foo" targetPageTitle="BarBaz" />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveTextContent('BarBaz')
+  });
+
+  it('renders just the word "Back" if no text was specified and the state does not have a title', function () {
+    render(<NxBackButton href="/foo" />);
+
+    const link = screen.getByRole('link');
+
+    expect(link).toHaveTextContent('Back')
+  });
+});

--- a/lib/src/components/NxButton/__tests__/NxButton.iday.test.tsx
+++ b/lib/src/components/NxButton/__tests__/NxButton.iday.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+
+import NxFontAwesomeIcon from '../../NxFontAwesomeIcon/NxFontAwesomeIcon';
+import NxButton from '../NxButton';
+
+describe('NxButton', function() {
+  it('renders a button', function() {
+    render(<NxButton />);
+
+    expect(screen.getByRole('button')).toHaveClass('nx-btn');
+  });
+
+  it('renders a primary button', function() {
+    render(<NxButton variant="primary">Primary Button</NxButton>);
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveClass('nx-btn--primary');
+    expect(button).toHaveTextContent('Primary Button');
+  });
+
+  it('does not render a variant class if the variant matches the default variant of "secondary"', function() {
+    render(<NxButton variant="secondary">Secondary Button</NxButton>);
+
+    expect(screen.getByRole('button')).not.toHaveClass('nx-btn--secondary');
+  });
+
+  it('renders an icon-only button', function() {
+    render(<NxButton iconOnly={true}><NxFontAwesomeIcon icon={faCheck}/></NxButton>);
+
+    const button = screen.getByRole('button');
+    const icon = screen.getByRole('img', { hidden: true });
+
+    expect(button).toHaveClass('nx-btn--icon-only');
+    expect(button).toContainElement(icon);
+  });
+
+  it('renders an error button', function () {
+    render(<NxButton variant="error">Disabled Button</NxButton>);
+
+    expect(screen.getByRole('button')).toHaveClass('nx-btn--error');
+  });
+
+  it('is enabled by default', function () {
+    render(<NxButton>Button</NxButton>);
+
+    expect(screen.getByRole('button')).not.toHaveAttribute('disabled');
+  });
+
+  it('passes the disabled attribute through', function() {
+    render(<NxButton disabled>Disabled Button</NxButton>);
+
+    expect(screen.getByRole('button')).toHaveAttribute('disabled');
+  });
+
+  it('renders an inline button', function() {
+    render(<NxButton inline>Disabled Button</NxButton>);
+
+    expect(screen.getByRole('button')).toHaveClass('nx-btn--inline');
+  });
+});

--- a/lib/yarn.lock
+++ b/lib/yarn.lock
@@ -307,6 +307,21 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.10.5"
+  resolved "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.5.tgz#a57fe6c13045ca33768a2aa527ead795146febe1"
+  integrity sha512-RMafpmrNB5E/bwdSphLr8a8++9TosnyJp98RZzI6VOx2R2CCMpsXXXRvmI700O9oEKpXdZat6oEK68/F0zjd4A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.9.2":
+  version "7.10.5"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3":
   version "7.7.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz#d18c511121aff1b4f2cd1d452f1bac9601dd830f"
@@ -673,6 +688,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
 "@material-ui/core@4.5.0":
   version "4.5.0"
   resolved "https://registry.npmjs.org/@material-ui/core/-/core-4.5.0.tgz#7e57cc40988c71b6340e3b2569b47dbac1820351"
@@ -747,6 +772,46 @@
   integrity sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==
   dependencies:
     type-detect "4.0.8"
+
+"@testing-library/dom@^7.17.1":
+  version "7.21.4"
+  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-7.21.4.tgz#24b045f3161b7c91fdb35da7c001908cdc99b55b"
+  integrity sha512-IXjKRTAH31nQ+mx6q3IPw85RTLul8VlWBm1rxURoxDt7JI0HPlAAfbtrKTdeq83XYCYO7HSHogyV+OsD+6FX0Q==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    dom-accessibility-api "^0.4.6"
+    pretty-format "^25.5.0"
+
+"@testing-library/jest-dom@^5.11.1":
+  version "5.11.1"
+  resolved "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.1.tgz#b9541d7625cec9e5feb647f49a96c43f7c055cdd"
+  integrity sha512-NHOHjDwyBoqM7mXjNLieSp/6vJ17DILzhNTw7+RarluaBkyWRzWgFj+d6xnd1adMBlwfQSeR2FWGTxHXCxeMSA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react@^10.4.7":
+  version "10.4.7"
+  resolved "https://registry.npmjs.org/@testing-library/react/-/react-10.4.7.tgz#fc14847fb70a5e93576b8f7f0d1490ead02a9061"
+  integrity sha512-hUYbum3X2f1ZKusKfPaooKNYqE/GtPiQ+D2HJaJ4pkxeNJQFVUEvAvEh9+3QuLdBeTWkDMNY5NSijc5+pGdM4Q==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    "@testing-library/dom" "^7.17.1"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.1.7":
   version "7.1.7"
@@ -853,6 +918,14 @@
   dependencies:
     jest-diff "*"
 
+"@types/jest@*":
+  version "26.0.5"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.5.tgz#23a8eecf4764a770ea8d3a0d1ea16b96c822035d"
+  integrity sha512-heU+7w8snfwfjtcj2H458aTx3m5unIToOJhx75ebHilBiiQ39OIdA18WkG4LP08YKeAoWAGvWg8s+22w/PeJ6w==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
 "@types/jest@=24.0.11":
   version "24.0.11"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
@@ -911,6 +984,13 @@
   version "1.0.1"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.1.tgz#aba5ee062b7880f69c212ef769389f30752806e5"
+  integrity sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -1320,6 +1400,14 @@ argparse@^1.0.10, argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 arity-n@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
@@ -1462,7 +1550,7 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-atob@^2.1.1:
+atob@^2.1.1, atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
@@ -2193,6 +2281,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js-pure@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+
 core-js@^2.4.0:
   version "2.6.11"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -2336,6 +2429,11 @@ css-what@2.1:
   resolved "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 css@^2.0.0:
   version "2.2.4"
   resolved "https://registry.npmjs.org/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -2345,6 +2443,15 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -2568,6 +2675,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.6.tgz#f3f2af68aee01b1c862f37918d41841bb1aaf92a"
+  integrity sha512-qxFVFR/ymtfamEQT/AsYLe048sitxFCoCHiM+vuOdR3fE94i3so2SCFJxyz/RxV69PZ+9FgToYWOd7eqJqcbYw==
 
 dom-helpers@^5.0.1:
   version "5.1.3"
@@ -3888,6 +4000,11 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
@@ -3906,7 +4023,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4419,6 +4536,16 @@ jest-diff@*:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-diff@^25.1.0, jest-diff@^25.2.1, jest-diff@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
+  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
 jest-diff@^25.3.0:
   version "25.3.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-25.3.0.tgz#0d7d6f5d6171e5dacde9e05be47b3615e147c26f"
@@ -4587,6 +4714,16 @@ jest-leak-detector@^25.3.0:
   dependencies:
     jest-get-type "^25.2.6"
     pretty-format "^25.3.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
+  integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
 
 jest-matcher-utils@^25.3.0:
   version "25.3.0"
@@ -5525,6 +5662,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-css-extract-plugin@=0.6.0:
   version "0.6.0"
@@ -6513,6 +6655,16 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^25.2.1, pretty-format@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 pretty-format@^25.3.0:
   version "25.3.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-25.3.0.tgz#d0a4f988ff4a6cd350342fdabbb809aeb4d49ad5"
@@ -6863,6 +7015,14 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
@@ -6877,6 +7037,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -7430,6 +7595,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.16"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -7744,6 +7917,13 @@ strip-indent@^1.0.1:
   integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This PR shows some tests based on the `@testing-library/react`. We've been using this library successfully in repository manager so I wanted to see how tests would look in the RSC. The idea behind this testing library is that you write tests to interact with your components in a similar fashion to how the user interacts with the components (think black-box testing). In particular, you are encouraged to use the `getByRole` query to select elements by their ARIA accessibility role (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques). This should result in writing components in a more accessible manner because you are using similar tools to identify the components as a screen reader would be.

In writing the tests for the NxAlert component I ended up adding the `alert` role and making the `icon` prop optional so that I could pass in an `NxFontAwesome` icon with an `aria-label` to identify the type of alert by the label for the icon. This should make that component more accessible.