### PR TITLE
NxDropdown accessibility improvements

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxDropdown/NxDropdownNavigationExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownNavigationExample.tsx
@@ -25,16 +25,16 @@ function NxDropdownNavigationExample() {
         Text link 3
       </a>
       <button onClick={onClick} className="nx-dropdown-button">
-        Nav Link4 - this link should trigger truncation
+        Button Link 4 - this link should trigger truncation
       </button>
       <button onClick={onClick} className="nx-dropdown-button">
-        Nav Link5
+        Button Link 5
       </button>
       <button onClick={onClick} className="nx-dropdown-button">
-        Nav Link6
+        Button Link 6
       </button>
       <button className="disabled nx-dropdown-button">
-        Nav Link7 Disabled
+        Button Link 7 Disabled
       </button>
     </NxDropdown>
   );

--- a/gallery/src/components/NxDropdown/NxDropdownNavigationExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownNavigationExample.tsx
@@ -15,14 +15,14 @@ function NxDropdownNavigationExample() {
 
   return (
     <NxDropdown label="Navigation" isOpen={isOpen} onToggleCollapse={onToggleCollapse}>
-      <a onClick={onClick} className="nx-dropdown-button">
-        Nav Link1
+      <a onClick={onClick} href="#/pages/NxDropdown" className="nx-dropdown-button">
+        Text link 1
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
-        Nav Link2
+      <a onClick={onClick} href="#/pages/NxDropdown" className="nx-dropdown-button">
+        Text link 2
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
-        Nav Link3
+      <a onClick={onClick} href="#/pages/NxDropdown" className="nx-dropdown-button">
+        Text link 3
       </a>
       <button onClick={onClick} className="nx-dropdown-button">
         Nav Link4 - this link should trigger truncation

--- a/gallery/src/components/NxDropdown/NxDropdownRightButtonsExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownRightButtonsExample.tsx
@@ -17,19 +17,19 @@ function NxDropdownRightButtonsExample() {
   return (
     <NxDropdown label="Navigation" isOpen={isOpen} onToggleCollapse={onToggleCollapse}>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        <span className="nx-dropdown-button-content">Nav Link1</span>
+        <span className="nx-dropdown-button-content">Text Link1</span>
       </a>
       <NxButton onClick={() => alert('icon click')} className="nx-dropdown-right-button" variant="icon-only">
         <NxFontAwesomeIcon icon={faTrash}/>
       </NxButton>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        <span className="nx-dropdown-button-content">Nav Link2</span>
+        <span className="nx-dropdown-button-content">Button Link2</span>
       </a>
       <NxButton onClick={() => alert('icon click')} className="nx-dropdown-right-button" variant="icon-only">
         <NxFontAwesomeIcon icon={faTrash}/>
       </NxButton>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        <span className="nx-dropdown-button-content">Nav Link3 - this link should trigger truncation</span>
+        <span className="nx-dropdown-button-content">Text Link3 - this link should trigger truncation</span>
       </a>
     </NxDropdown>
   );

--- a/gallery/src/components/NxDropdown/NxDropdownScrollingExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownScrollingExample.tsx
@@ -18,43 +18,43 @@ function NxDropdownNavigationExample() {
                 isOpen={isOpen}
                 onToggleCollapse={onToggleCollapse}>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link1
+        Text Link 1
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link2
+        Text Link 2
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link3
+        Text Link 3
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link4
+        Text Link 4
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link5
+        Text Link 5
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link6
+        Text Link 6
       </a>
       <a href="#" className="disabled nx-dropdown-button">
-        Nav Link7 Disabled
+        Text Link 7 Disabled
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link8
+        Text Link 8
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link9
+        Text Link 9
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link10
+        Text Link 10
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link11
+        Text Link 11
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link12
+        Text Link 12
       </a>
       <a href="#" onClick={onClick} className="nx-dropdown-button">
-        Nav Link13
+        Text Link 13
       </a>
     </NxDropdown>
   );

--- a/gallery/src/components/NxDropdown/NxDropdownScrollingExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownScrollingExample.tsx
@@ -17,43 +17,43 @@ function NxDropdownNavigationExample() {
     <NxDropdown label="Scrolling - this label also triggers truncation"
                 isOpen={isOpen}
                 onToggleCollapse={onToggleCollapse}>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link1
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link2
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link3
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link4
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link5
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link6
       </a>
-      <a className="disabled nx-dropdown-button">
+      <a href="#" className="disabled nx-dropdown-button">
         Nav Link7 Disabled
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link8
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link9
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link10
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link11
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link12
       </a>
-      <a onClick={onClick} className="nx-dropdown-button">
+      <a href="#" onClick={onClick} className="nx-dropdown-button">
         Nav Link13
       </a>
     </NxDropdown>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxDropdown/NxDropdown.tsx
+++ b/lib/src/components/NxDropdown/NxDropdown.tsx
@@ -40,7 +40,7 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
               className={buttonClasses}
               onClick={!disabled && onToggleCollapse || undefined}
               aria-haspopup="true"
-              aria-expanded={isOpen ? true : false}>
+              aria-expanded={isOpen}>
       <span className="nx-dropdown__toggle-label">{ label }</span>
       <NxFontAwesomeIcon icon={isOpen ? faCaretUp : faCaretDown}/>
     </NxButton>

--- a/lib/src/components/NxDropdown/NxDropdown.tsx
+++ b/lib/src/components/NxDropdown/NxDropdown.tsx
@@ -40,7 +40,6 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
               className={buttonClasses}
               onClick={!disabled && onToggleCollapse || undefined}
               aria-haspopup="true"
-              aria-pressed={isOpen ? true : false}
               aria-expanded={isOpen ? true : false}>
       <span className="nx-dropdown__toggle-label">{ label }</span>
       <NxFontAwesomeIcon icon={isOpen ? faCaretUp : faCaretDown}/>

--- a/lib/src/components/NxDropdown/NxDropdown.tsx
+++ b/lib/src/components/NxDropdown/NxDropdown.tsx
@@ -38,7 +38,10 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
     <NxButton type="button"
               variant={variant || 'tertiary'}
               className={buttonClasses}
-              onClick={!disabled && onToggleCollapse || undefined}>
+              onClick={!disabled && onToggleCollapse || undefined}
+              aria-haspopup="true"
+              aria-pressed={isOpen ? true : false}
+              aria-expanded={isOpen ? true : false}>
       <span className="nx-dropdown__toggle-label">{ label }</span>
       <NxFontAwesomeIcon icon={isOpen ? faCaretUp : faCaretDown}/>
     </NxButton>


### PR DESCRIPTION
Added attributes for `aria-haspopup`, `aria-pressed`, and `aria-expanded`

Fixed examples with anchor tags so that they have dummy `href`'s and will be recognized by screen readers.