### PR TITLE
Improve nx-btn accessibility RSC-398

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxButton/NxButtonIconExample.tsx
+++ b/gallery/src/components/NxButton/NxButtonIconExample.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { faSync, faSave, faEdit } from '@fortawesome/free-solid-svg-icons';
+import { faSync, faSave, faEdit, faSmile } from '@fortawesome/free-solid-svg-icons';
 
 import { NxButton, NxFontAwesomeIcon, NxTooltip } from '@sonatype/react-shared-components';
 
@@ -17,11 +17,15 @@ const NxButtonIconExample = () =>
     </NxButton>
 
     <NxTooltip title="Save">
-      <NxButton><NxFontAwesomeIcon icon={faSave} aria-label="save" /></NxButton>
+      <NxButton><NxFontAwesomeIcon icon={faSave} /></NxButton>
     </NxTooltip>
 
     <NxTooltip title="Edit">
-      <NxButton variant="tertiary"><NxFontAwesomeIcon icon={faEdit} aria-label="edit" /></NxButton>
+      <NxButton variant="tertiary"><NxFontAwesomeIcon icon={faEdit} /></NxButton>
+    </NxTooltip>
+
+    <NxTooltip title="Smile">
+      <NxButton variant="primary"><NxFontAwesomeIcon icon={faSmile} /></NxButton>
     </NxTooltip>
   </div>;
 

--- a/gallery/src/components/NxButton/NxButtonIconExample.tsx
+++ b/gallery/src/components/NxButton/NxButtonIconExample.tsx
@@ -5,16 +5,24 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import {faSync} from '@fortawesome/free-solid-svg-icons';
+import { faSync, faSave, faEdit } from '@fortawesome/free-solid-svg-icons';
 
-import { NxButton, NxFontAwesomeIcon } from '@sonatype/react-shared-components';
+import { NxButton, NxFontAwesomeIcon, NxTooltip } from '@sonatype/react-shared-components';
 
 const NxButtonIconExample = () =>
   <div className="nx-btn-bar">
-    <NxButton>
+    <NxButton aria-label="sync">
       <NxFontAwesomeIcon icon={faSync}/>
       <span>Icons in buttons</span>
     </NxButton>
+
+    <NxTooltip title="Save">
+      <NxButton><NxFontAwesomeIcon icon={faSave} aria-label="save" /></NxButton>
+    </NxTooltip>
+
+    <NxTooltip title="Edit">
+      <NxButton variant="tertiary"><NxFontAwesomeIcon icon={faEdit} aria-label="edit" /></NxButton>
+    </NxTooltip>
   </div>;
 
 export default NxButtonIconExample;

--- a/gallery/src/components/NxButton/NxButtonIconOnlyExample.tsx
+++ b/gallery/src/components/NxButton/NxButtonIconOnlyExample.tsx
@@ -7,15 +7,21 @@
 import React from 'react';
 import {faExclamationTriangle, faEdit, faSave} from '@fortawesome/free-solid-svg-icons';
 
-import { NxButton, NxFontAwesomeIcon } from '@sonatype/react-shared-components';
+import { NxButton, NxFontAwesomeIcon, NxTooltip } from '@sonatype/react-shared-components';
 
 const NxButtonIconOnlyExample = () =>
   <div className="nx-btn-bar">
-    <NxButton variant="icon-only" aria-label="alert">
-      <NxFontAwesomeIcon icon={faExclamationTriangle}/>
-    </NxButton>
-    <NxButton variant="icon-only" aria-label="edit"><NxFontAwesomeIcon icon={faEdit}/></NxButton>
-    <NxButton variant="icon-only" aria-label="save"><NxFontAwesomeIcon icon={faSave}/></NxButton>
+    <NxTooltip title="Alert">
+      <NxButton variant="icon-only" aria-label="alert">
+        <NxFontAwesomeIcon icon={faExclamationTriangle}/>
+      </NxButton>
+    </NxTooltip>
+    <NxTooltip title="Edit">
+      <NxButton variant="icon-only" aria-label="edit"><NxFontAwesomeIcon icon={faEdit}/></NxButton>
+    </NxTooltip>
+    <NxTooltip title="Save">
+      <NxButton variant="icon-only" aria-label="save"><NxFontAwesomeIcon icon={faSave}/></NxButton>
+    </NxTooltip>
   </div>;
 
 export default NxButtonIconOnlyExample;

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -68,15 +68,18 @@ export default function NxButtonPage() {
                           id="nx-button-icon-example"
                           liveExample={NxButtonIconExample}
                           codeExamples={nxButtonIconCode}>
-        An example of a button containing an icon in addition to text.
+        An example of buttons containing icons. When an icon's only content consists of an icon it should be wrapped
+        in an <code className="nx-code">NxTooltip</code> and its <code className="nx-code">aria-label</code> set.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Icon only buttons"
                           id="nx-button-icon-only-example"
                           liveExample={NxButtonIconOnlyExample}
                           codeExamples={nxButtonIconOnlyCode}>
-        An example of a button containing only an icon. For accessibility purposes it is important to add an
-        aria-label for the screen reader to interpret the content correctly.
+        The <code className="nx-code">icon-only</code> variant is meant to be used in places like lists or tables where
+        a slightly smaller button size is desirable. For accessibility purposes it is important to wrap it in
+        an <code className="nx-code">NxTooltip</code> and an <code className="nx-code">aria-label</code> for the screen
+        reader to interpret the content correctly.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -68,8 +68,8 @@ export default function NxButtonPage() {
                           id="nx-button-icon-example"
                           liveExample={NxButtonIconExample}
                           codeExamples={nxButtonIconCode}>
-        An example of buttons containing icons. When an icon's only content consists of an icon it should be wrapped
-        in an <code className="nx-code">NxTooltip</code> and its <code className="nx-code">aria-label</code> set.
+        An example of buttons containing icons. When an button's only content consists of an icon it should be wrapped
+        in an <code className="nx-code">NxTooltip</code> for accessibility.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Icon only buttons"
@@ -78,8 +78,7 @@ export default function NxButtonPage() {
                           codeExamples={nxButtonIconOnlyCode}>
         The <code className="nx-code">icon-only</code> variant is meant to be used in places like lists or tables where
         a slightly smaller button size is desirable. For accessibility purposes it is important to wrap it in
-        an <code className="nx-code">NxTooltip</code> and an <code className="nx-code">aria-label</code> for the screen
-        reader to interpret the content correctly.
+        an <code className="nx-code">NxTooltip</code>.
       </GalleryExampleTile>
     </>
   );

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-398

Added tooltips to icon only buttons, added examples of "normal" buttons with only icons as content. Updated/improved descriptions and examples.