### PR TITLE
Add newline escapes to SVG url - RSC-403

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-form-select.scss
+++ b/lib/src/base-styles/_nx-form-select.scss
@@ -11,8 +11,8 @@
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background: #fff url("data:image/svg+xml;utf8,
-    <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%232c2c2c'>
+  background: #fff url("data:image/svg+xml;utf8, \
+    <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%232c2c2c'> \
     <polygon points='0,0 100,0 50,50'/></svg>") no-repeat;
   background-size: 12px;
   background-position: calc(100% - 16px) 16px;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-403

Should "fix" https://github.com/sonatype/insight-brain/pull/5830#discussion_r533485752 (quotes around "fix" to disable GH's auto-close feature)