### PR TITLE
nx-alert at page level - RSC-434

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -62,7 +62,7 @@ function Application() {
       <PageHeader />
       <div className="nx-page-content">
         <Switch>
-          <Route exact path="/PageLevelErrorExample">
+          <Route exact path="/PageLevelAlertExample">
             <NxErrorAlert>
               This is an example of a page-level alert. Use your browser's back button to return to
               another page of the RSC gallery.

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -20,11 +20,11 @@ import GalleryNav from './GalleryNav';
 import Home from './pages/Home';
 import handleQueryParams from './handleQueryParams';
 
+import NxLoadWrapperPageLevelExample from './components/NxLoadWrapper/NxLoadWrapperPageLevelExample';
 import NxViewportSizedExample from './styles/NxViewportSized/NxViewportSizedExample';
 import NxViewportSizedExpandingExample
   from './styles/NxViewportSized/NxViewportSizedExpandingExample';
 import SectionScrollingWrapper from './styles/NxViewportSized/SectionScrollingWrapper';
-import { NxErrorAlert } from '@sonatype/react-shared-components';
 
 const pageMappings: PageMapping = mergeAll(values(pageConfig));
 
@@ -63,10 +63,7 @@ function Application() {
       <div className="nx-page-content">
         <Switch>
           <Route exact path="/PageLevelAlertExample">
-            <NxErrorAlert>
-              This is an example of a page-level alert. Use your browser's back button to return to
-              another page of the RSC gallery.
-            </NxErrorAlert>
+            <NxLoadWrapperPageLevelExample/>
           </Route>
           <Route>
             <aside className="nx-page-sidebar" id="gallery-sidebar">

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -24,7 +24,7 @@ import NxViewportSizedExample from './styles/NxViewportSized/NxViewportSizedExam
 import NxViewportSizedExpandingExample
   from './styles/NxViewportSized/NxViewportSizedExpandingExample';
 import SectionScrollingWrapper from './styles/NxViewportSized/SectionScrollingWrapper';
-import { NxLoadError } from '@sonatype/react-shared-components';
+import { NxErrorAlert } from '@sonatype/react-shared-components';
 
 const pageMappings: PageMapping = mergeAll(values(pageConfig));
 
@@ -63,7 +63,10 @@ function Application() {
       <div className="nx-page-content">
         <Switch>
           <Route exact path="/PageLevelErrorExample">
-            <NxLoadError error={<>An example of a page-level error that is a direct child of <code className="nx-code">nx-page-content</code>.</>} retryHandler={() => {}} />
+            <NxErrorAlert>
+              This is an example of a page-level alert. Use your browser's back button to return to
+              another page of the RSC gallery.
+            </NxErrorAlert>
           </Route>
           <Route>
             <aside className="nx-page-sidebar" id="gallery-sidebar">

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -24,6 +24,7 @@ import NxViewportSizedExample from './styles/NxViewportSized/NxViewportSizedExam
 import NxViewportSizedExpandingExample
   from './styles/NxViewportSized/NxViewportSizedExpandingExample';
 import SectionScrollingWrapper from './styles/NxViewportSized/SectionScrollingWrapper';
+import { NxLoadError } from '@sonatype/react-shared-components';
 
 const pageMappings: PageMapping = mergeAll(values(pageConfig));
 
@@ -60,25 +61,32 @@ function Application() {
     <Router>
       <PageHeader />
       <div className="nx-page-content">
-        <aside className="nx-page-sidebar" id="gallery-sidebar">
-          <GalleryNav />
-        </aside>
         <Switch>
-          <Route path="/pages/:pageName" component={Page} />
-          <Route exact path="/" component={Page} />
+          <Route exact path="/PageLevelErrorExample">
+            <NxLoadError error={<>An example of a page-level error that is a direct child of <code className="nx-code">nx-page-content</code>.</>} retryHandler={() => {}} />
+          </Route>
+          <Route>
+            <aside className="nx-page-sidebar" id="gallery-sidebar">
+              <GalleryNav />
+            </aside>
+            <Switch>
+              <Route path="/pages/:pageName" component={Page} />
+              <Route exact path="/" component={Page} />
 
-          {/* Special cases, these examples need their own page separate from their documentation */}
-          <Route exact path="/NxViewportSizedExample">
-            <SectionScrollingWrapper>
-              <NxViewportSizedExample />
-            </SectionScrollingWrapper>
+              {/* Special cases, these examples need their own page separate from their documentation */}
+              <Route exact path="/NxViewportSizedExample">
+                <SectionScrollingWrapper>
+                  <NxViewportSizedExample />
+                </SectionScrollingWrapper>
+              </Route>
+              <Route exact path="/NxViewportSizedExpandingExample">
+                <SectionScrollingWrapper>
+                  <NxViewportSizedExpandingExample />
+                </SectionScrollingWrapper>
+              </Route>
+              <Redirect to="/" />
+            </Switch>
           </Route>
-          <Route exact path="/NxViewportSizedExpandingExample">
-            <SectionScrollingWrapper>
-              <NxViewportSizedExpandingExample />
-            </SectionScrollingWrapper>
-          </Route>
-          <Redirect to="/" />
         </Switch>
       </div>
     </Router>

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -11,8 +11,10 @@ import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-compon
 import NxLoadWrapperErrorRetryExample from './NxLoadWrapperErrorRetryExample';
 import NxLoadWrapperLoadingExample from './NxLoadWrapperLoadingExample';
 import NxLoadWrapperChildrenExample from './NxLoadWrapperChildrenExample';
+import CodeExample from '../../CodeExample';
 
 const childrenSourceCode = require('!!raw-loader!./NxLoadWrapperChildrenExample').default;
+const pageLevelSourceCode = require('!!raw-loader!./NxLoadWrapperPageLevelExample').default;
 const loadingSourceCode = require('!!raw-loader!./NxLoadWrapperLoadingExample').default;
 const errorRetrySourceCode = require('!!raw-loader!./NxLoadWrapperErrorRetryExample').default;
 
@@ -90,6 +92,36 @@ const NxLoadWrapperPage = () =>
       is set along with a <code className="nx-code">retryHandler</code>, and thus
       an <code className="nx-code">NxErrorAlert</code> is rendered.
     </GalleryExampleTile>
+
+    <section className="nx-tile">
+      <header className="nx-tile-header">
+        <div className="nx-tile-header__title">
+          <h2 className="nx-h2"><code className="nx-code">NxLoadWrapper</code> at the page level</h2>
+        </div>
+      </header>
+      <div className="nx-tile-content">
+        <p className="nx-p">
+          It is frequently the case that the entire content of the page should be wrapped in
+          an <code className="nx-code">NxLoadWrapper</code>.
+          That is, that a page which would typically include
+          an <code className="nx-code">.nx-page-main</code> and perhaps
+          an <code className="nx-code">.nx-page-sidebar</code> should instead include only an error alert in the
+          event that the data for the page fails to load, or the user does not have permission to access that page,
+          or some similar error condition. The RSC styles have specific support for this case:
+          an <code className="nx-code">.nx-alert</code> that is the only child of
+          the <code className="nx-code">.nx-page-content</code> element will correctly center itself on the page.
+          Thus, <code className="nx-code">NxLoadWrapper</code> can be used to wrap
+          the <code className="nx-code">.nx-page-main</code> and
+          (optional) <code className="nx-code">.nx-page-sidebar</code> elements. See the example below:
+        </p>
+        <p className="nx-p">
+          <a className="nx-text-link" href="#/PageLevelAlertExample">
+            Click here to navigate to the live example.
+          </a>
+        </p>
+        <CodeExample content={pageLevelSourceCode} />
+      </div>
+    </section>
   </>;
 
 export default NxLoadWrapperPage;

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPageLevelExample.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPageLevelExample.tsx
@@ -9,8 +9,7 @@ import React, { useState } from 'react';
 import { NxLoadWrapper } from '@sonatype/react-shared-components';
 
 const errorMessage = `This is an example of a page-level alert. Use your browser's back button to return to
-    another page of the RSC gallery.`
-
+    another page of the RSC gallery.`;
 
 const NxLoadWrapperErrorRetryExample = () => {
   const [error, setError] = useState<string | null>(errorMessage);

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPageLevelExample.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPageLevelExample.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { useState } from 'react';
+
+import { NxLoadWrapper } from '@sonatype/react-shared-components';
+
+const errorMessage = `This is an example of a page-level alert. Use your browser's back button to return to
+    another page of the RSC gallery.`
+
+
+const NxLoadWrapperErrorRetryExample = () => {
+  const [error, setError] = useState<string | null>(errorMessage);
+
+  function retryHandler() {
+    setError(null);
+  }
+
+  return (
+    <NxLoadWrapper error={error} retryHandler={retryHandler}>
+      <aside className="nx-page-sidebar">Sidebar stuff</aside>
+      <main className="nx-page-sidebar">Children will not render until after Retry</main>
+    </NxLoadWrapper>
+  );
+};
+
+export default NxLoadWrapperErrorRetryExample;

--- a/gallery/src/styles/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertPage.tsx
@@ -54,38 +54,6 @@ const NxAlertPage = () =>
                         codeExamples={nxAlertErrorCode}>
       An <code className="nx-code">nx-alert</code> demonstrating error styles.
     </GalleryExampleTile>
-
-    <section className="nx-tile">
-      <header className="nx-tile-header">
-        <div className="nx-tile-header__title">
-          <h2 className="nx-h2">Alert at the Page level</h2>
-        </div>
-      </header>
-      <div className="nx-tile-content">
-        <p className="nx-p">
-          It is frequently the case that an alert should be conditionally displayed as the entirety of the page
-          contents – that is, that a page which would typically include
-          an <code className="nx-code">.nx-page-main</code> and perhaps
-          an <code className="nx-code">.nx-page-sidebar</code> should instead include only an error alert in the
-          event that the data for the page fails to load, or the user does not have permission to access that page,
-          or some similar error condition. The RSC styles have specific support for this case:
-          an <code className="nx-code">.nx-alert</code> that is the only child of
-          the <code className="nx-code">.nx-page-content</code> element will correctly center itself on the page.
-          To view this in action, click the link below.
-        </p>
-        <p className="nx-p">
-          <a className="nx-text-link" href="#/PageLevelAlertExample">
-            Click here to navigate to the live example.
-          </a>
-        </p>
-        <p className="nx-p">
-          In terms of how an application would integrate such an alert, most typically
-          an <code className="nx-code">NxLoadWrapper</code> would be used which wraps
-          the <code className="nx-code">.nx-page-main</code> and
-          (optional) <code className="nx-code">.nx-page-sidebar</code> elements.
-        </p>
-      </div>
-    </section>
   </>;
 
 export default NxAlertPage;

--- a/gallery/src/styles/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertPage.tsx
@@ -54,6 +54,38 @@ const NxAlertPage = () =>
                         codeExamples={nxAlertErrorCode}>
       An <code className="nx-code">nx-alert</code> demonstrating error styles.
     </GalleryExampleTile>
+
+    <section className="nx-tile">
+      <header className="nx-tile-header">
+        <div className="nx-tile-header__title">
+          <h2 className="nx-h2">Alert at the Page level</h2>
+        </div>
+      </header>
+      <div className="nx-tile-content">
+        <p className="nx-p">
+          It is frequently the case that an alert should be conditionally displayed as the entirety of the page
+          contents – that is, that a page which would typically include
+          an <code className="nx-code">.nx-page-main</code> and perhaps
+          an <code className="nx-code">.nx-page-sidebar</code> should instead include only an error alert in the
+          event that the data for the page fails to load, or the user does not have permission to access that page,
+          or some similar error condition. The RSC styles have specific support for this case:
+          an <code className="nx-code">.nx-alert</code> that is the only child of
+          the <code className="nx-code">.nx-page-content</code> element will correctly center itself on the page.
+          To view this in action, click the link below.
+        </p>
+        <p className="nx-p">
+          <a className="nx-text-link" href="#/PageLevelErrorExample">
+            Click here to navigate to the live example.
+          </a>
+        </p>
+        <p className="nx-p">
+          In terms of how an application would integrate such an alert, most typically
+          an <code className="nx-code">NxLoadWrapper</code> would be used which wraps
+          the <code className="nx-code">.nx-page-main</code> and
+          (optional) <code className="nx-code">.nx-page-sidebar</code> elements.
+        </p>
+      </div>
+    </section>
   </>;
 
 export default NxAlertPage;

--- a/gallery/src/styles/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertPage.tsx
@@ -74,7 +74,7 @@ const NxAlertPage = () =>
           To view this in action, click the link below.
         </p>
         <p className="nx-p">
-          <a className="nx-text-link" href="#/PageLevelErrorExample">
+          <a className="nx-text-link" href="#/PageLevelAlertExample">
             Click here to navigate to the live example.
           </a>
         </p>

--- a/gallery/visualtests/nxAlert.js
+++ b/gallery/visualtests/nxAlert.js
@@ -37,4 +37,17 @@ describe('NxAlert', function() {
   describe('NxWarningAlert', function() {
     it('looks right', simpleTest(warningSelector));
   });
+
+  describe('Page-level NxAlert', function() {
+    beforeEach(async function() {
+      await browser.url('#/PageLevelAlertExample');
+    });
+
+    it('looks right using page-scrolling', simpleTest('.nx-alert'));
+
+    it('looks right using section scrolling', async function() {
+      await browser.url('#/PageLevelAlertExample?disablePageScrolling=true');
+      await simpleTest('.nx-alert')();
+    });
+  });
 });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -41,6 +41,12 @@
   max-width: $nx-page-width-max;
   overflow-y: hidden;
   width: 100%;
+
+  // page-load errors are often at this level and not encapsulated within a nx-page-sidebar or nx-page-main
+  > .nx-alert {
+    align-self: flex-start;
+    margin: $nx-spacing-xl auto 0 auto;
+  }
 }
 
 .nx-page-sidebar {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -85,13 +85,13 @@
   }
 
   .nx-page-header {
-    position: fixed;
+    position: sticky;
     top: 0;
     left: 0;
     z-index: 1;
   }
 
   .nx-page-content {
-    margin: $nx-main-header-height auto 0 auto;
+    margin: 0 auto;
   }
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-434

While talking to @regoarrarr today we found that it's going to be common for applications to wrap both their `.nx-page-main` and `.nx-page-sidebar` in a single `NxLoadWrapper` - which would place the error alert as a direct child of the `.nx-page-content`.  This PR adds support for that placement.