### PR TITLE
Change NxTextInput ref to refer to wrapping div - RSC-408

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.23.2",
+  "version": "3.0.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.23.2",
+  "version": "3.0.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTextInput/NxTextInput.tsx
+++ b/lib/src/components/NxTextInput/NxTextInput.tsx
@@ -29,7 +29,7 @@ export { Props, propTypes, inputTypes } from './types';
  * @param onKeyPress A callback for when the user presses a key that doesn't necessarily change the input value
  *    (e.g. by hitting enter)
  */
-const NxTextInput = forwardRef<TextInputElement, Props>(
+const NxTextInput = forwardRef<HTMLDivElement, Props>(
     function NxTextInput(props, forwardedRef) {
       const {
         type,
@@ -67,25 +67,6 @@ const NxTextInput = forwardRef<TextInputElement, Props>(
       const inputRef: MutableRefObject<TextInputElement | null> = useRef<TextInputElement>(null),
           invalidMessageId = useMemo(() => getRandomId('nx-text-input-invalid-message'), []);
 
-      /*
-       * We have two different refs that we want set to the <input>: the forwarded one
-       * and the one we use internally for setting the focus. We can't just use the forwarded one
-       * to manage the focus, because it isn't guaranteed to be an object with a `current` prop, it could actually
-       * be a function instead. So what we have to do is pass this refSetter function to the <input>, which handles
-       * setting both the forwarded and the internal ref.
-       * Inspired by: https://stackoverflow.com/a/62238917
-       */
-      function refSetter(el: TextInputElement) {
-        inputRef.current = el;
-
-        if (typeof forwardedRef === 'function') {
-          forwardedRef(el);
-        }
-        else if (forwardedRef) {
-          (forwardedRef as MutableRefObject<TextInputElement>).current = el;
-        }
-      }
-
       // when the box padding is clicked, set the focus to the <input> as that's what the user thought
       // they were clicking
       function setFocusToInput() {
@@ -107,12 +88,12 @@ const NxTextInput = forwardRef<TextInputElement, Props>(
       }
 
       return (
-        <div className={internalClassName}>
+        <div ref={forwardedRef} className={internalClassName}>
           <div className="nx-text-input__box" onClick={setFocusToInput}>
             {React.createElement(element, {
               ...newProps,
               disabled,
-              ref: refSetter,
+              ref: inputRef,
               type: typeAttr,
               onChange: inputOnChange,
               className: 'nx-text-input__input',

--- a/lib/src/components/NxTextInput/stateful/NxStatefulTextInput.tsx
+++ b/lib/src/components/NxTextInput/stateful/NxStatefulTextInput.tsx
@@ -23,7 +23,7 @@ export { Props, propTypes } from './types';
  * @param onKeyPress A callback for when the user presses a key that not necessarily changes the value of the text box
  * See the doc page for this component for information about other supported attributes.
  */
-const NxStatefulTextInput = forwardRef<HTMLInputElement | HTMLTextAreaElement, Props>(
+const NxStatefulTextInput = forwardRef<HTMLDivElement, Props>(
     function NxStatefulTextInput(props, ref) {
       const { defaultValue, onChange, validator, ...attrs } = props,
           [state, setState] = useState(initialState(defaultValue || '', validator));


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-408

By setting the ref to the div to tooltip aligns to the correct element.  Note that this is a breaking change, though I have asked around and it doesn't seem like it will cause problems within Sonatype.