### PR TITLE
Improve NxTreeView examples - RSC-146

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxTreeView/NxTreeViewCheckboxExample.tsx
+++ b/gallery/src/components/NxTreeView/NxTreeViewCheckboxExample.tsx
@@ -9,13 +9,15 @@ import React, { useState } from 'react';
 import { NxTreeView, NxCheckbox, NxRadio, NxTreeViewChild } from '@sonatype/react-shared-components';
 
 export default function NxTreeViewCheckboxExample() {
-  const [isOpen, setOpen] = useState(false),
-      onToggleCollapse = () => setOpen(!isOpen);
+  const [is1Open, set1Open] = useState(false),
+      [is2Open, set2Open] = useState(false),
+      onToggle1Collapse = () => set1Open(!is1Open),
+      onToggle2Collapse = () => set2Open(!is2Open);
 
   return (
     <>
-      <NxTreeView isOpen={isOpen}
-                  onToggleCollapse={onToggleCollapse}
+      <NxTreeView isOpen={is1Open}
+                  onToggleCollapse={onToggle1Collapse}
                   triggerContent="Organization">
         <NxTreeViewChild>
           <NxCheckbox isChecked={true}>
@@ -29,8 +31,8 @@ export default function NxTreeViewCheckboxExample() {
           <NxCheckbox isChecked={true}>Baz</NxCheckbox>
         </NxTreeViewChild>
       </NxTreeView>
-      <NxTreeView isOpen={isOpen}
-                  onToggleCollapse={onToggleCollapse}
+      <NxTreeView isOpen={is2Open}
+                  onToggleCollapse={onToggle2Collapse}
                   triggerContent="Organization">
         <NxTreeViewChild>
           <NxRadio name="test-radio" value="foo" isChecked={false}>Foo</NxRadio>

--- a/gallery/src/components/NxTreeView/NxTreeViewTooltipExample.tsx
+++ b/gallery/src/components/NxTreeView/NxTreeViewTooltipExample.tsx
@@ -11,8 +11,10 @@ import { NxTreeView, NxTreeViewChild, TooltipConfigProps } from '@sonatype/react
 function NxTreeViewTooltipExample() {
   // this example uses the `useState` hook for succinctness, but you could also manage the state manually
   // in a class component
-  const [toggleCheck, setToggleCheck] = useState(false),
-      onToggleCollapse = () => setToggleCheck(!toggleCheck),
+  const [toggle1Check, setToggle1Check] = useState(false),
+      [toggle2Check, setToggle2Check] = useState(false),
+      onToggle1Collapse = () => setToggle1Check(!toggle1Check),
+      onToggle2Collapse = () => setToggle2Check(!toggle2Check),
       complexTooltipConfig: TooltipConfigProps = {
         placement: 'left',
         title: <em>Complicated</em>
@@ -20,8 +22,8 @@ function NxTreeViewTooltipExample() {
 
   return (
     <>
-      <NxTreeView onToggleCollapse={onToggleCollapse}
-                  isOpen={toggleCheck}
+      <NxTreeView onToggleCollapse={onToggle1Collapse}
+                  isOpen={toggle1Check}
                   triggerTooltip="Tooltip!"
                   triggerContent="Tooltip configured by string">
         <NxTreeViewChild>Test1</NxTreeViewChild>
@@ -29,8 +31,8 @@ function NxTreeViewTooltipExample() {
         <NxTreeViewChild>Test3</NxTreeViewChild>
         <NxTreeViewChild>Test4</NxTreeViewChild>
       </NxTreeView>
-      <NxTreeView onToggleCollapse={onToggleCollapse}
-                  isOpen={toggleCheck}
+      <NxTreeView onToggleCollapse={onToggle2Collapse}
+                  isOpen={toggle2Check}
                   triggerTooltip={complexTooltipConfig}
                   triggerContent="Complex tooltip configuration">
         <NxTreeViewChild>Test1</NxTreeViewChild>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
 As pointed out by @glenhunter while testing https://issues.sonatype.org/browse/RSC-146, the tree view examples really should all go through the trouble of having the trees independently open and close.