### PR TITLE
Remove nx form margins RSC-347

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -10,7 +10,6 @@
 
 .nx-form {
   @include container-vertical;
-  margin: $nx-spacing-xl 0;
 }
 
 .nx-form-group {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-347

I removed the `margin` declaration from `.nx-form` because it does not seem that browser agents set a default margin on a `<form>` element so resetting it is unnecessary