### PR TITLE
RSC-369: Pass HtmlInputChange Event

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTextInput/NxTextInput.tsx
+++ b/lib/src/components/NxTextInput/NxTextInput.tsx
@@ -12,11 +12,9 @@ import { faExclamationCircle, faCheck } from '@fortawesome/free-solid-svg-icons'
 import './NxTextInput.scss';
 
 import NxFontAwesomeIcon from '../NxFontAwesomeIcon/NxFontAwesomeIcon';
-import { Props, propTypes } from './types';
+import { Props, propTypes, TextInputElement } from './types';
 import { hasValidationErrors, getFirstValidationError } from '../../util/validationUtil';
 export { Props, propTypes, inputTypes } from './types';
-
-type TextInputElement = HTMLInputElement | HTMLTextAreaElement;
 
 /**
  * Standard text input with validation styling
@@ -96,7 +94,7 @@ const NxTextInput = forwardRef<TextInputElement, Props>(
 
       function inputOnChange(e: FormEvent<TextInputElement>) {
         if (onChange) {
-          onChange(e.currentTarget.value);
+          onChange(e.currentTarget.value, e);
         }
       }
 

--- a/lib/src/components/NxTextInput/__tests__/NxTextInput.test.tsx
+++ b/lib/src/components/NxTextInput/__tests__/NxTextInput.test.tsx
@@ -138,15 +138,16 @@ describe('NxTextInput', function() {
     expect(getShallowComponent({ name: 'a-name' }).find('input')).toHaveProp('name', 'a-name');
   });
 
-  it('calls onChange with the new value of the input element', function() {
+  it('calls onChange with the new value of the input element and event that fired', function() {
     const onChange = jest.fn(),
+        givenChangeEvent = { currentTarget: { value: 'foo' }},
         element = getShallowComponent({ onChange }).find('input');
 
     expect(onChange).not.toHaveBeenCalled();
 
-    element.simulate('change', { currentTarget: { value: 'foo' } });
+    element.simulate('change', givenChangeEvent);
 
-    expect(onChange).toHaveBeenCalledWith('foo');
+    expect(onChange).toHaveBeenCalledWith('foo', givenChangeEvent);
   });
 
   it('calls onKeyPress with the key value', function() {

--- a/lib/src/components/NxTextInput/types.ts
+++ b/lib/src/components/NxTextInput/types.ts
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import * as PropTypes from 'prop-types';
-import {InputHTMLAttributes, TextareaHTMLAttributes} from 'react';
+import { FormEvent, InputHTMLAttributes, TextareaHTMLAttributes } from 'react';
 
 /**
  * The valid values for the `type` Prop
@@ -34,10 +34,12 @@ type FusedProps = InputHTMLAttributes<HTMLInputElement> & TextareaHTMLAttributes
 // Leave out props to be re-defined
 export type HTMLProps = Omit<FusedProps, 'onChange'|'onKeyPress'|'type'|'defaultValue'>;
 
+export type TextInputElement = HTMLInputElement | HTMLTextAreaElement;
+
 // Final Props are the HTMLProps & our re-definitions
 export type Props = Omit<StateProps, 'trimmedValue'> & HTMLProps & {
   type?: NxTextInputType | null;
-  onChange?: ((newVal: string) => void) | null;
+  onChange?: ((newVal: string, e: FormEvent<TextInputElement>) => void) | null;
   onKeyPress?: ((keyCode: string) => void) | null;
   validatable?: boolean | null;
 };


### PR DESCRIPTION
This adds a second argument to the NxTextInput onChange callback which
receives the originating change event.

This will maintain backwards compatibility for the majority use case
where only the updated value is desired but still allow for other use
cases where additional information from the event is needed