### PR TITLE
IWeek NxAlert a11y

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxAlert/NxAlertExample.tsx
+++ b/gallery/src/components/NxAlert/NxAlertExample.tsx
@@ -16,7 +16,11 @@ function NxAlertExample() {
   }
 
   return isOpen ? (
-    <NxAlert icon={faEye} id="this-id-ends-up-on-the-div" className="nx-alert--modifier" onClose={dismiss}>
+    <NxAlert icon={faEye}
+             iconLabel="Observe"
+             id="this-id-ends-up-on-the-div"
+             className="nx-alert--modifier"
+             onClose={dismiss}>
       This is an example alert message.
       It is expected that users create their own modifier classes to alter the styles of this component.
       This alert has long text content in order to demonstrate text wrapping.

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -45,6 +45,16 @@ const NxAlertPage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
+            <td className="nx-cell">iconLabel</td>
+            <td className="nx-cell">string</td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
+              Brief descriptive text to apply to the icon using
+              the <code className="nx-code">aria-label</code> attribute. Optional for backwards compatibility, but
+              strongly recommended.
+            </td>
+          </tr>
+          <tr className="nx-table-row">
             <td className="nx-cell">onClose</td>
             <td className="nx-cell">Function</td>
             <td className="nx-cell">No</td>
@@ -77,6 +87,23 @@ const NxAlertPage = () =>
         Accepts any prop that is valid on a div as well as the <code className="nx-code">onClose</code> prop
         described above.
       </p>
+      <section className="nx-tile-subsection">
+        <header className="nx-tile-subsection__header">
+          <h3 className="nx-h3">Accessibility Considerations</h3>
+        </header>
+        <p className="nx-p">
+          Different types of alerts use
+          different <a target="_blank" rel="noreferrer" href="https://www.w3.org/WAI/PF/aria/roles">ARIA roles</a>.{' '}
+          <code className="nx-code">NxErrorAlert</code> uses <code className="nx-code">alert</code>.{' '}
+          <code className="nx-code">NxSuccessAlert</code> uses <code className="nx-code">status</code>.{' '}
+          <code className="nx-code">NxInfoAlert</code> uses no special role by default, though
+          the <code className="nx-code">status</code> role may be appropriate in some use cases.{' '}
+          Finally, <code className="nx-code">NxWarningAlert</code> also has no default role, but
+          when used in dynamic circumstances, should typically be given either
+          the <code className="nx-code">status</code> or <code className="nx-code">alert</code> role.
+          The roles which are provided by default may be overridden by the caller.
+        </p>
+      </section>
     </GalleryTile>
 
     <GalleryExampleTile title="Success Alert Example"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxAlert/NxAlert.tsx
+++ b/lib/src/components/NxAlert/NxAlert.tsx
@@ -28,7 +28,7 @@ const NxAlert = forwardRef<HTMLDivElement, NxAlertProps>(
 
       return (
         <div { ...otherProps } ref={ref} className={classes} aria-atomic={true}>
-          <NxFontAwesomeIcon aria-label={iconLabel} icon={icon}/>
+          <NxFontAwesomeIcon aria-label={iconLabel} aria-hidden={!iconLabel} icon={icon}/>
           <div className="nx-alert__content">{children}</div>
           { onClose && <NxCloseButton onClick={onClose} /> }
         </div>

--- a/lib/src/components/NxAlert/NxAlert.tsx
+++ b/lib/src/components/NxAlert/NxAlert.tsx
@@ -27,7 +27,7 @@ const NxAlert = forwardRef<HTMLDivElement, NxAlertProps>(
           classes = classnames('nx-alert', className);
 
       return (
-        <div { ...otherProps } ref={ref} className={classes} aria-atomic="true">
+        <div { ...otherProps } ref={ref} className={classes} aria-atomic={true}>
           <NxFontAwesomeIcon aria-label={iconLabel} icon={icon}/>
           <div className="nx-alert__content">{children}</div>
           { onClose && <NxCloseButton onClick={onClose} /> }

--- a/lib/src/components/NxAlert/NxAlert.tsx
+++ b/lib/src/components/NxAlert/NxAlert.tsx
@@ -23,12 +23,12 @@ export { Props, propTypes, NxAlertProps, nxAlertPropTypes } from './types';
  */
 const NxAlert = forwardRef<HTMLDivElement, NxAlertProps>(
     function NxAlert(props, ref) {
-      const { className, icon, children, onClose, ...otherProps } = props,
+      const { className, icon, iconLabel, children, onClose, ...otherProps } = props,
           classes = classnames('nx-alert', className);
 
       return (
-        <div { ...otherProps } ref={ref} className={classes}>
-          <NxFontAwesomeIcon icon={icon}/>
+        <div { ...otherProps } ref={ref} className={classes} aria-atomic="true">
+          <NxFontAwesomeIcon aria-label={iconLabel} icon={icon}/>
           <div className="nx-alert__content">{children}</div>
           { onClose && <NxCloseButton onClick={onClose} /> }
         </div>
@@ -47,7 +47,12 @@ export const NxErrorAlert = forwardRef<HTMLDivElement, Props>(
     function NxErrorAlert(props, ref) {
       const classes = classnames('nx-alert--error', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faExclamationCircle} />;
+      return <NxAlert role="alert"
+                      { ...props }
+                      ref={ref}
+                      className={classes}
+                      icon={faExclamationCircle}
+                      iconLabel="Error" />;
     }
 );
 
@@ -61,7 +66,7 @@ export const NxInfoAlert = forwardRef<HTMLDivElement, Props>(
     function NxInfoAlert(props, ref) {
       const classes = classnames('nx-alert--info', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faInfoCircle} />;
+      return <NxAlert { ...props } ref={ref} className={classes} icon={faInfoCircle} iconLabel="Info" />;
     }
 );
 NxInfoAlert.propTypes = propTypes;
@@ -74,7 +79,7 @@ export const NxWarningAlert = forwardRef<HTMLDivElement, Props>(
     function NxWarningAlert(props, ref) {
       const classes = classnames('nx-alert--warning', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faExclamationTriangle} />;
+      return <NxAlert { ...props } ref={ref} className={classes} icon={faExclamationTriangle} iconLabel="Warning" />;
     }
 );
 
@@ -88,7 +93,12 @@ export const NxSuccessAlert = forwardRef<HTMLDivElement, Props>(
     function NxSuccessAlert(props, ref) {
       const classes = classnames('nx-alert--success', props.className);
 
-      return <NxAlert { ...props } ref={ref} className={classes} icon={faCheckCircle} />;
+      return <NxAlert role="status"
+                      { ...props }
+                      ref={ref}
+                      className={classes}
+                      icon={faCheckCircle}
+                      iconLabel="Success" />;
     }
 );
 

--- a/lib/src/components/NxAlert/__tests__/NxAlert.test.tsx
+++ b/lib/src/components/NxAlert/__tests__/NxAlert.test.tsx
@@ -60,11 +60,11 @@ describe('NxAlert', function() {
   });
 
   it('renders the icon passed to it', function() {
-    expect(getNxAlert())
-        .toContainReact(<NxFontAwesomeIcon icon={faBiohazard}/>);
+    expect(getNxAlert().find(NxFontAwesomeIcon)).toExist();
+    expect(getNxAlert().find(NxFontAwesomeIcon)).toHaveProp('icon', faBiohazard);
 
-    expect(getNxAlert({icon: faCrow}))
-        .toContainReact(<NxFontAwesomeIcon icon={faCrow}/>);
+    expect(getNxAlert({icon: faCrow}).find(NxFontAwesomeIcon)).toExist();
+    expect(getNxAlert({icon: faCrow}).find(NxFontAwesomeIcon)).toHaveProp('icon', faCrow);
   });
 
   it('passes any other props to the div', function() {
@@ -79,6 +79,11 @@ describe('NxAlert', function() {
 
   it('sets the icons\'s aria-label from the iconLabel prop', function() {
     expect(getNxAlert({ iconLabel: 'foo' }).find(NxFontAwesomeIcon)).toHaveProp('aria-label', 'foo');
+  });
+
+  it('sets the icons\'s aria-hidden to false if the iconLabel is defined', function() {
+    expect(getNxAlert({ iconLabel: 'foo' }).find(NxFontAwesomeIcon)).toHaveProp('aria-hidden', false);
+    expect(getNxAlert().find(NxFontAwesomeIcon)).toHaveProp('aria-hidden', true);
   });
 
   it('renders a Close button if given an onClose prop', function() {

--- a/lib/src/components/NxAlert/__tests__/NxAlert.test.tsx
+++ b/lib/src/components/NxAlert/__tests__/NxAlert.test.tsx
@@ -73,6 +73,14 @@ describe('NxAlert', function() {
     expect(component).toHaveProp('title', 'baz');
   });
 
+  it('sets aria-atomic on the div', function() {
+    expect(getNxAlert()).toHaveProp('aria-atomic', true);
+  });
+
+  it('sets the icons\'s aria-label from the iconLabel prop', function() {
+    expect(getNxAlert({ iconLabel: 'foo' }).find(NxFontAwesomeIcon)).toHaveProp('aria-label', 'foo');
+  });
+
   it('renders a Close button if given an onClose prop', function() {
     const onClose = jest.fn(),
         component = getNxAlert({ onClose });
@@ -97,6 +105,14 @@ describe('NxAlert', function() {
       it('renders an NxAlert', function() {
         const nxErrorAlert = getNxErrorAlert();
         expect(nxErrorAlert).toMatchSelector(NxAlert);
+      });
+
+      it('sets the role to "alert"', function() {
+        expect(getNxErrorAlert()).toHaveProp('role', 'alert');
+      });
+
+      it('sets the iconLabel to "Error"', function() {
+        expect(getNxErrorAlert()).toHaveProp('iconLabel', 'Error');
       });
 
       it('uses the appropriate error classes', function() {
@@ -133,6 +149,10 @@ describe('NxAlert', function() {
         expect(nxWarningAlert).toMatchSelector(NxAlert);
       });
 
+      it('sets the iconLabel to "Warning"', function() {
+        expect(getNxWarningAlert()).toHaveProp('iconLabel', 'Warning');
+      });
+
       it('renders the appropriate alert icon', function() {
         const nxWarningAlert = getNxWarningAlert();
         expect(nxWarningAlert).toMatchSelector(NxAlert);
@@ -167,6 +187,10 @@ describe('NxAlert', function() {
         expect(nxInfoAlert).toMatchSelector(NxAlert);
       });
 
+      it('sets the iconLabel to "Info"', function() {
+        expect(getNxInfoAlert()).toHaveProp('iconLabel', 'Info');
+      });
+
       it('renders the appropriate info classes', function() {
         const nxInfoAlert = getNxInfoAlert();
         expect(nxInfoAlert).toMatchSelector(NxAlert);
@@ -199,6 +223,14 @@ describe('NxAlert', function() {
       it('renders an NxAlert', function() {
         const nxSuccessAlert = getNxSuccessAlert();
         expect(nxSuccessAlert).toMatchSelector(NxAlert);
+      });
+
+      it('sets the role to "status"', function() {
+        expect(getNxSuccessAlert()).toHaveProp('role', 'status');
+      });
+
+      it('sets the iconLabel to "Success"', function() {
+        expect(getNxSuccessAlert()).toHaveProp('iconLabel', 'Success');
       });
 
       it('renders the appropriate info classes', function() {

--- a/lib/src/components/NxAlert/types.ts
+++ b/lib/src/components/NxAlert/types.ts
@@ -21,9 +21,11 @@ export const propTypes = {
 
 export type NxAlertProps = Props & {
   icon: IconDefinition;
+  iconLabel? : string | null;
 };
 
 export const nxAlertPropTypes: PropTypes.ValidationMap<NxAlertProps> = {
   icon: PropTypes.any,
+  iconLabel: PropTypes.string,
   onClose: PropTypes.func
 };


### PR DESCRIPTION
https://trello.com/c/1P0pfFRg/22-nxalert

Allows NxAlert users to specify the role and a label on the icon.  Provides default values for that role and label for the various NxAlert specializations.

Note: in ChromeVox, these changes made almost no difference.  I'd want someone with VoiceOver to check them as well.