### PR TITLE
Tile footer spacing bug RSC-327

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-footer.scss
+++ b/lib/src/base-styles/_nx-footer.scss
@@ -10,7 +10,7 @@
 
   border-top: 1px solid #e9e9e9;
   margin-top: $nx-spacing-l;
-  padding: $nx-spacing-l 0;
+  padding-top: $nx-spacing-l;
 
   .nx-alert {
     margin-bottom: $nx-spacing-l;

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -22,6 +22,10 @@ $nx-tile-background-color: $nx-white;
   border-radius: $nx-border-radius;
   margin: $nx-spacing-xs 0 $nx-spacing-md 0;
   padding: $nx-spacing-l;
+
+  .nx-footer {
+    padding-bottom: 0;
+  }
 }
 
 // Special tile for containing grids

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -22,10 +22,6 @@ $nx-tile-background-color: $nx-white;
   border-radius: $nx-border-radius;
   margin: $nx-spacing-xs 0 $nx-spacing-md 0;
   padding: $nx-spacing-l;
-
-  .nx-footer {
-    padding-bottom: 0;
-  }
 }
 
 // Special tile for containing grids

--- a/lib/src/components/NxModal/NxModal.scss
+++ b/lib/src/components/NxModal/NxModal.scss
@@ -19,6 +19,7 @@ $nx-modal-padding: $nx-spacing-l;
   border-radius: $nx-border-radius;
   background-color: #ffffff;
   margin: 100px 0;
+  padding: $nx-spacing-l 0;
   width: 800px;
 
   .nx-footer {
@@ -50,7 +51,7 @@ $nx-modal-padding: $nx-spacing-l;
 
   border-bottom: 1px solid #d1d6f0;
   margin: 0 $nx-modal-padding;
-  padding: $nx-modal-padding 0 $nx-spacing-l 0;
+  padding: 0 0 $nx-spacing-l 0;
 
   .nx-h2 {
     @include nx-truncate-ellipsis;
@@ -98,12 +99,6 @@ $nx-modal-padding: $nx-spacing-l;
   .nx-tab-panel {
     flex-shrink: 1;
     overflow-y: auto;
-    padding-bottom: $nx-spacing-l;
-  }
-}
-
-.nx-modal {
-  .nx-footer {
     padding-bottom: $nx-spacing-l;
   }
 }

--- a/lib/src/components/NxModal/NxModal.scss
+++ b/lib/src/components/NxModal/NxModal.scss
@@ -101,3 +101,9 @@ $nx-modal-padding: $nx-spacing-l;
     padding-bottom: $nx-spacing-l;
   }
 }
+
+.nx-modal {
+  .nx-footer {
+    padding-bottom: $nx-spacing-l;
+  }
+}


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-327

Simple fix to remove the bottom padding of `nx-footer` when it appears with `nx-tile`