### PR TITLE
bulleted list top padding fix RSC-345

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -113,6 +113,10 @@
     list-style: disc outside;
     padding: 8px 0 0 0;
 
+    &:first-child {
+      padding-top: 0;
+    }
+
     .nx-list__text {
       display: inline-block;
       // this is half the value specified in the designs. Browsers calculate the distance between the bullet
@@ -129,6 +133,11 @@
 
     .nx-list__item {
       list-style-type: circle;
+      padding-top: 8px;
+
+      &:first-child {
+        padding-top: 8px;
+      }
 
       .nx-list__text {
         @include regular();


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-345

It's a bit convoluted but the top padding on the very first list item is removed using `:first-child` then restored for all `:first-child`'s of nested lists.