### PR TITLE
Avoid oveflow: hidden in nx-viewport-sized - RSC-418

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-viewport-sized.scss
+++ b/lib/src/base-styles/_nx-viewport-sized.scss
@@ -8,7 +8,6 @@
 .nx-viewport-sized {
   display: flex;
   flex-direction: column;
-  overflow-y: hidden;
 }
 
 .nx-viewport-sized__container, .nx-viewport-sized {
@@ -17,6 +16,7 @@
     flex: none;
     margin-top: 0;
     width: 100%;
+    min-height: 0;
   }
 }
 
@@ -25,7 +25,6 @@
   display: flex;
   flex-direction: column;
   flex: auto;
-  overflow-y: hidden;
 }
 
 .nx-viewport-sized__scrollable {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-418

This should fix the issue with the tab focus borders getting cut off on @regoarrarr 's PR here: https://github.com/sonatype/insight-brain/pull/5903