### PR TITLE
Add buttons to page title RSC-400

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.13.4",
+  "version": "2.14.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxPageTitle/NxPageTitleActionsExample.html
+++ b/gallery/src/styles/NxPageTitle/NxPageTitleActionsExample.html
@@ -14,8 +14,8 @@
     Page Title
   </h1>
   <div class="nx-btn-bar">
-    <button class="nx-btn">First</button>
-    <button class="nx-btn">Second</button>
+    <button class="nx-btn nx-btn--tertiary">First</button>
+    <button class="nx-btn nx-btn--tertiary">Second</button>
   </div>
   <div class="nx-page-title__description">
     <p class="nx-p">

--- a/gallery/src/styles/NxPageTitle/NxPageTitleActionsExample.html
+++ b/gallery/src/styles/NxPageTitle/NxPageTitleActionsExample.html
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2019-present Sonatype, Inc.
+    This program and the accompanying materials are made available under
+    the terms of the Eclipse Public License 2.0 which accompanies this
+    distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+
+-->
+<div class="nx-page-title nx-page-title__actions">
+  <h1 class="nx-h1">
+    <svg class="nx-icon nx-page-title__page-icon" style="height: 1em; width: 1em;" viewBox="-1 -1 2 2">
+      <circle r="1" />
+    </svg>
+    Page Title
+  </h1>
+  <div class="nx-btn-bar">
+    <button class="nx-btn">First</button>
+    <button class="nx-btn">Second</button>
+  </div>
+  <div class="nx-page-title__description">
+    <p class="nx-p">
+      Tokyo alcohol marketing girl vehicle jeans sign papier-mache assassin San Francisco rifle physical 3D-printed
+      denim tanto courier concrete dolphin rebar free-market. tank-traps papier-mache dead free-market tanto drone
+      concrete dolphin sunglasses weathered dead jeans office vehicle nodal point. motion film meta- monofilament knife
+      vinyl post- bridge jeans city
+    </p>
+  </div>
+</div>

--- a/gallery/src/styles/NxPageTitle/NxPageTitleActionsExample.html
+++ b/gallery/src/styles/NxPageTitle/NxPageTitleActionsExample.html
@@ -11,7 +11,7 @@
     <svg class="nx-icon nx-page-title__page-icon" style="height: 1em; width: 1em;" viewBox="-1 -1 2 2">
       <circle r="1" />
     </svg>
-    Page Title
+    Long page title text that will cause ellipsis truncation to occur
   </h1>
   <div class="nx-btn-bar">
     <button class="nx-btn nx-btn--tertiary">First</button>

--- a/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
+++ b/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
@@ -11,6 +11,7 @@ import CodeExample from '../../CodeExample';
 import RawHtmlExample from '../../RawHtmlExample';
 
 const nxPageTitleCode = require('!!raw-loader!./NxPageTitleExample.html').default;
+const nxPageTitleActionsCode = require('!!raw-loader!./NxPageTitleActionsExample.html').default;
 
 const NxPageTitlePage = () =>
   <>
@@ -61,6 +62,9 @@ const NxPageTitlePage = () =>
 
     <RawHtmlExample html={nxPageTitleCode} />
     <CodeExample content={nxPageTitleCode} />
+
+    <RawHtmlExample html={nxPageTitleActionsCode} />
+    <CodeExample content={nxPageTitleActionsCode} />
   </>;
 
 export default NxPageTitlePage;

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.13.4",
+  "version": "2.14.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -7,46 +7,30 @@
 .nx-page-title {
   @include container-horizontal;
   @include container-vertical;
-  margin: 0 0 16px 0;
+  display: grid;
+  grid-template-areas:
+    "title actions"
+    "description description";
+  margin: 0 0 $nx-spacing-md 0;
 
   .nx-h1 {
-    display: inline-block;
+    grid-area: title;
     margin: 0;
     overflow: hidden;
     text-overflow: ellipsis;
-    vertical-align: middle;
     white-space: nowrap;
     max-width: $nx-paragraph-width-maximum;
   }
-}
 
-.nx-page-title__page-icon {
-  display: inline-block;
-  vertical-align: middle;
+  .nx-btn-bar {
+    grid-area: actions;
+    margin: 0;
+  }
 }
 
 .nx-page-title__description {
   @include container-vertical;
-  margin: 8px 0 0 0;
+  grid-area: description;
+  margin: $nx-spacing-xs 0 0 0;
   max-width: $nx-paragraph-width-maximum;
-}
-
-.nx-page-title__actions {
-  display: grid;
-  grid-template-areas: 
-    "title buttons"
-    "description description";
-
-  .nx-h1 {
-    grid-area: title;
-  }
-
-  .nx-btn-bar {
-    grid-area: buttons;
-    margin: 0;
-  }
-
-  .nx-page-title__description {
-    grid-area: description;
-  }
 }

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -30,3 +30,23 @@
   margin: 8px 0 0 0;
   max-width: $nx-paragraph-width-maximum;
 }
+
+.nx-page-title__actions {
+  display: grid;
+  grid-template-areas: 
+    "title buttons"
+    "description description";
+
+  .nx-h1 {
+    grid-area: title;
+  }
+
+  .nx-btn-bar {
+    grid-area: buttons;
+    margin: 0;
+  }
+
+  .nx-page-title__description {
+    grid-area: description;
+  }
+}

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -33,5 +33,4 @@
   @include container-vertical;
   grid-area: description;
   margin: $nx-spacing-xs 0 0 0;
-  max-width: $nx-paragraph-width-maximum;
 }

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -8,6 +8,7 @@
   @include container-horizontal;
   @include container-vertical;
   display: grid;
+  grid-template-columns: 1fr auto;
   grid-template-areas:
     "title actions"
     "description description";

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -7,6 +7,7 @@
 .nx-page-title {
   @include container-horizontal;
   @include container-vertical;
+  align-items: center;
   display: grid;
   grid-template-columns: 1fr auto;
   grid-template-areas:
@@ -20,12 +21,11 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: $nx-paragraph-width-maximum;
   }
 
   .nx-btn-bar {
     grid-area: actions;
-    margin: 0;
+    margin: 0 0 0 $nx-spacing-l;
   }
 }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-400

The purpose of this ticket was to add support for displaying buttons inside the page title. I used our standard `nx-btn-bar` container and a custom class on the page title, this allowed me to use CSS grid for positioning.