### PR TITLE
Example of how a tile containing only a form should be structured - Improvement Day

### DIFF
--- a/gallery/src/styles/NxTile/NxTileFormExample.tsx
+++ b/gallery/src/styles/NxTile/NxTileFormExample.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { FormEvent } from 'react';
+
+import { NxStatefulTextInput, NxButton } from '@sonatype/react-shared-components';
+
+export default function NxTileFormExample() {
+  function validator(val: string) {
+    return val.length ? null : 'Must be non-empty';
+  }
+
+  function onSubmit(evt: FormEvent) {
+    evt.preventDefault();
+    alert('Submitted!');
+  }
+
+  return (
+    <section className="nx-tile">
+      <form className="nx-form" onSubmit={onSubmit}>
+        <header className="nx-tile-header">
+          <div className="nx-tile-header__title"><h2 className="nx-h2">NX Simple Tile</h2></div>
+        </header>
+        <div className="nx-tile-content">
+          <div className="nx-form-group">
+            <label className="nx-label">
+              <span className="nx-label__text">Label</span>
+              <NxStatefulTextInput validator={validator}/>
+            </label>
+          </div>
+          <div className="nx-form-group">
+            <label className="nx-label nx-label--optional">
+              <span className="nx-label__text">Label</span>
+              <NxStatefulTextInput/>
+            </label>
+          </div>
+        </div>
+        <footer className="nx-footer">
+          <div className="nx-btn-bar">
+            <NxButton variant="primary">Footer Button</NxButton>
+          </div>
+        </footer>
+      </form>
+    </section>
+  );
+}

--- a/gallery/src/styles/NxTile/NxTilesExamples.tsx
+++ b/gallery/src/styles/NxTile/NxTilesExamples.tsx
@@ -7,11 +7,15 @@
 import React from 'react';
 import { GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
+import NxTileFormExample from './NxTileFormExample';
+
 const NxSimpleTileCode = require('!!raw-loader!./NxSimpleTileExample.html').default,
     NxTileWithActionsCode = require('!!raw-loader!./NxTileWithActionsExample.html').default,
     NxTileWithSubtitleCode = require('!!raw-loader!./NxTileWithSubtitleExample.html').default,
     NxTileSubsectionCode = require('!!raw-loader!./NxTileSubsectionExample.html').default,
-    NxTileWithHorizontalRuleCode = require('!!raw-loader!./NxTileWithHorizontalRuleExample.html').default;
+    NxTileWithHorizontalRuleCode = require('!!raw-loader!./NxTileWithHorizontalRuleExample.html').default,
+    NxTileFormCode = require('!!raw-loader!./NxTileFormExample.tsx').default;
+
 
 const NxTilesExamples = () =>
   <>
@@ -51,6 +55,13 @@ const NxTilesExamples = () =>
                         codeExamples={NxTileSubsectionCode}>
       An example of an <code className="nx-code">nx-tile</code> containing mulitple subsections. Note the horizontal
       rule which appears before the first subsection, but not between subsections.
+    </GalleryExampleTile>
+
+    <GalleryExampleTile title="NX Tile consisting of a form"
+                        id="nx-tile-form-example"
+                        liveExample={NxTileFormExample}
+                        codeExamples={NxTileFormCode}>
+      An example of an <code className="nx-code">nx-tile</code> which solely contains a form.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/styles/NxTile/NxTilesExamples.tsx
+++ b/gallery/src/styles/NxTile/NxTilesExamples.tsx
@@ -16,7 +16,6 @@ const NxSimpleTileCode = require('!!raw-loader!./NxSimpleTileExample.html').defa
     NxTileWithHorizontalRuleCode = require('!!raw-loader!./NxTileWithHorizontalRuleExample.html').default,
     NxTileFormCode = require('!!raw-loader!./NxTileFormExample.tsx').default;
 
-
 const NxTilesExamples = () =>
   <>
     <GalleryExampleTile title="NX Simple Tile Example"


### PR DESCRIPTION
I found it ambiguous determining how a tile containing only a form should be structured.  After doing more research into how `header` and `footer` are supposed to work, I determined that the form and the tile cannot be the same element, because `form` is not a [Sectioning Content](https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#sectioning-content) element - that is, it does not create a semantic container for the `<header>` and `<footer>`, like `<section>` does.  This Gallery example proves that the styles work if you nest the `<form>` inside the` <section class="nx-tile">`, and asserts that that is the correct way to do it.

The other age-old question about this scenario – whether to use `nx-tile-footer` or `nx-form-footer` – is moot in this PR as it is based on my other branch where I merged them both into simply `nx-footer`.