### PR TITLE
iWeek nxCloseBtn accessibility

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxCloseButton/NxCloseButton.tsx
+++ b/lib/src/components/NxCloseButton/NxCloseButton.tsx
@@ -16,7 +16,12 @@ const NxCloseButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBut
       const btnClasses = classnames('nx-btn--close', className);
 
       return (
-        <NxButton ref={ref} type="button" className={btnClasses} variant="icon-only" { ...otherProps }>
+        <NxButton ref={ref}
+                  type="button"
+                  className={btnClasses}
+                  variant="icon-only"
+                  { ...otherProps }
+                  aria-label="Dismiss">
           <Close/>
         </NxButton>
       );

--- a/lib/src/components/NxCloseButton/NxCloseButton.tsx
+++ b/lib/src/components/NxCloseButton/NxCloseButton.tsx
@@ -20,8 +20,8 @@ const NxCloseButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBut
                   type="button"
                   className={btnClasses}
                   variant="icon-only"
-                  { ...otherProps }
-                  aria-label="Dismiss">
+                  aria-label="Dismiss"
+                  { ...otherProps }>
           <Close/>
         </NxButton>
       );

--- a/lib/src/components/NxCloseButton/NxCloseButton.tsx
+++ b/lib/src/components/NxCloseButton/NxCloseButton.tsx
@@ -20,7 +20,7 @@ const NxCloseButton = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLBut
                   type="button"
                   className={btnClasses}
                   variant="icon-only"
-                  aria-label="Dismiss"
+                  aria-label="Close"
                   { ...otherProps }>
           <Close/>
         </NxButton>


### PR DESCRIPTION
Added an `aria-label="Dismiss"` attribute. The only place we specifically use this is in NxAlert (right now). I found that if `NxAlert` was given the attribute `role="alert"` VoiceOver read the text of the alert first even when the dismiss button was focused, and then identified the button in the context of the dismiss button of the alert (which seems very clever). 