### PR TITLE
Prevent horizontal scrollbar at min width - RSC-392

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -74,6 +74,10 @@
     overflow: visible;
   }
 
+  .nx-page {
+    min-width: $nx-page-width-min - $nx-scrollbar-width;
+  }
+
   .nx-page-header {
     position: fixed;
     top: 0;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-392

Note that the issue only affected full-page-scrolling mode, and so the fix is constrained to that mode as well.