### PR TITLE
Safari legend margin bug RSC-406

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
@@ -60,11 +60,11 @@ export default function NxFormLayoutExample() {
       <div className="nx-form-group">
         <label htmlFor="long-field" className="nx-label nx-label--optional">
           <span className="nx-label__text">Hostname</span>
-          <div className="nx-sub-label">
-            <NxFontAwesomeIcon icon={faCalendar}/>
-            <span id="long-field-sublabel">The field element below is wider than the default.</span>
-          </div>
         </label>
+        <div className="nx-sub-label">
+          <NxFontAwesomeIcon icon={faCalendar}/>
+          <span id="long-field-sublabel">The field element below is wider than the default.</span>
+        </div>
         <NxStatefulTextInput id="long-field" aria-describedby="long-field-sublabel" className="nx-text-input--long"/>
       </div>
       <fieldset className="nx-fieldset">
@@ -78,8 +78,8 @@ export default function NxFormLayoutExample() {
       <fieldset className="nx-fieldset">
         <legend className="nx-legend nx-legend--optional">
           <span className="nx-legend__text">Primary Color</span>
-          <div className="nx-sub-label">Pick a single color</div>
         </legend>
+        <div className="nx-sub-label">Pick a single color</div>
         <NxRadio name="color"
                  value="red"
                  onChange={setColor}
@@ -117,10 +117,10 @@ export default function NxFormLayoutExample() {
           <span className="nx-legend__text">
             Enable features
           </span>
-          <div className="nx-sub-label">
-            In a form layout toggles are laid out in a <code className="nx-code">&lt;fieldset&gt;</code>
-          </div>
         </legend>
+        <div className="nx-sub-label">
+          In a form layout toggles are laid out in a <code className="nx-code">&lt;fieldset&gt;</code>
+        </div>
         <NxToggle inputId="subscribe-check" onChange={toggleWarp} isChecked={isWarpOn}>
           Enable Warp Drive
         </NxToggle>
@@ -134,8 +134,8 @@ export default function NxFormLayoutExample() {
       <div className="nx-form-group">
         <label className="nx-label">
           <span className="nx-label__text">Comments</span>
+          <NxStatefulTextInput type="textarea" placeholder="placeholder"/>
         </label>
-        <NxStatefulTextInput type="textarea" placeholder="placeholder"/>
       </div>
       <footer className="nx-footer">
         <div className="nx-btn-bar">

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
@@ -48,8 +48,8 @@ export default function NxFormLayoutExample() {
       <div className="nx-form-group">
         <label className="nx-label">
           <span className="nx-label__text">A Field to Fill in</span>
-          <NxStatefulTextInput aria-required={true} validator={validator}/>
         </label>
+        <NxStatefulTextInput aria-required={true} validator={validator}/>
       </div>
       <div className="nx-form-group">
         <label htmlFor="input-2" className="nx-label nx-label--optional">
@@ -60,11 +60,11 @@ export default function NxFormLayoutExample() {
       <div className="nx-form-group">
         <label htmlFor="long-field" className="nx-label nx-label--optional">
           <span className="nx-label__text">Hostname</span>
+          <div className="nx-sub-label">
+            <NxFontAwesomeIcon icon={faCalendar}/>
+            <span id="long-field-sublabel">The field element below is wider than the default.</span>
+          </div>
         </label>
-        <div className="nx-sub-label">
-          <NxFontAwesomeIcon icon={faCalendar}/>
-          <span id="long-field-sublabel">The field element below is wider than the default.</span>
-        </div>
         <NxStatefulTextInput id="long-field" aria-describedby="long-field-sublabel" className="nx-text-input--long"/>
       </div>
       <fieldset className="nx-fieldset">
@@ -78,8 +78,8 @@ export default function NxFormLayoutExample() {
       <fieldset className="nx-fieldset">
         <legend className="nx-legend nx-legend--optional">
           <span className="nx-legend__text">Primary Color</span>
+          <div className="nx-sub-label">Pick a single color</div>
         </legend>
-        <div className="nx-sub-label">Pick a single color</div>
         <NxRadio name="color"
                  value="red"
                  onChange={setColor}
@@ -117,10 +117,10 @@ export default function NxFormLayoutExample() {
           <span className="nx-legend__text">
             Enable features
           </span>
+          <div className="nx-sub-label">
+            In a form layout toggles are laid out in a <code className="nx-code">&lt;fieldset&gt;</code>
+          </div>
         </legend>
-        <div className="nx-sub-label">
-          In a form layout toggles are laid out in a <code className="nx-code">&lt;fieldset&gt;</code>
-        </div>
         <NxToggle inputId="subscribe-check" onChange={toggleWarp} isChecked={isWarpOn}>
           Enable Warp Drive
         </NxToggle>
@@ -134,8 +134,8 @@ export default function NxFormLayoutExample() {
       <div className="nx-form-group">
         <label className="nx-label">
           <span className="nx-label__text">Comments</span>
-          <NxStatefulTextInput type="textarea" placeholder="placeholder"/>
         </label>
+        <NxStatefulTextInput type="textarea" placeholder="placeholder"/>
       </div>
       <footer className="nx-footer">
         <div className="nx-btn-bar">

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
@@ -61,10 +61,10 @@ export default function NxFormLayoutExample() {
         <label htmlFor="long-field" className="nx-label nx-label--optional">
           <span className="nx-label__text">Hostname</span>
         </label>
-        <span className="nx-sub-label">
+        <div className="nx-sub-label">
           <NxFontAwesomeIcon icon={faCalendar}/>
           <span id="long-field-sublabel">The field element below is wider than the default.</span>
-        </span>
+        </div>
         <NxStatefulTextInput id="long-field" aria-describedby="long-field-sublabel" className="nx-text-input--long"/>
       </div>
       <fieldset className="nx-fieldset">
@@ -78,8 +78,8 @@ export default function NxFormLayoutExample() {
       <fieldset className="nx-fieldset">
         <legend className="nx-legend nx-legend--optional">
           <span className="nx-legend__text">Primary Color</span>
-          <span className="nx-sub-label">Pick a single color</span>
         </legend>
+        <div className="nx-sub-label">Pick a single color</div>
         <NxRadio name="color"
                  value="red"
                  onChange={setColor}
@@ -102,25 +102,25 @@ export default function NxFormLayoutExample() {
       <div className="nx-form-group">
         <label className="nx-label">
           <span className="nx-label__text">Select</span>
-          <select className="nx-form-select" value={selectVal} onChange={onSelectChange}>
-            <option value="">Select an option</option>
-            <option value="option1">Option 1</option>
-            <option value="option2">Option 2</option>
-            <option value="option3">Option 3</option>
-            <option value="option4">Option 4</option>
-            <option value="option5">Option 5</option>
-          </select>
         </label>
+        <select className="nx-form-select" value={selectVal} onChange={onSelectChange}>
+          <option value="">Select an option</option>
+          <option value="option1">Option 1</option>
+          <option value="option2">Option 2</option>
+          <option value="option3">Option 3</option>
+          <option value="option4">Option 4</option>
+          <option value="option5">Option 5</option>
+        </select>
       </div>
       <fieldset className="nx-fieldset">
         <legend className="nx-legend">
           <span className="nx-legend__text">
             Enable features
           </span>
-          <span className="nx-sub-label">
-            In a form layout toggles are laid out in a <code className="nx-code">&lt;fieldset&gt;</code>
-          </span>
         </legend>
+        <div className="nx-sub-label">
+          In a form layout toggles are laid out in a <code className="nx-code">&lt;fieldset&gt;</code>
+        </div>
         <NxToggle inputId="subscribe-check" onChange={toggleWarp} isChecked={isWarpOn}>
           Enable Warp Drive
         </NxToggle>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -47,6 +47,11 @@
   }
 }
 
+// hack to get Safari to recognize the legend's text margins
+.nx-legend {
+  -webkit-margin-collapse: separate;
+}
+
 .nx-label__text, .nx-legend__text {
   @include bold();
   @include container-horizontal;

--- a/lib/src/components/NxFieldset/NxFieldset.tsx
+++ b/lib/src/components/NxFieldset/NxFieldset.tsx
@@ -19,8 +19,8 @@ const NxFieldset = forwardRef<HTMLFieldSetElement, Props>(
         <fieldset className={classNames} ref={ref} { ...attrs }>
           <legend className={legendClassnames}>
             <span className="nx-legend__text">{label}</span>
-            { sublabel && <span className="nx-sub-label">{sublabel}</span> }
           </legend>
+          { sublabel && <span className="nx-sub-label">{sublabel}</span> }
           {children}
         </fieldset>
       );

--- a/lib/src/components/NxFieldset/NxFieldset.tsx
+++ b/lib/src/components/NxFieldset/NxFieldset.tsx
@@ -20,7 +20,7 @@ const NxFieldset = forwardRef<HTMLFieldSetElement, Props>(
           <legend className={legendClassnames}>
             <span className="nx-legend__text">{label}</span>
           </legend>
-          { sublabel && <span className="nx-sub-label">{sublabel}</span> }
+          { sublabel && <div className="nx-sub-label">{sublabel}</div> }
           {children}
         </fieldset>
       );

--- a/lib/src/components/NxFormGroup/NxFormGroup.tsx
+++ b/lib/src/components/NxFormGroup/NxFormGroup.tsx
@@ -31,7 +31,7 @@ const NxFormGroup = forwardRef<HTMLDivElement, Props>(
           <label htmlFor={childId} className={labelClassnames}>
             <span className="nx-label__text">{label}</span>
           </label>
-          { sublabel && <span id={sublabelId} className="nx-sub-label">{sublabel}</span> }
+          { sublabel && <div id={sublabelId} className="nx-sub-label">{sublabel}</div> }
           {childEl}
         </div>
       );


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-406

The issue is a long-standing bug in Safari where it collapses all margin on `<legend>`. There are a variety of fixes offered and this one seemed to work the best with our layouts. I also made our use of `sub-label` consistent across the layout examples.