### PR TITLE
NxTable doc updates and selected prop - RSC-250

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxTable/NxTableClickableExample.tsx
+++ b/gallery/src/components/NxTable/NxTableClickableExample.tsx
@@ -17,7 +17,7 @@ import {
 const NxTableClickableExample = () => {
   const rows = [
     { name: 'Name 1' },
-    { name: 'Name 2' },
+    { name: 'Name 2', selected: true },
     { name: 'Name 3' }
   ];
 
@@ -31,9 +31,9 @@ const NxTableClickableExample = () => {
         </NxTableRow>
       </NxTableHead>
       <NxTableBody>
-        {rows.map(row =>
-          <NxTableRow key={row.name} isClickable onClick={() => alert(`Clicked ${row.name}`)}>
-            <NxTableCell>{row.name}</NxTableCell>
+        {rows.map(({ name, selected = false }) =>
+          <NxTableRow key={name} isClickable selected={selected} onClick={() => alert(`Clicked ${name}`)}>
+            <NxTableCell>{name}</NxTableCell>
             <NxTableCell>Content</NxTableCell>
             <NxTableCell chevron/>
           </NxTableRow>

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -48,8 +48,8 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             The top-level component to use when displaying tables of data.
-            It can have <code className="nx-code">&lt;NxTableHead&gt;</code> and
-            <code className="nx-code">&lt;NxTableBody&gt;</code> components as children.
+            It can have <code className="nx-code">NxTableHead</code> and
+            {' '}<code className="nx-code">NxTableBody</code> components as children.
           </p>
         </section>
 
@@ -59,9 +59,9 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;thead&gt;</code> element.
-            The <code className="nx-code">&lt;NxTableRow&gt;</code> component is the only valid child.
-            Descendant <code className="nx-code">&lt;NxTableCell&gt;</code> components will have the
-            <code className="nx-code">&lt;isHeader&gt;</code> prop set.
+            The <code className="nx-code">NxTableRow</code> component is the only valid child.
+            Descendant <code className="nx-code">NxTableCell</code> components will have the
+            <code className="nx-code">isHeader</code> prop set.
           </p>
         </section>
 
@@ -71,7 +71,7 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;tbody&gt;</code> element.
-            It should have <code className="nx-code">&lt;NxTableRow&gt;</code> for children.
+            It should have <code className="nx-code">NxTableRow</code> for children.
           </p>
           <NxTable>
             <NxTableHead>
@@ -127,8 +127,48 @@ export default function NxTablePage() {
             Equivalent to the <code className="nx-code">&lt;tr&gt;</code> element.
             It automatically assigns <code className="nx-code">isHeader</code> on the children
             if that prop is set on this row.
-            It should have <code className="nx-code">&lt;NxTableCell&gt;</code> for children.
+            It should have <code className="nx-code">NxTableCell</code> for children.
           </p>
+          <NxTable>
+            <NxTableHead>
+              <NxTableRow>
+                <NxTableCell>Prop</NxTableCell>
+                <NxTableCell>Type</NxTableCell>
+                <NxTableCell>Required</NxTableCell>
+                <NxTableCell>Details</NxTableCell>
+              </NxTableRow>
+            </NxTableHead>
+            <NxTableBody>
+              <NxTableRow>
+                <NxTableCell>isClickable</NxTableCell>
+                <NxTableCell>boolean</NxTableCell>
+                <NxTableCell>false</NxTableCell>
+                <NxTableCell>Indicates that a table row is clickable.</NxTableCell>
+              </NxTableRow>
+              <NxTableRow>
+                <NxTableCell>isFilterHeader</NxTableCell>
+                <NxTableCell>boolean</NxTableCell>
+                <NxTableCell>false</NxTableCell>
+                <NxTableCell>Indicates that this row is a table header row containing filter inputs.</NxTableCell>
+              </NxTableRow>
+              <NxTableRow>
+                <NxTableCell>selected</NxTableCell>
+                <NxTableCell>boolean</NxTableCell>
+                <NxTableCell>false</NxTableCell>
+                <NxTableCell>
+                  For clickable table rows, indicates that this row is the currently selected one.
+                </NxTableCell>
+              </NxTableRow>
+              <NxTableRow>
+                <NxTableCell>isHeader</NxTableCell>
+                <NxTableCell>boolean</NxTableCell>
+                <NxTableCell>false</NxTableCell>
+                <NxTableCell>
+                  Automatically set to true when in an <code className="nx-code">NxTableHead</code> component
+                </NxTableCell>
+              </NxTableRow>
+            </NxTableBody>
+          </NxTable>
         </section>
 
         <section className="nx-tile-subsection">
@@ -154,7 +194,9 @@ export default function NxTablePage() {
                 <NxTableCell>isHeader</NxTableCell>
                 <NxTableCell>boolean</NxTableCell>
                 <NxTableCell>false</NxTableCell>
-                <NxTableCell>Automatically set to true when in a &lt;NxTableHead&gt; component</NxTableCell>
+                <NxTableCell>
+                  Automatically set to true when in an <code className="nx-code">NxTableHead</code> component
+                </NxTableCell>
               </NxTableRow>
               <NxTableRow>
                 <NxTableCell>metaInfo</NxTableCell>
@@ -165,7 +207,7 @@ export default function NxTablePage() {
                   applied to table cells that provide meta-information about the table data, such as loading, error,
                   and empty table states. For those three states, the caller of
                   the <code className="nx-code">NxTable</code> react component does not manage the table cells
-                  directly (instead using the appropriate props on <code className="nx-code">NxTableBody</code>, and
+                  directly (instead using the appropriate props on <code className="nx-code">NxTableBody</code>), and
                   therefore does not need to use this prop. However, the prop is available for any
                   other meta-info states that the caller might wish to convey. The intended usage is that a cell
                   using this prop would be the only cell in the only row in the table body, and would have
@@ -183,7 +225,9 @@ export default function NxTablePage() {
                 <NxTableCell>isSortable</NxTableCell>
                 <NxTableCell>boolean</NxTableCell>
                 <NxTableCell>false</NxTableCell>
-                <NxTableCell>Used for columns that can be sorted</NxTableCell>
+                <NxTableCell>
+                  Used for column headers that can be sorted. Should not be applied to data cells
+                </NxTableCell>
               </NxTableRow>
               <NxTableRow>
                 <NxTableCell>sortDir</NxTableCell>
@@ -192,8 +236,8 @@ export default function NxTablePage() {
                 <NxTableCell>
                   Used to indicate the sorting direction applied.
                   A null value indicates the column is not yet sorted.
-                  This should only be used for <code className="nx-code">&lt;NxTableCell&gt;</code> components
-                  in the <code className="nx-code">&lt;NxTableHead&gt;</code>
+                  This should only be used for <code className="nx-code">NxTableCell</code> components
+                  in the <code className="nx-code">NxTableHead</code>
                 </NxTableCell>
               </NxTableRow>
               <NxTableRow>
@@ -202,7 +246,7 @@ export default function NxTablePage() {
                 <NxTableCell>false</NxTableCell>
                 <NxTableCell>
                   Used to indicate a column whose data cells contain only one or
-                  more <code className="nx-code">&lt;NxFontAwesomeIcon&gt;</code>s
+                  more <code className="nx-code">NxFontAwesomeIcon</code>s
                 </NxTableCell>
               </NxTableRow>
               <NxTableRow>
@@ -213,16 +257,6 @@ export default function NxTablePage() {
                   Desginates a cell that should contain only the right-facing chevron icon used at that end of
                   clickable table cells. <code className="nx-code">NxTableCell</code>s with this prop set will
                   self-populate with the icon, and do not take <code className="nx-code">children</code>.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>isFilterHeader</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
-                  Used to indicate a table header cell contains a filter. When a table supports filtering,
-                  it should include a second row within the <code className="nx-code">thead</code>
-                  (<code className="nx-code">NxTableHead</code>) which contains the filter header cells.
                 </NxTableCell>
               </NxTableRow>
             </NxTableBody>

--- a/gallery/visualtests/nxTable.js
+++ b/gallery/visualtests/nxTable.js
@@ -20,7 +20,7 @@ describe('NxTable', function() {
       errorTableSelector = '#nx-table-error-example .nx-table';
 
   it('looks right with a hovered row', async function() {
-    const middleRowSelector = `${clickableTableSelector} tbody tr:nth-of-type(2)`,
+    const middleRowSelector = `${clickableTableSelector} tbody tr:nth-of-type(1)`,
         [table, row] = await Promise.all([browser.$(clickableTableSelector), browser.$(middleRowSelector)]);
 
       await row.scrollIntoView({ block: 'center' });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTableCell/types.ts
+++ b/lib/src/components/NxTableCell/types.ts
@@ -13,7 +13,6 @@ export type Props = (TdHTMLAttributes<HTMLTableCellElement> | ThHTMLAttributes<H
   metaInfo?: boolean | null;
   isNumeric?: boolean | null;
   isSortable?: boolean | null;
-  isFilterHeader?: boolean | null;
   hasIcon?: boolean | null;
   chevron?: boolean | null;
   sortDir?: 'asc' | 'desc' | null;
@@ -24,7 +23,6 @@ export const propTypes: PropTypes.ValidationMap<Props> = {
   metaInfo: PropTypes.bool,
   isNumeric: PropTypes.bool,
   isSortable: PropTypes.bool,
-  isFilterHeader: PropTypes.bool,
   hasIcon: PropTypes.bool,
   chevron: PropTypes.bool,
   sortDir: PropTypes.oneOf(['asc', 'desc', null]),

--- a/lib/src/components/NxTableRow/NxTableRow.tsx
+++ b/lib/src/components/NxTableRow/NxTableRow.tsx
@@ -13,11 +13,12 @@ import {Props, propTypes} from './types';
 export {Props} from './types';
 
 const NxTableRow = function NxTableRow(props: Props) {
-  const {isHeader = false, isFilterHeader = false, isClickable = false, className, children, ...attrs} = props;
+  const {isHeader = false, isFilterHeader = false, isClickable, selected, className, children, ...attrs} = props;
   const classes = classnames('nx-table-row', className, {
     'nx-table-row--header': isHeader,
     'nx-clickable': isClickable,
-    'nx-table-row--filter-header': isFilterHeader
+    'nx-table-row--filter-header': isFilterHeader,
+    selected
   });
 
   return (

--- a/lib/src/components/NxTableRow/types.ts
+++ b/lib/src/components/NxTableRow/types.ts
@@ -12,11 +12,13 @@ export type Props = HTMLAttributes<HTMLTableRowElement> & {
   isHeader?: boolean | null;
   isFilterHeader?: boolean | null;
   isClickable?: boolean | null;
+  selected?: boolean | null;
 };
 
 export const propTypes: PropTypes.ValidationMap<Props> = {
   isHeader: PropTypes.bool,
   isFilterHeader: PropTypes.bool,
   isClickable: PropTypes.bool,
+  selected: PropTypes.bool,
   children: PropTypes.node
 };


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-250

Fix up the docs and typescript types for `NxTable`, and also add a prop for specifying `selected` clickable rows, so that that doesn't have to be specified as a CSS class explicitly.