### PR TITLE
Increase sidebar l/r padding to 24px RSC-370

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -51,7 +51,7 @@
   box-sizing: border-box;
   flex-basis: $nx-sidebar-width;
   overflow-x: hidden;
-  padding: $nx-spacing-xl $nx-spacing-md $nx-spacing-xs $nx-spacing-md;
+  padding: $nx-spacing-xl $nx-spacing-l $nx-spacing-xs $nx-spacing-l;
   position: relative;
   white-space: normal;
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-370

Per discussion we @dturner32 we are updating the sidebar left/right padding to `24px` to match the other container elements in RSC.