### PR TITLE
nx-btn--tertiary background RSC-363 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-btn.scss
+++ b/lib/src/base-styles/_nx-btn.scss
@@ -70,12 +70,17 @@
 .nx-btn--tertiary {
   @extend %nx-btn--disabled;
 
+  background-color: transparent;
   border-color: #d1d6f0;
   color: #2c2c2c;
 
   &:hover {
-    background-color: $nx-white;
+    background-color: transparent;
     border-color: #2c2c2c;
+  }
+
+  &:focus {
+    background-color: transparent;
   }
 
   &:active {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-363

Per direction from Derrek change the background colour of the default, `:hover`, and `:focus` states from `#fff` to `transparent`.