### PR TITLE
Fix Gallery in IE11

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -60,6 +60,7 @@
     "@fortawesome/react-fontawesome": "=0.1.4",
     "@sonatype/react-shared-components": "link:../lib/dist",
     "classnames": "2.2.6",
+    "core-js": "3.6.5",
     "es6-object-assign": "1.1.0",
     "es6-set": "0.1.5",
     "node-sass": "4.12.0",

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -8,6 +8,9 @@ import React, { useEffect } from 'react';
 import { RouteChildrenProps } from 'react-router';
 import { HashRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
 import { mergeAll, values } from 'ramda';
+
+// polyfill Array.prototype.includes which is used in query-string
+import 'core-js/features/array/includes';
 import queryString from 'query-string';
 
 import { PageMapping } from './pageConfigTypes';
@@ -15,6 +18,7 @@ import pageConfig from './pageConfig';
 import PageHeader from './PageHeader';
 import GalleryNav from './GalleryNav';
 import Home from './pages/Home';
+import handleQueryParams from './handleQueryParams';
 
 const pageMappings: PageMapping = mergeAll(values(pageConfig));
 
@@ -23,17 +27,8 @@ function Page({ match, location }: RouteChildrenProps<{ pageName: string }>) {
       pageHeader = pageName || 'Home',
       Content = pageName ? pageMappings[pageName] : Home;
 
-  // Different page layout modes can be triggered via query params.  These page layout modes are
-  // implemented via classes on the <html> element. This feature exists so that visual tests
-  // of all page layout modes can be done
   useEffect(function() {
-    const queryParams = queryString.parse(location.search),
-        htmlEl = document.documentElement;
-
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    htmlEl!.classList.toggle('nx-html--page-scrolling', queryParams.disablePageScrolling !== 'true');
-    htmlEl!.classList.toggle('gallery-hide-sidebar', queryParams.hideSidebar === 'true');
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    handleQueryParams(queryString.parse(location.search));
   }, [location.search]);
 
   if (Content) {

--- a/gallery/src/handleQueryParams.ts
+++ b/gallery/src/handleQueryParams.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import { ParsedQuery } from 'query-string';
+
+/*
+ * Different page layout modes can be triggered via query params.  These page layout modes are
+ * implemented via classes on the <html> element. This feature exists so that visual tests
+ * of all page layout modes can be done
+ */
+export default function handleQueryParams(queryParams: ParsedQuery) {
+  const { classList } = document.documentElement;
+
+  if (queryParams.disablePageScrolling === 'true') {
+    classList.remove('nx-html--page-scrolling');
+  }
+  else {
+    classList.add('nx-html--page-scrolling');
+  }
+
+  if (queryParams.hideSidebar === 'true') {
+    classList.add('gallery-hide-sidebar');
+  }
+  else {
+    classList.remove('gallery-hide-sidebar');
+  }
+}

--- a/gallery/webpack.config.js
+++ b/gallery/webpack.config.js
@@ -36,7 +36,10 @@ module.exports = function(env = { production: false }) {
         loader: 'ts-loader',
         include: [
           path.resolve(__dirname, 'src'),
-          path.resolve(__dirname, 'node_modules/fuse.js/')
+          path.resolve(__dirname, 'node_modules/fuse.js/'),
+          path.resolve(__dirname, 'node_modules/query-string/'),
+          path.resolve(__dirname, 'node_modules/split-on-first/'),
+          path.resolve(__dirname, 'node_modules/strict-uri-encode/')
         ]
       }, {
         test: /\.s?css$/,

--- a/gallery/yarn.lock
+++ b/gallery/yarn.lock
@@ -2162,6 +2162,11 @@ core-js@^2.4.0:
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
+core-js@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -6888,15 +6893,6 @@ qs@~6.5.2:
   resolved "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@6.13.1:
-  version "6.13.1"
-  resolved "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
-  integrity sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 query-string@^5.0.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
@@ -6905,6 +6901,15 @@ query-string@^5.0.1:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
+
+query-string@^6.13.1:
+  version "6.13.1"
+  resolved "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
+  integrity sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I found today that the Gallery had been broken in IE11 since the query-string dependency was included.  Additionally the HTML element classname adjustments that were being in conjunction with query-string used a native API (the two-param classList.toggle function) that IE11 does not support, so that code had to be rewritten as well.