### PR TITLE
Add type="button" to components that use NxButton - RSC-242

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxCloseButton/NxCloseButton.tsx
+++ b/lib/src/components/NxCloseButton/NxCloseButton.tsx
@@ -18,7 +18,7 @@ const NxCloseButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBut
       const btnClasses = classnames('nx-btn--close', className);
 
       return (
-        <NxButton ref={ref} className={btnClasses} iconOnly={true} variant="tertiary" { ...otherProps }>
+        <NxButton ref={ref} type="button" className={btnClasses} iconOnly={true} variant="tertiary" { ...otherProps }>
           <Close/>
         </NxButton>
       );

--- a/lib/src/components/NxCloseButton/__tests__/NxCloseButton.test.tsx
+++ b/lib/src/components/NxCloseButton/__tests__/NxCloseButton.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import * as enzymeUtils from '../../../__testutils__/enzymeUtils';
+import NxCloseButton from '../NxCloseButton';
+import NxButton from '../../NxButton/NxButton';
+import Close from '../../../icons/Close';
+
+describe('NxCloseButton', function() {
+  const getShallowComponent = enzymeUtils.getShallowComponent(NxCloseButton, {});
+
+  it('renders an tertiary NxButton with type=button', function() {
+    expect(getShallowComponent()).toMatchSelector(NxButton);
+    expect(getShallowComponent()).toHaveProp('variant', 'tertiary');
+    expect(getShallowComponent()).toHaveProp('type', 'button');
+  });
+
+  it('passes the specified classes to the NxButton plus nx-btn--close', function() {
+    expect(getShallowComponent({ className: 'foo' })).toHaveClassName('foo');
+    expect(getShallowComponent({ className: 'foo' })).toHaveClassName('nx-btn--close');
+  });
+
+  it('passes other props on to the NxButton', function() {
+    expect(getShallowComponent({ id: 'foo' })).toHaveProp('id', 'foo');
+  });
+
+  it('contains a Close icon', function() {
+    expect(getShallowComponent().children()).toMatchSelector(Close);
+  });
+});

--- a/lib/src/components/NxDropdown/NxDropdown.tsx
+++ b/lib/src/components/NxDropdown/NxDropdown.tsx
@@ -35,7 +35,8 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
   const toggleTooltipProps = toggleTooltip && wrapTooltipProps(toggleTooltip);
 
   const toggle = (
-    <NxButton variant={variant || 'tertiary'}
+    <NxButton type="button"
+              variant={variant || 'tertiary'}
               className={buttonClasses}
               onClick={!disabled && onToggleCollapse || undefined}>
       <span className="nx-dropdown__toggle-label">{ label }</span>

--- a/lib/src/components/NxDropdown/__tests__/NxDropdown.test.tsx
+++ b/lib/src/components/NxDropdown/__tests__/NxDropdown.test.tsx
@@ -18,13 +18,14 @@ describe('NxDropdown', () => {
     isOpen: false
   });
 
-  it('renders a button with the appropriate classes', function() {
+  it('renders a button with the appropriate classes and type=button', function() {
     const component = getShallowComponent(),
         button = component.find(NxButton);
 
     expect(component).toHaveClassName('.nx-dropdown');
     expect(button).toHaveClassName('.nx-dropdown__toggle');
     expect(button).toHaveProp('variant', 'tertiary');
+    expect(button).toHaveProp('type', 'button');
     expect(button.childAt(0)).toContainReact(<span className="nx-dropdown__toggle-label">dropdown</span>);
     expect(button.childAt(1)).toHaveProp('icon', faCaretDown);
   });

--- a/lib/src/components/NxLoadError/NxLoadError.tsx
+++ b/lib/src/components/NxLoadError/NxLoadError.tsx
@@ -36,7 +36,7 @@ const NxLoadError = forwardRef<HTMLDivElement, Props>(
             { error }
           </span>
           { retryHandler &&
-            <NxButton variant="error" onClick={retryHandler} className="nx-load-error__retry">
+            <NxButton type="button" variant="error" onClick={retryHandler} className="nx-load-error__retry">
               <NxFontAwesomeIcon icon={faSync} />
               <span>Retry</span>
             </NxButton>

--- a/lib/src/components/NxLoadError/__tests__/NxLoadError.test.tsx
+++ b/lib/src/components/NxLoadError/__tests__/NxLoadError.test.tsx
@@ -53,6 +53,14 @@ describe('NxLoadError', function() {
     expect(getShallowComponent({ error: 'Error!', retryHandler: () => {} }).find(NxButton)).toIncludeText('Retry');
   });
 
+  it('adds the appropriate class, variant, and type to the retry button', function() {
+    const button = getShallowComponent({ error: 'Error!', retryHandler: () => {} }).find(NxButton);
+
+    expect(button).toHaveClassName('nx-load-error__retry');
+    expect(button).toHaveProp('variant', 'error');
+    expect(button).toHaveProp('type', 'button');
+  });
+
   it('calls the retryHandler when the retry button is clicked', function() {
     const retryHandler = jest.fn(),
         props = { error: 'Error!', canRetry: true, retryHandler },


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-242

I discovered during Improvement Day today that NxLoadError components within forms would trigger form submission, due to their Retry buttons not specifying a `type`, and defaulting to "submit".  This PR fixes that for NxLoadError as well as for other components which rely on NxButton and which should not trigger form submission.

Note that I considered just setting `type="button"` by default on NxButton, but I decided that, in light of `submit` being the default within HTML itself, that would violate the principle of least surprise.