### PR TITLE
Export Donut Chart Props - RSC-379

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -134,4 +134,7 @@ export {
 export * from './util/threatLevels';
 export * from './util/validationUtil';
 
-export { default as NxBinaryDonutChart } from './components/NxBinaryDonutChart/NxBinaryDonutChart';
+export {
+  default as NxBinaryDonutChart,
+  Props as NxBinaryDonutChartProps
+} from './components/NxBinaryDonutChart/NxBinaryDonutChart';


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-379

When the NxBinaryDonutChart was implemented, it was forgotten to export its typescript `Props` type as a public member of RSC.