### PR TITLE
Checker background fixes - RSC-301

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/gallery-components/GalleryTiles.tsx
+++ b/gallery/src/gallery-components/GalleryTiles.tsx
@@ -48,7 +48,7 @@ export const GalleryTile: FunctionComponent<GalleryTileProps> =
           <div className="nx-tile-header__title">
             <h2 className="nx-h2">{title}</h2>
           </div>
-          { actionButtons && <div className="nx-tile-header__actions">{actionButtons}</div> }
+          { actionButtons && <div className="nx-tile__actions">{actionButtons}</div> }
         </div>
         <div className={galleryTileClasses}>
           {children}

--- a/gallery/src/gallery-components/GalleryTiles.tsx
+++ b/gallery/src/gallery-components/GalleryTiles.tsx
@@ -48,7 +48,9 @@ export const GalleryTile: FunctionComponent<GalleryTileProps> =
           <div className="nx-tile-header__title">
             <h2 className="nx-h2">{title}</h2>
           </div>
-          { actionButtons && <div className="nx-tile__actions">{actionButtons}</div> }
+          { actionButtons &&
+            <div className="nx-tile__actions gallery-checkered-background-toggle">{actionButtons}</div>
+          }
         </div>
         <div className={galleryTileClasses}>
           {children}

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -122,3 +122,12 @@
     display: none;
   }
 }
+
+// This media query selects IE11
+@media (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  // hide checkered background checkbox in IE since the background doesn't work there (and we don't care to support
+  // it there
+  .gallery-checkered-background-toggle {
+    display: none;
+  }
+}

--- a/gallery/src/styles/NxTile/NxTilesExamples.tsx
+++ b/gallery/src/styles/NxTile/NxTilesExamples.tsx
@@ -65,6 +65,7 @@ const NxTilesExamples = () =>
 
     <GalleryExampleTile title="NX Tile consisting of a form"
                         id="nx-tile-form-example"
+                        defaultCheckeredBackground={true}
                         liveExample={NxTileFormExample}
                         codeExamples={NxTileFormCode}>
       An example of an <code className="nx-code">nx-tile</code> which solely contains a form.
@@ -72,6 +73,7 @@ const NxTilesExamples = () =>
 
     <GalleryExampleTile title="NX Tile with an NxDropdown in the actions buttons area"
                         id="nx-tile-dropdown-actions-example"
+                        defaultCheckeredBackground={true}
                         liveExample={NxTileDropdownActionsExample}
                         codeExamples={NxTileDropdownActionsCode}>
       An example of a tile with an <code className="nx-code">NxDropdown</code> (or

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-301

The checkered background doesn't work in IE11, and we don't care to fix it there, so instead we just hide the toggle for it.  A few other fixes as well.