### PR TITLE
Add a max-width to nx-alert - RSC-285

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-alert.scss
+++ b/lib/src/base-styles/_nx-alert.scss
@@ -17,7 +17,7 @@
   border: $nx-border-darker;
   border-radius: $nx-border-radius;
   display: flex;
-  margin: 8px 0;
+  margin: 8px auto;
   max-width: 950px;
   padding: $nx-spacing-xs $nx-spacing-md $nx-spacing-xs $nx-spacing-md;
 

--- a/lib/src/base-styles/_nx-alert.scss
+++ b/lib/src/base-styles/_nx-alert.scss
@@ -18,6 +18,7 @@
   border-radius: $nx-border-radius;
   display: flex;
   margin: 8px 0;
+  max-width: 950px;
   padding: $nx-spacing-xs $nx-spacing-md $nx-spacing-xs $nx-spacing-md;
 
   > .nx-icon {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-285

Per conversation in Slack with @dturner32 it should be centered when there's extra space.

![image](https://user-images.githubusercontent.com/3630091/94196525-7deb5600-fe82-11ea-89e0-03a9b73d0ec8.png)
