### PR TITLE
implement teal colour palette RSC-362

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-btn.scss
+++ b/lib/src/base-styles/_nx-btn.scss
@@ -38,7 +38,7 @@
   }
 
   &:focus {
-    border: 1px solid #02a6d9;
+    border: 1px solid $nx-focus-border-color;
     box-shadow: $nx-focus-box-shadow;
     outline: 0;
   }

--- a/lib/src/base-styles/_nx-form-select.scss
+++ b/lib/src/base-styles/_nx-form-select.scss
@@ -31,7 +31,7 @@
 
   &:focus {
     box-shadow: $nx-focus-box-shadow;
-    border-color: #02a6d9;
+    border-color: $nx-focus-border-color;
     outline: none;
   }
 

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -178,7 +178,7 @@
 
     &:focus {
       box-shadow: $nx-focus-box-shadow;
-      border-color: #02a6d9;
+      border-color: $nx-focus-border-color;
       outline: none;
     }
 

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -39,7 +39,7 @@
     .nx-radio-checkbox__control {
       border-color: $nx-focus-border-color;
       stroke: $nx-focus-border-color;
-      filter: drop-shadow(0 0 3px rgba(2, 166, 217, 0.4));
+      filter: drop-shadow(0 0 3px rgba($nx-focus-border-color, 0.4));
     }
 
     &:hover {

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -37,8 +37,8 @@
 
   &:focus-within {
     .nx-radio-checkbox__control {
-      border-color: #02a6d9;
-      stroke: #02a6d9;
+      border-color: $nx-focus-border-color;
+      stroke: $nx-focus-border-color;
       filter: drop-shadow(0 0 3px rgba(2, 166, 217, 0.4));
     }
 
@@ -113,7 +113,7 @@ svg.nx-radio-checkbox__control {
   &:focus {
     // less-nice IE11 focus style because IE11 doesn't support :focus-within
     margin-right: $nx-spacing-xxs;
-    outline: 1px solid #02a6d9;
+    outline: 1px solid $nx-focus-border-color;
     opacity: 1;
     position: static;
     vertical-align: 5px;

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -86,7 +86,7 @@
         outline: none;
 
         > .nx-cell {
-          border-color: #02a6d9;
+          border-color: $nx-focus-border-color;
         }
       }
     }

--- a/lib/src/components/NxAccordion/NxAccordion.scss
+++ b/lib/src/components/NxAccordion/NxAccordion.scss
@@ -31,7 +31,7 @@
   padding: $nx-spacing-md $nx-spacing-l;
 
   &:focus {
-    outline: 1px solid #02a6d9;
+    outline: 1px solid $nx-focus-border-color;
     outline-offset: -1px;
     box-shadow: $nx-focus-box-shadow;
   }

--- a/lib/src/components/NxNexusPageHeader/NxNexusPageHeader.scss
+++ b/lib/src/components/NxNexusPageHeader/NxNexusPageHeader.scss
@@ -95,7 +95,7 @@
     padding-bottom: $nx-spacing-xs;
 
     &:active, &.nx-page-header__link--current {
-      border-bottom-color: #00a1e2;
+      border-bottom-color:$nx-teal-400;
     }
   }
 

--- a/lib/src/components/NxTabs/NxTabs.scss
+++ b/lib/src/components/NxTabs/NxTabs.scss
@@ -57,7 +57,7 @@
     border-bottom-width: 1px;
     box-shadow: $nx-focus-box-shadow;
     margin-bottom: 0;
-    outline: solid 1px #02a6d9;
+    outline: solid 1px $nx-focus-border-color;
   }
 
   // a hidden copy of the text, always at semi-bold weight, to enfore consistent element width

--- a/lib/src/components/NxTreeView/NxTreeView.scss
+++ b/lib/src/components/NxTreeView/NxTreeView.scss
@@ -78,8 +78,8 @@ $twisty-proportion-difference: 2px;
     outline: none;
 
     .nx-tree-view__twisty {
-      filter: drop-shadow(0 0 3px transparentize(#02a6d9, 0.7));
-      stroke: #02a6d9;
+      filter: drop-shadow(0 0 3px transparentize($nx-focus-border-color, 0.7));
+      stroke: $nx-focus-border-color;
 
       // This is intepreted in the SVG's coordinate space. The svg has a viewbox height of 512 and an on-page
       // height of 22px so this computes to 1 on-page pixel
@@ -165,7 +165,7 @@ button, a {
     }
 
     &:focus {
-      border-color: #02a6d9;
+      border-color: $nx-focus-border-color;
       box-shadow: $nx-focus-box-shadow;
       outline: none;
     }

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -31,3 +31,16 @@ $nx-grey-300: #c7c7c7;
 $nx-grey-200: #e9e9e9;
 $nx-grey-100: #f1f3fa;
 $nx-grey-50: #f4f5f9;
+
+// Teals
+$nx-teal-1000: #005375;
+$nx-teal-900: #00658e;
+$nx-teal-800: #0074a4;
+$nx-teal-700: #0080b5;
+$nx-teal-600: #028bc3;
+$nx-teal-500: #0096d3;
+$nx-teal-400: #00a1e2;
+$nx-teal-300: #02a6d9;
+$nx-teal-200: #00ade2;
+$nx-teal-100: #07baf1;
+$nx-teal-50: #38d0ff;

--- a/lib/src/scss-shared/_nx-colors.scss
+++ b/lib/src/scss-shared/_nx-colors.scss
@@ -17,7 +17,7 @@ $nx-sonatype-orange: #f89100;
 // Tints based on HSL lightness value
 $nx-color-blue-41: #3A4D95;
 $nx-color-blue-42: #2B66AB;
-$nx-color-blue-44: #00A1E2;
+$nx-color-blue-44:$nx-teal-400;
 $nx-color-blue-96: #f2f3f8;
 
 // Shades of Grey

--- a/lib/src/scss-shared/_nx-colors.scss
+++ b/lib/src/scss-shared/_nx-colors.scss
@@ -91,6 +91,7 @@ $nx-active-background: $nx-blue-200;
 $nx-hover-background: $nx-grey-100;
 $nx-disabled-background: $nx-grey-200;
 $nx-disabled-border: $nx-grey-500;
+$nx-focus-border-color: $nx-teal-300;
 
 //  Borders
 $nx-border-darker: 1px solid $nx-slate;

--- a/lib/src/scss-shared/_nx-variables.scss
+++ b/lib/src/scss-shared/_nx-variables.scss
@@ -59,7 +59,7 @@ $nx-form-element-width-wide: 624px;
 $nx-submit-mask-z-index: 10;
 $nx-modal-backdrop-z-index: 1050;
 
-$nx-focus-box-shadow: 0 0 3px 1px transparentize(#02a6d9, 0.7);
+$nx-focus-box-shadow: 0 0 3px 1px transparentize($nx-focus-border-color, 0.7);
 
 $nx-table-cell-header-height: 48px;
 $nx-table-cell-vertical-padding: $nx-spacing-sm;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-362

The main colour used in these swatches was the teal for the focus borders. I created a variable for that, otherwise there were very few of these colours used in the code.