### PR TITLE
NxPolicyThreatSlider style update - RSC-338

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/visualtests/nxPolicyThreatSlider.js
+++ b/gallery/visualtests/nxPolicyThreatSlider.js
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-const { clickTest, focusTest, focusAndHoverTest, hoverTest, simpleTest } = require('./testUtils');
+const { focusTest, simpleTest } = require('./testUtils');
 
 describe('NxPolicyThreatSlider', function() {
   beforeEach(async function() {
@@ -54,6 +54,9 @@ describe('NxPolicyThreatSlider', function() {
       await dragSliderHandle(browser, lowerSliderElement, spacesFromDefault);
       await dragSliderHandle(browser, upperSliderElement, -(spacesFromDefault));
 
+      // click off of the slider
+      await targetElement.click({ x: -1, y: -1 });
+
       await simpleTest(selector)();
     };
   }
@@ -64,4 +67,6 @@ describe('NxPolicyThreatSlider', function() {
   it('looks right at 3 and 7', testSlider(3));
   it('looks right at 4 and 6', testSlider(4));
   it('looks right at 5 and 5', testSlider(5));
+
+  it('looks right when a slider is focused', focusTest(selector, lowerSliderSelector));
 });

--- a/gallery/visualtests/nxPolicyThreatSlider.js
+++ b/gallery/visualtests/nxPolicyThreatSlider.js
@@ -36,7 +36,7 @@ describe('NxPolicyThreatSlider', function() {
         type: 'pointerMove',
         duration: 0,
         origin: 'pointer',
-        x: 18 * spaces,
+        x: 20 * spaces,
         y: 0
       }, {
         type: 'pointerUp',
@@ -55,7 +55,7 @@ describe('NxPolicyThreatSlider', function() {
       await dragSliderHandle(browser, upperSliderElement, -(spacesFromDefault));
 
       // click off of the slider
-      await targetElement.click({ x: -1, y: -1 });
+      await targetElement.click({ x: -50, y: -50 });
 
       await simpleTest(selector)();
     };
@@ -68,5 +68,5 @@ describe('NxPolicyThreatSlider', function() {
   it('looks right at 4 and 6', testSlider(4));
   it('looks right at 5 and 5', testSlider(5));
 
-  it('looks right when a slider is focused', focusTest(selector, lowerSliderSelector));
+  it('looks right when a slider is focused', focusTest(selector, upperSliderSelector));
 });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -51,34 +51,39 @@
     &.MuiSlider-active, &:hover {
       box-shadow: none;
     }
+
+    &:focus {
+      border-color: $nx-focus-border-color;
+      box-shadow: $nx-focus-box-shadow;
+    }
   }
 
   .nx-policy-threat-slider__value-label--none {
-    .MuiSlider-thumb {
+    .MuiSlider-thumb:not(:focus) {
       border-color: $nx-threat-color-none;
     }
   }
 
   .nx-policy-threat-slider__value-label--low {
-    .MuiSlider-thumb {
+    .MuiSlider-thumb:not(:focus) {
       border-color: $nx-threat-color-low;
     }
   }
 
   .nx-policy-threat-slider__value-label--moderate {
-    .MuiSlider-thumb {
+    .MuiSlider-thumb:not(:focus) {
       border-color: $nx-threat-color-moderate;
     }
   }
 
   .nx-policy-threat-slider__value-label--severe {
-    .MuiSlider-thumb {
+    .MuiSlider-thumb:not(:focus) {
       border-color: $nx-threat-color-severe;
     }
   }
 
   .nx-policy-threat-slider__value-label--critical {
-    .MuiSlider-thumb {
+    .MuiSlider-thumb:not(:focus) {
       border-color: $nx-threat-color-critical;
     }
   }

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -15,7 +15,6 @@
 
   // flex so line-height doesn't get involved in the element overall height
   display: inline-flex;
-  font-size: 13px;
   margin: $nx-spacing-xs 0;
 
   // the .MuiSlider-thumb elements actually stick out of the sides of the .MuiSlider-root at their min and max

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -7,19 +7,22 @@
 @import '../../scss-shared/nx-variables';
 
 .nx-policy-threat-slider {
-  display: inline-block;
+  $rail-height: 8px;
+  $thumb-size: 32px;
+
+  // distance from top of thumb to top of rail
+  $thumb-vertical-overflow: ($thumb-size - $rail-height) / 2;
 
   font-size: 13px;
 
   // the .MuiSlider-thumb elements actually stick out of the sides of the .MuiSlider-root at their min and max
   // positions.  This padding ensures that they don't stick out of the overall box for this component
-  padding: 0 9px;
+  padding: 0 ($thumb-size / 2);
 
   .MuiSlider-root {
-    display: inline-block;
-    height: 6px;
-    padding: 9px 0;
-    width: 180px;
+    height: $rail-height;
+    padding: $thumb-vertical-overflow 0;
+    width: 200px;
   }
 
   .MuiSlider-markActive {
@@ -31,15 +34,18 @@
   }
 
   .MuiSlider-thumb {
-    align-items: stretch;
-    border-radius: 4px;
-
-    color: $nx-off-white;
-
-    height: 17px;
-    width: 18px;
-
-    margin-left: -9px;
+    box-sizing: border-box;
+    background-color: $nx-white;
+    border: 2px solid;
+    border-radius: $nx-border-radius;
+    color: $nx-text-color-dark;
+    font-size: $nx-font-size-s;
+    font-weight: bold;
+    height: $thumb-size;
+    width: $thumb-size;
+    line-height: 1;
+    margin-left: $thumb-size / -2;
+    margin-top: -($thumb-vertical-overflow);
 
     &.MuiSlider-active, &:hover {
       box-shadow: none;
@@ -48,40 +54,42 @@
 
   .nx-policy-threat-slider__value-label--none {
     .MuiSlider-thumb {
-      background-color: $nx-threat-color-none;
+      border-color: $nx-threat-color-none;
     }
   }
 
   .nx-policy-threat-slider__value-label--low {
     .MuiSlider-thumb {
-      background-color: $nx-threat-color-low;
+      border-color: $nx-threat-color-low;
     }
   }
 
   .nx-policy-threat-slider__value-label--moderate {
     .MuiSlider-thumb {
-      background-color: $nx-threat-color-moderate;
+      border-color: $nx-threat-color-moderate;
     }
   }
 
   .nx-policy-threat-slider__value-label--severe {
     .MuiSlider-thumb {
-      background-color: $nx-threat-color-severe;
+      border-color: $nx-threat-color-severe;
     }
   }
 
   .nx-policy-threat-slider__value-label--critical {
     .MuiSlider-thumb {
-      background-color: $nx-threat-color-critical;
+      border-color: $nx-threat-color-critical;
     }
   }
 
   .MuiSlider-mark {
-    height: 6px;
+    $border-radius: $rail-height / 2;
+
+    height: $rail-height;
 
     // threat level 0
-    border-radius: 4px 0 0 4px;
-    color: $nx-threat-color-none-light;
+    border-radius: $border-radius 0 0 $border-radius;
+    color: $nx-threat-color-none;
 
     // the first mark only goes from 0 - 0.5, so is only 5% wide.
     // The rest (except the last) each go from (n - 0.5) to (n + 0.5), so are 10% wide with a -5% left margin.
@@ -98,18 +106,18 @@
       width: 10%;
 
       // threat level 1
-      color: $nx-threat-color-low-light;
+      color: $nx-threat-color-low;
 
       ~ .MuiSlider-mark {
         // threat level 2
-        color: $nx-threat-color-moderate-light;
+        color: $nx-threat-color-moderate;
 
         ~ .MuiSlider-mark {
           // threat level 3
 
           ~ .MuiSlider-mark {
             // threat level 4
-            color: $nx-threat-color-severe-light;
+            color: $nx-threat-color-severe;
 
             ~ .MuiSlider-mark {
               // threat level 5
@@ -122,14 +130,14 @@
 
                   ~ .MuiSlider-mark {
                     // threat level 8
-                    color: $nx-threat-color-critical-light;
+                    color: $nx-threat-color-critical;
 
                     ~ .MuiSlider-mark {
                       // threat level 9
 
                       ~ .MuiSlider-mark {
                         // threat level 10
-                        border-radius: 0 4px 4px 0;
+                        border-radius: 0 $border-radius $border-radius 0;
                         width: 5%;
                       }
                     }

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -14,6 +14,7 @@
   $thumb-vertical-overflow: ($thumb-size - $rail-height) / 2;
 
   font-size: 13px;
+  margin: $nx-spacing-xs 0;
 
   // the .MuiSlider-thumb elements actually stick out of the sides of the .MuiSlider-root at their min and max
   // positions.  This padding ensures that they don't stick out of the overall box for this component

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -57,6 +57,13 @@
       border-color: $nx-focus-border-color;
       box-shadow: $nx-focus-box-shadow;
     }
+
+    // this class seems to be applied, perhaps incorrectly,
+    // after a thumb loses focus due to arrows keys and thumbs crossing
+    // over one another. It should _not_ have focus styles
+    &.Mui-focusVisible:not(:focus) {
+      box-shadow: none;
+    }
   }
 
   .nx-policy-threat-slider__value-label--none {

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -13,7 +13,8 @@
   // distance from top of thumb to top of rail
   $thumb-vertical-overflow: ($thumb-size - $rail-height) / 2;
 
-  display: inline-block;
+  // flex so line-height doesn't get involved in the element overall height
+  display: inline-flex;
   font-size: 13px;
   margin: $nx-spacing-xs 0;
 

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -13,6 +13,7 @@
   // distance from top of thumb to top of rail
   $thumb-vertical-overflow: ($thumb-size - $rail-height) / 2;
 
+  display: inline-block;
   font-size: 13px;
   margin: $nx-spacing-xs 0;
 

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -24,7 +24,9 @@
   .MuiSlider-root {
     height: $rail-height;
     padding: $thumb-vertical-overflow 0;
-    width: 200px;
+
+    // NOTE: this number needs to be divisible by 10 for the track to render cleanly
+    width: 230px;
   }
 
   .MuiSlider-markActive {

--- a/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
+++ b/lib/src/components/NxPolicyThreatSlider/NxPolicyThreatSlider.scss
@@ -26,7 +26,7 @@
     padding: $thumb-vertical-overflow 0;
 
     // NOTE: this number needs to be divisible by 10 for the track to render cleanly
-    width: 230px;
+    width: 220px;
   }
 
   .MuiSlider-markActive {

--- a/lib/src/scss-shared/_nx-colors.scss
+++ b/lib/src/scss-shared/_nx-colors.scss
@@ -117,10 +117,3 @@ $nx-threat-color-low: $nx-blue-600;
 $nx-threat-color-moderate: #ffbf27;
 $nx-threat-color-severe: #ff8100;
 $nx-threat-color-critical: #cd0028;
-
-// Threat colors - light variant
-$nx-threat-color-none-light: #d9ecfb;
-$nx-threat-color-low-light: #92cbff;
-$nx-threat-color-moderate-light: #fdecaf;
-$nx-threat-color-severe-light: #ffd6a2;
-$nx-threat-color-critical-light: #ff9493;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-338

NOTE: The zeplin mockups here seem to be missing some changes that I recall being agreed to:

* In the mockups the track goes from the furthest left that the left edge of the thumb can be, to the furthest right that the right edge of the thumb can be.  I thought we agreed to keep the track as essentially covering the extent that the center of the thumb can travel.
* The "Select Range" text included in the mockup is not part of the component, it is just part of the gallery example.

Additionally, the mockup does not include focus styles, and I can't remember what was said about them.  I've updated them to match our typical focus styling.

I also went against the mockup regarding the overall width of the component.  In order to keep the track size divisible by 10 so that it renders well (without gaps) using our 5% and 10% widths, I increased it by 4px from the spec'd 228 to 232.