### PR TITLE
NxLoadError visual tests - RSC-191

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 @Library(['private-pipeline-library', 'jenkins-shared']) _
 
 def seleniumDockerImage = 'selenium/standalone-chrome'
-def seleniumDockerVersion = '3.141.59-20200409'
+def seleniumDockerVersion = '84.0'
 
 dockerizedBuildPipeline(
   // expose gallery port on host so selenium container can hit it

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 @Library(['private-pipeline-library', 'jenkins-shared']) _
 
 def seleniumDockerImage = 'selenium/standalone-chrome'
-def seleniumDockerVersion = '84.0'
+def seleniumDockerVersion = '3.141.59'
 
 dockerizedBuildPipeline(
   // expose gallery port on host so selenium container can hit it

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 @Library(['private-pipeline-library', 'jenkins-shared']) _
 
 def seleniumDockerImage = 'selenium/standalone-chrome'
-def seleniumDockerVersion = '3.141.59'
+def seleniumDockerVersion = '3.141.59-20200730'
 
 dockerizedBuildPipeline(
   // expose gallery port on host so selenium container can hit it

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
+++ b/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
@@ -73,6 +73,7 @@ const NxLoadErrorPage = () =>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Standard Example with Retry Button"
+                        id="nx-load-error-retry-example"
                         codeExamples={retrySourceCode}
                         liveExample={NxLoadErrorRetryExample}>
       In this example, the error is cleared on retry. Note that
@@ -106,6 +107,7 @@ const NxLoadErrorPage = () =>
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Retry Button with Long Text"
+                        id="nx-load-error-long-retry-example"
                         codeExamples={retryLongMessageSourceCode}
                         liveExample={NxLoadErrorRetryLongMessageExample}>
       This example demonstrates that when the text is long, the Retry button falls

--- a/gallery/visualtests/nxLoadError.js
+++ b/gallery/visualtests/nxLoadError.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+const { simpleTest } = require('./testUtils');
+
+describe('NxLoadError', function() {
+  beforeEach(async function() {
+    await browser.url('#/pages/NxLoadError');
+  });
+
+  const simpleSelector = '#nx-load-error-retry-example .nx-alert--load-error',
+      longElementSelector = '#nx-load-error-long-retry-example .nx-alert--load-error'
+
+  describe('NxLoadError with short text and Retry button', function() {
+    it('looks right', simpleTest(simpleSelector));
+  });
+
+  describe('NxLoadError with long text and Retry button', function() {
+    it('looks right', simpleTest(longElementSelector));
+  });
+});

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-alert.scss
+++ b/lib/src/base-styles/_nx-alert.scss
@@ -25,6 +25,7 @@
     // replicate the vertical-alignment that fontawesome icons usually have.  vertical-align itself has
     // no effect here so we use relative positioning instead
     bottom: -0.125em;
+    flex-shrink: 0;
     height: 1em;
     margin-right: $nx-spacing-md;
     position: relative;

--- a/lib/src/components/NxLoadError/NxLoadError.scss
+++ b/lib/src/components/NxLoadError/NxLoadError.scss
@@ -3,16 +3,15 @@
 
 .nx-alert--load-error {
   .nx-alert__content {
-    @include container-vertical;
     @include container-horizontal;
     align-items: first baseline;
     display: flex;
     flex-wrap: wrap;
+    row-gap: $nx-spacing-l;
   }
 }
 
 .nx-load-error__message {
-  margin-bottom: $nx-spacing-sm;
   margin-right: $nx-spacing-sm;
 
   word-break: break-word;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-191

This PR includes visual tests for NxLoadError and also a bug fix for the layout of NxLoadError: currently on master, when the error message is short and the Retry button is inline with it, the Retry button has too much space below it owing to the bottom margin on the error message.  Additionally, @dturner32 has made an adjustment to the expected spacing under that message which would have made the issue worse.  This PR fixes that by using the flexbox `row-gap` property instead of bottom margin.  Note that this property is only supported on the very latest versions of Chrome and Edge, and recent versions of Firefox.