### PR TITLE
Export NxTextInput stateHelpers from index file - RSC-67

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxForm/NxFormCustomizedExample.tsx
+++ b/gallery/src/components/NxForm/NxFormCustomizedExample.tsx
@@ -6,9 +6,10 @@
  */
 import React, { useState } from 'react';
 
-import { NxForm, NxFormGroup, NxTextInput, NxButton } from '@sonatype/react-shared-components';
+import { NxForm, NxFormGroup, NxTextInput, NxButton, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
 import { SUCCESS_VISIBLE_TIME_MS } from '@sonatype/react-shared-components/components/NxSubmitMask/NxSubmitMask';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 export default function NxFormCustomizedExample() {
   const initialFieldState = { username: initialState(''), hostname: initialState('') },

--- a/gallery/src/components/NxForm/NxFormExample.tsx
+++ b/gallery/src/components/NxForm/NxFormExample.tsx
@@ -6,10 +6,12 @@
  */
 import React, { useState, useEffect, FormEvent } from 'react';
 
-import { NxCheckbox, NxForm, NxRadio, NxFormGroup, NxTextInput } from '@sonatype/react-shared-components';
+import { NxCheckbox, NxForm, NxRadio, NxFormGroup, NxTextInput, nxTextInputStateHelpers }
+  from '@sonatype/react-shared-components';
 import { SUCCESS_VISIBLE_TIME_MS } from '@sonatype/react-shared-components/components/NxSubmitMask/NxSubmitMask';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
 import { combineValidationErrors, hasValidationErrors } from '@sonatype/react-shared-components/util/validationUtil';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 export default function NxFormExample() {
   function validator(val: string) {

--- a/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
@@ -6,9 +6,11 @@
  */
 import React, {useState} from 'react';
 
-import {NxModal, NxFontAwesomeIcon, NxTextInput, NxLoadError, NxButton} from '@sonatype/react-shared-components';
+import {NxModal, NxFontAwesomeIcon, NxTextInput, NxLoadError, NxButton, nxTextInputStateHelpers}
+  from '@sonatype/react-shared-components';
 import {faAngry} from '@fortawesome/free-solid-svg-icons';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 export default function NxModalFormErrorExample() {
   const [showModal, setShowModal] = useState(false);

--- a/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
@@ -4,11 +4,11 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 
-import {NxModal, NxFontAwesomeIcon, NxTextInput, NxLoadError, NxButton, nxTextInputStateHelpers}
+import { NxModal, NxFontAwesomeIcon, NxTextInput, NxLoadError, NxButton, nxTextInputStateHelpers }
   from '@sonatype/react-shared-components';
-import {faAngry} from '@fortawesome/free-solid-svg-icons';
+import { faAngry } from '@fortawesome/free-solid-svg-icons';
 
 const { initialState, userInput } = nxTextInputStateHelpers;
 

--- a/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipDynamicExample.tsx
+++ b/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipDynamicExample.tsx
@@ -6,8 +6,9 @@
  */
 import React, { useState } from 'react';
 
-import { NxOverflowTooltip, NxTextInput } from '@sonatype/react-shared-components';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+import { NxOverflowTooltip, NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 export default function NxOverflowTooltipDynamicExample() {
   const [textState, setTextState] = useState(initialState('Supercalfragulisticexpealidocious'));

--- a/gallery/src/components/NxTextInput/NxTextInputLongExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputLongExample.tsx
@@ -6,8 +6,9 @@
  */
 import React, { useState } from 'react';
 
-import { NxTextInput } from '@sonatype/react-shared-components';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+import { NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 export default function NxTextInputSimpleExample() {
   const [state1, setState1] = useState(initialState('')),

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -146,7 +146,7 @@ const NxTextInputPage = () =>
       </table>
       <h3>State Helpers</h3>
       <p className="nx-p">
-        <code className="nx-code">@sonatype/react-shared-components/components/NxTextInput/stateHelpers.ts</code>{' '}
+        The <code className="nx-code">nxTextInputStateHelpers</code>{' '}
         includes the following recommended state helper functions, which each return an object containining the
         "stateful" parts of the NxTextInput props{' '}
         (<code className="nx-code">value</code>, <code className="nx-code">isPristine</code>, and{' '}

--- a/gallery/src/components/NxTextInput/NxTextInputPasswordExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPasswordExample.tsx
@@ -6,8 +6,9 @@
  */
 import React, { useState } from 'react';
 
-import { NxTextInput } from '@sonatype/react-shared-components';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+import { NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 // exactly the same as NxTextInputSimpleExample, except for type="password"
 export default function NxTextInputPasswordExample() {

--- a/gallery/src/components/NxTextInput/NxTextInputSimpleExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputSimpleExample.tsx
@@ -11,7 +11,7 @@ import { NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-com
 const { initialState, userInput } = nxTextInputStateHelpers;
 
 export default function NxTextInputSimpleExample() {
-   const [state, setState] = useState(initialState(''));
+  const [state, setState] = useState(initialState(''));
 
   function onChange(val: string) {
     setState(userInput(null, val));

--- a/gallery/src/components/NxTextInput/NxTextInputSimpleExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputSimpleExample.tsx
@@ -6,11 +6,12 @@
  */
 import React, { useState } from 'react';
 
-import { NxTextInput } from '@sonatype/react-shared-components';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+import { NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 export default function NxTextInputSimpleExample() {
-  const [state, setState] = useState(initialState(''));
+   const [state, setState] = useState(initialState(''));
 
   function onChange(val: string) {
     setState(userInput(null, val));

--- a/gallery/src/components/NxTextInput/NxTextInputTextAreaExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputTextAreaExample.tsx
@@ -6,8 +6,9 @@
  */
 import React, { useState } from 'react';
 
-import { NxTextInput } from '@sonatype/react-shared-components';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+import { NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 // exactly the same as NxTextInputSimpleExample, except for type="textarea"
 export default function NxTextInputTextAreaExample() {

--- a/gallery/src/components/NxTextInput/NxTextInputTextAreaValidationExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputTextAreaValidationExample.tsx
@@ -6,8 +6,9 @@
  */
 import React, { useState } from 'react';
 
-import { NxTextInput } from '@sonatype/react-shared-components';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+import { NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 function validator(val: string) {
   return val.length ? null : 'Must be non-empty';

--- a/gallery/src/components/NxTextInput/NxTextInputValidationExample.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputValidationExample.tsx
@@ -6,8 +6,9 @@
  */
 import React, { useState } from 'react';
 
-import { NxTextInput } from '@sonatype/react-shared-components';
-import { initialState, userInput } from '@sonatype/react-shared-components/components/NxTextInput/stateHelpers';
+import { NxTextInput, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+
+const { initialState, userInput } = nxTextInputStateHelpers;
 
 function validator(val: string) {
   return val.length ? null : 'Must be non-empty';

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -15,6 +15,10 @@ export { default as NxLoadError, Props as NxLoadErrorProps } from './components/
 export { default as NxLoadWrapper, Props as NxLoadWrapperProps } from './components/NxLoadWrapper/NxLoadWrapper';
 export { default as NxModal, Props as NxModalProps } from './components/NxModal/NxModal';
 export { default as NxTextInput, Props as NxTextInputProps } from './components/NxTextInput/NxTextInput';
+
+import * as nxTextInputStateHelpers from './components/NxTextInput/stateHelpers';
+export { nxTextInputStateHelpers };
+
 export {
   default as NxAlert,
   NxWarningAlert,


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-67

After this PR, importing the stateHelper functions directly from `stateHelpers.ts` will be considered deprecated