### PR TITLE
i-week nx-alert examples for a11y

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxAlert/NxAlertErrorExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertErrorExample.tsx
@@ -10,7 +10,7 @@ import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertErrorExample = () =>
   <div className="nx-alert nx-alert--error" role="alert" aria-atomic={true}>
-    <NxFontAwesomeIcon icon={faExclamationCircle} aria-label="error" />
+    <NxFontAwesomeIcon icon={faExclamationCircle} aria-label="error" aria-hidden={false} />
     <span><strong>Error!</strong> I am an error alert! There is an error!</span>
     <NxCloseButton />
   </div>;

--- a/gallery/src/styles/NxAlert/NxAlertErrorExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertErrorExample.tsx
@@ -9,7 +9,7 @@ import { NxFontAwesomeIcon, NxCloseButton } from '@sonatype/react-shared-compone
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertErrorExample = () =>
-  <div className="nx-alert nx-alert--error" role="alert" aria-atomic={true}>
+  <div className="nx-alert nx-alert--error" role="alert">
     <NxFontAwesomeIcon icon={faExclamationCircle} aria-label="error" aria-hidden={false} />
     <span><strong>Error!</strong> I am an error alert! There is an error!</span>
     <NxCloseButton />

--- a/gallery/src/styles/NxAlert/NxAlertErrorExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertErrorExample.tsx
@@ -9,8 +9,8 @@ import { NxFontAwesomeIcon, NxCloseButton } from '@sonatype/react-shared-compone
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertErrorExample = () =>
-  <div className="nx-alert nx-alert--error">
-    <NxFontAwesomeIcon icon={faExclamationCircle}/>
+  <div className="nx-alert nx-alert--error" role="alert" aria-atomic={true}>
+    <NxFontAwesomeIcon icon={faExclamationCircle} aria-label="error" />
     <span><strong>Error!</strong> I am an error alert! There is an error!</span>
     <NxCloseButton />
   </div>;

--- a/gallery/src/styles/NxAlert/NxAlertInfoExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertInfoExample.tsx
@@ -9,8 +9,8 @@ import { NxFontAwesomeIcon, NxCloseButton } from '@sonatype/react-shared-compone
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertInfoExample = () =>
-  <div className="nx-alert nx-alert--info">
-    <NxFontAwesomeIcon icon={faInfoCircle}/>
+  <div className="nx-alert nx-alert--info" aria-atomic={true}>
+    <NxFontAwesomeIcon aria-label="information" aria-hidden={false} icon={faInfoCircle}/>
     <span>Information! I am an informational alert! Be informed!</span>
     <NxCloseButton />
   </div>;

--- a/gallery/src/styles/NxAlert/NxAlertInfoExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertInfoExample.tsx
@@ -10,7 +10,7 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertInfoExample = () =>
   <div className="nx-alert nx-alert--info" aria-atomic={true}>
-    <NxFontAwesomeIcon aria-label="information" aria-hidden={false} icon={faInfoCircle}/>
+    <NxFontAwesomeIcon icon={faInfoCircle} aria-label="information" aria-hidden={false} />
     <span>Information! I am an informational alert! Be informed!</span>
     <NxCloseButton />
   </div>;

--- a/gallery/src/styles/NxAlert/NxAlertSuccessExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertSuccessExample.tsx
@@ -9,7 +9,7 @@ import { NxFontAwesomeIcon, NxCloseButton } from '@sonatype/react-shared-compone
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertErrorExample = () =>
-  <div className="nx-alert nx-alert--success" role="status" aria-atomic={true}>
+  <div className="nx-alert nx-alert--success" role="status">
     <NxFontAwesomeIcon icon={faCheckCircle} aria-label="success" aria-hidden={false} />
     <span><strong>Success!</strong> This was a triumph! A great success!</span>
     <NxCloseButton />

--- a/gallery/src/styles/NxAlert/NxAlertSuccessExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertSuccessExample.tsx
@@ -9,8 +9,8 @@ import { NxFontAwesomeIcon, NxCloseButton } from '@sonatype/react-shared-compone
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertErrorExample = () =>
-  <div className="nx-alert nx-alert--success">
-    <NxFontAwesomeIcon icon={faCheckCircle}/>
+  <div className="nx-alert nx-alert--success" role="status" aria-atomic={true}>
+    <NxFontAwesomeIcon icon={faCheckCircle}/ aria-label="success">
     <span><strong>Success!</strong> This was a triumph! A great success!</span>
     <NxCloseButton />
   </div>;

--- a/gallery/src/styles/NxAlert/NxAlertSuccessExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertSuccessExample.tsx
@@ -10,7 +10,7 @@ import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertErrorExample = () =>
   <div className="nx-alert nx-alert--success" role="status" aria-atomic={true}>
-    <NxFontAwesomeIcon icon={faCheckCircle}/ aria-label="success">
+    <NxFontAwesomeIcon icon={faCheckCircle} aria-label="success" aria-hidden={false} />
     <span><strong>Success!</strong> This was a triumph! A great success!</span>
     <NxCloseButton />
   </div>;

--- a/gallery/src/styles/NxAlert/NxAlertWarningExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertWarningExample.tsx
@@ -10,7 +10,7 @@ import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertWarningExample = () =>
   <div className="nx-alert nx-alert--warning" aria-atomic={true}>
-    <NxFontAwesomeIcon icon={faExclamationTriangle} aria-label="warning" />
+    <NxFontAwesomeIcon icon={faExclamationTriangle} aria-label="warning" aria-hidden={false} />
     <span><strong>Alert!</strong> I am an alert! Be alerted!</span>
     <NxCloseButton />
   </div>;

--- a/gallery/src/styles/NxAlert/NxAlertWarningExample.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertWarningExample.tsx
@@ -9,8 +9,8 @@ import { NxFontAwesomeIcon, NxCloseButton } from '@sonatype/react-shared-compone
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 
 const NxAlertWarningExample = () =>
-  <div className="nx-alert nx-alert--warning">
-    <NxFontAwesomeIcon icon={faExclamationTriangle}/>
+  <div className="nx-alert nx-alert--warning" aria-atomic={true}>
+    <NxFontAwesomeIcon icon={faExclamationTriangle} aria-label="warning" />
     <span><strong>Alert!</strong> I am an alert! Be alerted!</span>
     <NxCloseButton />
   </div>;

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
match the style examples to what the NxAlert component will do for a11y: roles and aria props.

build: https://jenkins.ci.sonatype.dev/job/uxui/job/sonatype-react-shared-components/job/iweek-nx-alert-a11y/