### PR TITLE
Fix page description line height RSC-277 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -22,7 +22,6 @@
 
 .nx-page-title__page-icon {
   display: inline-block;
-  font-size: 32px;
   vertical-align: middle;
 }
 

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -22,7 +22,7 @@
 
 .nx-page-title__page-icon {
   display: inline-block;
-  font-size: 26px;
+  font-size: 32px;
   vertical-align: middle;
 }
 

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -11,7 +11,6 @@
 
   .nx-h1 {
     display: inline-block;
-    font-size: 26px;
     margin: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -29,7 +28,6 @@
 
 .nx-page-title__description {
   @include container-vertical;
-  line-height: 16px;
   margin: 8px 0 0 0;
   max-width: $nx-paragraph-width-maximum;
 }


### PR DESCRIPTION
While working on this I noticed that the page title itself had a custom font-size that it shouldn't have so I changed that as well.

Before:
<img width="618" alt="Screen Shot 2020-10-02 at 4 06 04 PM" src="https://user-images.githubusercontent.com/1991443/94965289-36d81300-04c9-11eb-8702-eb8395f759de.png">
After:
<img width="599" alt="Screen Shot 2020-10-02 at 4 05 02 PM" src="https://user-images.githubusercontent.com/1991443/94965300-3b043080-04c9-11eb-8273-9cfcdcff8b57.png">
