### PR TITLE
Add default bottom margin to text inputs RSC-357

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -9,6 +9,10 @@
 // Basic form layout
 .nx-form-group {
   margin-bottom: $nx-spacing-xl;
+
+  .nx-text-input {
+    margin-bottom: 0;
+  }
 }
 
 .nx-form-row {

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -10,6 +10,7 @@
 .nx-filter-input {
   @include container-horizontal;
 
+  margin-bottom: 0;
   white-space: nowrap;
 
   &:focus-within {

--- a/lib/src/components/NxTextInput/NxTextInput.scss
+++ b/lib/src/components/NxTextInput/NxTextInput.scss
@@ -7,6 +7,8 @@
 @import '../../scss-shared/_nx-form-validation.scss';
 
 .nx-text-input {
+  margin-bottom: $nx-spacing-xl;
+
   .nx-icon--invalid, .nx-icon--valid {
     display: none;
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-357

I used the same bottom margin (32px) as for the form groups because we know it accommodates the validation message plus a bit of extra space.