### PR TITLE
Fix links in cards to use correct class RSC-222

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxCard/NxCardRowAltLayoutExample.tsx
+++ b/gallery/src/styles/NxCard/NxCardRowAltLayoutExample.tsx
@@ -24,7 +24,7 @@ export default function NxCardRowAltLayoutExample() {
             Text
           </div>
         </div>
-        <footer className="nx-card__footer"><a href="nx-text-link">Link</a></footer>
+        <footer className="nx-card__footer"><a href="#" className="nx-text-link">Link</a></footer>
       </section>
       <section className="nx-card">
         <header className="nx-card__header">
@@ -38,7 +38,7 @@ export default function NxCardRowAltLayoutExample() {
             Data point details
           </div>
         </div>
-        <footer className="nx-card__footer"><a href="nx-text-link">Link</a></footer>
+        <footer className="nx-card__footer"><a href="#" className="nx-text-link">Link</a></footer>
       </section>
       <section className="nx-card">
         <header className="nx-card__header">
@@ -52,7 +52,7 @@ export default function NxCardRowAltLayoutExample() {
             Large icon
           </div>
         </div>
-        <footer className="nx-card__footer"><a href="nx-text-link">Link</a></footer>
+        <footer className="nx-card__footer"><a href="#" className="nx-text-link">Link</a></footer>
       </section>
     </div>
   );

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-222

Fix issue where I have the `className` in the `href` in one example 