### PR TITLE
Add standard margins to nx-list--bulleted RSC-345

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -104,7 +104,7 @@
 
 .nx-list--bulleted {
   border-top: none;
-  margin: 0;
+  margin: $nx-spacing-md 0 $nx-spacing-l 0;
   padding: 0 0 0 26px;
 
   .nx-list__item {
@@ -123,6 +123,7 @@
     }
 
     .nx-list {
+      margin: 0;
       padding: 0 0 0 14px;
     }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-345

Added standard top and bottom margin to `nx-list--bulleted`, ensured that margin is zeroed out on nested lists.