### PR TITLE
Fix weird activation behavior in NxTreeViewRadioSelect example - RSC-399

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.9.16",
+  "version": "2.9.17",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectDisabledExample.tsx
+++ b/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectDisabledExample.tsx
@@ -28,7 +28,7 @@ const NxTreeViewRadioSelectDisabledExample = () => {
     <NxTreeViewRadioSelect isOpen={true}
                            disabled={true}
                            disabledTooltip="Disabled Tooltip example"
-                           name="travel"
+                           name="travel-disabled"
                            selectedId={selection}
                            onChange={onSelectionChange}
                            options={options}>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.9.16",
+  "version": "2.9.17",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-399

This turned out to be an issue with the example itself: the page had two different radio groups that used the same `name`, neither encapsulated within a form. These appear to have caused a strange interaction. That one of the radio groups was disabled may have been a factor.  The solution is to simply avoid the duplicated name.