### PR TITLE
Checkbox Label Overflow - RSC-315

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxCheckbox/NxCheckboxNowrapExample.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxNowrapExample.tsx
@@ -16,11 +16,11 @@ function NxCheckboxNowrapExample() {
     <>
       <p className="nx-p">Subscribed: {isSubscribed.toString()}</p>
 
-      <div style={{width: '40px', border: '1px solid red'}}>
+      <div style={{width: '70px', border: '1px solid red'}}>
         Some text
         {' '}
         <NxCheckbox checkboxId="checkbox-nowrap" onChange={onChange} isChecked={isSubscribed}>
-          <span style={{color: 'red'}}>Subscribe</span>
+          Subscribe
         </NxCheckbox>
         {' '}
         some other text

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -86,7 +86,7 @@ const NxCheckboxPage = () =>
                         liveExample={NxCheckboxNowrapExample}
                         codeExamples={nowrapExampleCode}>
       This example includes a container around the checkboxes. This container is deliberately narrow and has a
-      red border. This makes it clear that the labels on checkboxes do not wrap.
+      red border. This makes it clear that the labels on checkboxes do not wrap, and truncate with an ellipsis.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxRadio/NxRadioNowrapExample.tsx
+++ b/gallery/src/components/NxRadio/NxRadioNowrapExample.tsx
@@ -17,15 +17,15 @@ export default function NxRadioNowrapExample() {
     <>
       <p style={{color: appliedColor}}>Selected Color: {color}</p>
 
-      <div style={{width: '40px', border: '1px solid red'}}>
+      <div style={{width: '70px', border: '1px solid red'}}>
         Some text
         {' '}
         <NxRadio name="color3" value="red" onChange={setColor} isChecked={color === 'red'}>
-          <span style={{color: 'red'}}>Red color</span>
+          Red color
         </NxRadio>
         {' '}
         <NxRadio name="color3" value="green" onChange={setColor} isChecked={color === 'green'}>
-          <span style={{color: 'green'}}>Green color</span>
+          Green color
         </NxRadio>
         {' '}
         some other text

--- a/gallery/src/components/NxRadio/NxRadioPage.tsx
+++ b/gallery/src/components/NxRadio/NxRadioPage.tsx
@@ -112,7 +112,7 @@ const NxRadioPage = () =>
                         liveExample={NxRadioNowrapExample}
                         codeExamples={nowrapExampleCode}>
       This example includes a container around the radio buttons. This container is deliberately narrow and has a
-      red border. This makes it clear that the labels on radio buttons do not wrap.
+      red border. This makes it clear that the labels on radio buttons do not wrap, and truncates with an ellipsis.
     </GalleryExampleTile>
   </>;
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -85,5 +85,6 @@
 
   border: 0;
   margin: 0 0 $nx-spacing-xl 0;
+  min-inline-size: auto;
   padding: 0;
 }

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -16,7 +16,14 @@
   display: flex;
   margin-bottom: $nx-spacing-xs;
   white-space: nowrap;
+
+  // fallback for IE11, which understands neither min nor max-content
   width: $nx-form-label-width-maximum;
+
+  // We have three upper bounds on the width of the element: $nx-form-label-width-maximum, the available space
+  // in the container, and the actual content width. The latter being needed so the click target doesn't extend beyond
+  // the end of the text
+  width: calc(min(#{$nx-form-label-width-maximum}, 100%));
   max-width: max-content;
 
   &:hover {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-315

While this was an IQ upgrade ticket, the issue is really in RSC.  It used to be that RSC only had to make sure the label didn't wrap, and then the calling code could truncate it with overflow styles on the container.  However, now that the radio and checkbox use flexbox internally for their layout, ancestor containers are no longer able to trigger ellipsis truncation within them.  Therefore it's up to the RSC styles to apply the truncation.