### PR TITLE
Back Button Updates - RSC-231

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-globals.scss
+++ b/lib/src/base-styles/_nx-globals.scss
@@ -15,11 +15,15 @@ $nx-scrollable-default-height: 400px;
   #Basic links
 */
 .nx-text-link {
-  color: $nx-link-color;
+  color: #045dd1;
   cursor: pointer;
 
   &:hover {
-    color: $nx-link-color-hover;
+    color: #034396;
+  }
+
+  &:active {
+    color: #2783fb;
   }
 }
 

--- a/lib/src/components/NxBackButton/NxBackButton.scss
+++ b/lib/src/components/NxBackButton/NxBackButton.scss
@@ -6,24 +6,15 @@
  */
 @import '../../scss-shared/nx-variables';
 @import '../../scss-shared/nx-container-helpers';
-@import '../../scss-shared/nx-text-helpers';
 
 .nx-back-button {
-  a {
+  margin-top: $nx-spacing-l;
+  margin-bottom: $nx-spacing-l;
+
+  .nx-text-link {
     @include container-horizontal;
-    @include semi-bold();
 
-    color: $nx-link-color;
-    font-size: 14px;
-    line-height: 32px;
+    font-size: $nx-font-size-s;
     text-decoration: none;
-
-    &:hover {
-      color: $nx-link-color-hover;
-    }
-
-    > .fa-chevron-left {
-      margin-right: 6px;
-    }
   }
 }

--- a/lib/src/components/NxBackButton/NxBackButton.tsx
+++ b/lib/src/components/NxBackButton/NxBackButton.tsx
@@ -26,7 +26,7 @@ const NxBackButton: FunctionComponent<Props> =
 
     return (
       <div className="nx-back-button tm-back-button">
-        <a href={href}>
+        <a className="nx-text-link" href={href}>
           <NxFontAwesomeIcon icon={faChevronLeft} />
           <span>{linkText}</span>
         </a>

--- a/lib/src/components/NxBackButton/__tests__/NxBackButton.test.tsx
+++ b/lib/src/components/NxBackButton/__tests__/NxBackButton.test.tsx
@@ -15,8 +15,9 @@ describe('NxBackButton', function() {
     expect(getShallowComponent().find('a')).toExist();
   });
 
-  it('renders the link', function() {
+  it('renders the link with the nx-text-link class', function() {
     expect(getShallowComponent().find('a')).toHaveProp('href', '/foo');
+    expect(getShallowComponent().find('a')).toHaveClassName('nx-text-link');
   });
 
   it('renders the specified text within the link', function() {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-231

I went ahead here and updated the styles for all links, assuming they should all use the colors defined in the back button mockup.

Weirdly, the text rendering in my browser seems noticeably different (thinner) than the zeplin mockup, but I'm pretty certain I have all of the properties right.