### PR TITLE
nxSubmitMask RSC-147

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
+++ b/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
@@ -64,7 +64,7 @@ const NxStatefulSubmitMaskPage = () =>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
               The text to display inside of the mask when <code className="nx-code">success</code> is false.  Defaults
-              to "Loading…"
+              to "Submitting…"
             </td>
           </tr>
           <tr className="nx-table-row nx-table-row--header">

--- a/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
+++ b/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
@@ -70,7 +70,7 @@ const NxSubmitMaskPage = () =>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
               The text to display inside of the mask when <code className="nx-code">success</code> is false.  Defaults
-              to "Loading…"
+              to "Submitting…"
             </td>
           </tr>
           <tr className="nx-table-row nx-table-row--header">

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxSubmitMask/NxSubmitMask.scss
+++ b/lib/src/components/NxSubmitMask/NxSubmitMask.scss
@@ -29,6 +29,7 @@
   position: fixed;
 
   .nx-submit-mask__message {
+    -ms-flex-item-align: start;
     align-self: start;
     margin-top: 200px;
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-147

Fixed the IE bug with a prefix
Changed the documentation in both the normal and stateful examples to reflect "Submitting..." as the new default text