### PR TITLE
Long, user-resizable textareas - RSC-271

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxTextInput/NxTextInputLongExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputLongExample.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { useState } from 'react';
+
+import { NxTextInput } from '@sonatype/react-shared-components';
+import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+
+export default function NxTextInputSimpleExample() {
+  const [state1, setState1] = useState(initialState('')),
+      [state2, setState2] = useState(initialState(''));
+
+  function onChange1(val: string) {
+    setState1(userInput(null, val));
+  }
+
+  function onChange2(val: string) {
+    setState2(userInput(null, val));
+  }
+
+  return (
+    <>
+      <div>
+        <NxTextInput className="nx-text-input--long" { ...state1 } onChange={onChange1} />
+      </div>
+      <div>
+        <NxTextInput className="nx-text-input--long" type="textarea" { ...state2 } onChange={onChange2} />
+      </div>
+    </>
+  );
+};

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -13,6 +13,7 @@ import NxTextInputValidationExample from './NxTextInputValidationExample';
 import NxTextInputPasswordExample from './NxTextInputPasswordExample';
 import NxTextInputTextAreaExample from './NxTextInputTextAreaExample';
 import NxTextInputTextAreaValidationExample from './NxTextInputTextAreaValidationExample';
+import NxTextInputLongExample from './NxTextInputLongExample';
 import NxTextInputDisabledExample from './NxTextInputDisabledExample';
 
 const simpleSourceCode = require('!!raw-loader!./NxTextInputSimpleExample').default;
@@ -20,6 +21,7 @@ const validationSourceCode = require('!!raw-loader!./NxTextInputValidationExampl
 const passwordSourceCode = require('!!raw-loader!./NxTextInputPasswordExample').default;
 const textAreaSourceCode = require('!!raw-loader!./NxTextInputTextAreaExample').default;
 const textAreaValidationSourceCode = require('!!raw-loader!./NxTextInputTextAreaValidationExample').default;
+const longSourceCode = require('!!raw-loader!./NxTextInputLongExample').default;
 const disabledSourceCode = require('!!raw-loader!./NxTextInputDisabledExample').default;
 
 const NxTextInputPage = () =>
@@ -225,6 +227,14 @@ const NxTextInputPage = () =>
                         liveExample={NxTextInputTextAreaValidationExample}
                         codeExamples={textAreaValidationSourceCode}>
       An example of an <code className="nx-code">NxTextInput</code> set up to be a multi-line text area with validation.
+    </GalleryExampleTile>
+
+    <GalleryExampleTile title="Long example"
+                        id="nx-text-input-long-example"
+                        liveExample={NxTextInputLongExample}
+                        codeExamples={longSourceCode}>
+      Examples of <code className="nx-code">NxTextInput</code>s using
+      the <code className="nx-code">long</code> modifier, which makes them wider.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Disabled example"

--- a/gallery/visualtests/nxTextInput.js
+++ b/gallery/visualtests/nxTextInput.js
@@ -13,7 +13,6 @@ describe('NxTextInput', function() {
       passwordComponentSelector = '#nx-text-input-password-example .nx-text-input',
       textareaComponentSelector = '#nx-text-input-textarea-validation-example .nx-text-input',
       validatableTextareaComponentSelector = '#nx-text-input-textarea-validation-example .nx-text-input',
-      validatableTextareaComponentSelector = '#nx-text-input-textarea-validation-example .nx-text-input',
       longComponentSelector = '#nx-text-input-long-example .nx-text-input:not(.nx-text-input--textarea)',
       longTextareaComponentSelector = '#nx-text-input-long-example .nx-text-input--textarea',
       disabledComponentSelector = '#nx-text-input-disabled-example .nx-text-input.pristine',

--- a/gallery/visualtests/nxTextInput.js
+++ b/gallery/visualtests/nxTextInput.js
@@ -13,6 +13,9 @@ describe('NxTextInput', function() {
       passwordComponentSelector = '#nx-text-input-password-example .nx-text-input',
       textareaComponentSelector = '#nx-text-input-textarea-validation-example .nx-text-input',
       validatableTextareaComponentSelector = '#nx-text-input-textarea-validation-example .nx-text-input',
+      validatableTextareaComponentSelector = '#nx-text-input-textarea-validation-example .nx-text-input',
+      longComponentSelector = '#nx-text-input-long-example .nx-text-input:not(.nx-text-input--textarea)',
+      longTextareaComponentSelector = '#nx-text-input-long-example .nx-text-input--textarea',
       disabledComponentSelector = '#nx-text-input-disabled-example .nx-text-input.pristine',
       disabledValidComponentSelector = '#nx-text-input-disabled-example .nx-text-input.valid',
       disabledInvalidComponentSelector = '#nx-text-input-disabled-example .nx-text-input.invalid';
@@ -121,6 +124,14 @@ describe('NxTextInput', function() {
       await browser.keys(['Backspace', 'Backspace', 'Backspace']);
       await browser.eyesRegionSnapshot(null, Target.region(targetElement));
     });
+  });
+
+  describe('Long NxTextInput', function() {
+    it('looks right', simpleTest(textareaComponentSelector));
+  });
+
+  describe('Long textarea NxTextInput', function() {
+    it('looks right', simpleTest(textareaComponentSelector));
   });
 
   describe('Disabled NxTextInput', function() {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -105,6 +105,10 @@
 
 .nx-text-input--long {
   width: $nx-form-element-width-wide;
+
+  textarea.nx-text-input__input {
+    width: $nx-form-element-width-wide - (2 * $nx-spacing-md);
+  }
 }
 
 .nx-text-input--textarea {
@@ -112,7 +116,8 @@
     align-items: flex-end;
   }
 
-  width: auto;
+  // textarea width is controlled at the textarea element itself so that it can still be user-resizable
+  width: min-content;
   min-width: 300px;
   max-width: 700px;
 }
@@ -120,6 +125,8 @@
 textarea.nx-text-input__input {
   min-height: 220px;
   padding: 0;
+
+  width: $nx-form-element-width-normal - (2 * $nx-spacing-md);
 }
 
 ::-ms-clear {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -103,35 +103,19 @@
   content: '\200b';
 }
 
-@function getInputWidth($component-width) {
-  // subtract padding and border from the component width to get the necessary <input> or <textarea> width
-  @return $component-width - (2 * ($nx-spacing-md + 1));
-}
-
 .nx-text-input--long {
   width: $nx-form-element-width-wide;
-
-  textarea.nx-text-input__input {
-    width: getInputWidth($nx-form-element-width-wide);
-  }
 }
 
 .nx-text-input--textarea {
   .nx-text-input__box {
     align-items: flex-end;
   }
-
-  // textarea width is controlled at the textarea element itself so that it can still be user-resizable
-  width: min-content;
-  min-width: 300px;
-  max-width: 700px;
 }
 
 textarea.nx-text-input__input {
   min-height: 220px;
   padding: 0;
-
-  width: getInputWidth($nx-form-element-width-normal);
 }
 
 ::-ms-clear {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -103,11 +103,16 @@
   content: '\200b';
 }
 
+@function getInputWidth($component-width) {
+  // subtract padding and border from the component width to get the necessary <input> or <textarea> width
+  @return $component-width - (2 * ($nx-spacing-md + 1));
+}
+
 .nx-text-input--long {
   width: $nx-form-element-width-wide;
 
   textarea.nx-text-input__input {
-    width: $nx-form-element-width-wide - (2 * $nx-spacing-md);
+    width: getInputWidth($nx-form-element-width-wide);
   }
 }
 
@@ -126,7 +131,7 @@ textarea.nx-text-input__input {
   min-height: 220px;
   padding: 0;
 
-  width: $nx-form-element-width-normal - (2 * $nx-spacing-md);
+  width: getInputWidth($nx-form-element-width-normal);
 }
 
 ::-ms-clear {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-271

Adjusts the styles for textarea NxTextInputs so that the `--long` modifier works ~~on them while still allowing them to be resizable~~.
