### PR TITLE
Increase page-title bottom spacing to 24px RSC-407

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -13,7 +13,7 @@
   grid-template-areas:
     "title tags actions"
     "description description description";
-  margin: 0 0 $nx-spacing-md 0;
+  margin: 0 0 $nx-spacing-l 0;
 
   .nx-h1 {
     grid-area: title;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-407

`.nx-page-title` bottom spacing was set at `16px`, but designs alls for `24px`. I updated the variable for margin bottom.