### PR TITLE
IWeek: NxPolicyThreatSlider Accessibility

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.tsx
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.tsx
@@ -11,7 +11,6 @@ import classnames from 'classnames';
 import { omit } from 'ramda';
 
 import { categoryByPolicyThreatLevel, ThreatLevelNumber } from '../../util/threatLevels';
-import { pathSet } from '../../util/jsUtil';
 
 import { Props, PolicyThreatLevelRange, propTypes } from './types';
 export { Props, PolicyThreatLevelRange, propTypes } from './types';
@@ -26,12 +25,14 @@ function NxPolicyThreatSliderValueLabelDisplay({ value, children, className, ...
 
   // this impl doesn't need to support these props. Filter them out so they don't cause react warnings on the span
   const filteredProps = omit(['open', 'valueLabelFormat', 'valueLabelDisplay'], otherProps),
-      thumb = React.Children.only(children),
-
-      // the thumb element isn't initially constructed with any children. Add the value as its child
-      thumbWithLabel = pathSet(['props', 'children'], value, thumb),
       limitedValue = Math.min(10, Math.max(0, Math.round(value))) as ThreatLevelNumber,
       threatCategory = categoryByPolicyThreatLevel[limitedValue],
+      thumb = React.Children.only(children),
+      screenReaderValue = `${limitedValue} (${threatCategory})`,
+
+      // the thumb element isn't initially constructed with any children. Add the value as its child and
+      // add extra accessibility attrs
+      thumbWithLabel = React.cloneElement(thumb, { 'aria-valuetext': screenReaderValue }, limitedValue),
       nxBaseClass = 'nx-policy-threat-slider__value-label',
       classes = classnames(nxBaseClass, `${nxBaseClass}--${threatCategory}`, className);
 

--- a/lib/src/components/NxPolicyThreatSlider/__tests__/NxPolicyThreatSlider.test.tsx
+++ b/lib/src/components/NxPolicyThreatSlider/__tests__/NxPolicyThreatSlider.test.tsx
@@ -86,6 +86,14 @@ describe('NxPolicyThreatSlider', function() {
       expect(getValueLabelDisplay({ value: 5 }).find('.foo').children()).toHaveText('5');
     });
 
+    it('sets the aria-valuetext of its child to include the numeric threat level and category', function() {
+      const component = getValueLabelDisplay({ value: 5 }).find('.foo'),
+          valueText = component.prop('aria-valuetext');
+
+      expect(valueText).toContain('5');
+      expect(valueText).toContain('severe');
+    });
+
     it('passes other props except open, valueLabelFormat, and valueLabelDisplay to the span', function() {
       const onClick = jest.fn(),
           props: any = {


### PR DESCRIPTION
This PR adds an aria-valuetext attribute to each slider so that they are read as both their numeric value and threat category.  Note that in ChromeVox this prevents the reading of the min and max values which was happening previously. My understanding is that that was not happening in VoiceOver anyway.

I would like it if someone could test in VO