### PR TITLE
Do not allow NxTreeView to collapse or expand when disabled - RSC-78

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTreeView/NxTreeView.tsx
+++ b/lib/src/components/NxTreeView/NxTreeView.tsx
@@ -19,8 +19,7 @@ import './NxTreeView.scss';
 
 const NxTreeView: FunctionComponent<Props> =
   function NxTreeView(props) {
-    const { onToggleCollapse, isOpen, disabled, children, triggerContent, triggerTooltip, className, id } = props,
-        onTriggerClick = disabled ? undefined : (onToggleCollapse || undefined);
+    const { onToggleCollapse, isOpen, disabled, children, triggerContent, triggerTooltip, className, id } = props;
 
     const isEmpty = !React.Children.count(children),
         isExpanded = isOpen && !isEmpty, // conceptually we don't allow empty tree views to expand
@@ -33,10 +32,10 @@ const NxTreeView: FunctionComponent<Props> =
         treeViewId = useMemo(() => id || getRandomId('nx-tree-view'), [id]),
         trigger = (
           <button className="nx-tree-view__trigger"
-                  onClick={onTriggerClick}
+                  onClick={onToggleCollapse || undefined}
                   aria-controls={treeViewId}
                   aria-expanded={isExpanded}
-                  aria-disabled={disabled || isEmpty || undefined}>
+                  disabled={disabled || isEmpty || undefined}>
             <NxFontAwesomeIcon className="nx-tree-view__twisty" icon={faCaretRight} />
             <span className="nx-tree-view__text">
               {triggerContent}

--- a/lib/src/components/NxTreeView/NxTreeView.tsx
+++ b/lib/src/components/NxTreeView/NxTreeView.tsx
@@ -19,7 +19,8 @@ import './NxTreeView.scss';
 
 const NxTreeView: FunctionComponent<Props> =
   function NxTreeView(props) {
-    const { onToggleCollapse, isOpen, disabled, children, triggerContent, triggerTooltip, className, id } = props;
+    const { onToggleCollapse, isOpen, disabled, children, triggerContent, triggerTooltip, className, id } = props,
+        onTriggerClick = disabled ? undefined : (onToggleCollapse || undefined);
 
     const isEmpty = !React.Children.count(children),
         isExpanded = isOpen && !isEmpty, // conceptually we don't allow empty tree views to expand
@@ -32,7 +33,7 @@ const NxTreeView: FunctionComponent<Props> =
         treeViewId = useMemo(() => id || getRandomId('nx-tree-view'), [id]),
         trigger = (
           <button className="nx-tree-view__trigger"
-                  onClick={onToggleCollapse || undefined}
+                  onClick={onTriggerClick}
                   aria-controls={treeViewId}
                   aria-expanded={isExpanded}
                   aria-disabled={disabled || isEmpty || undefined}>

--- a/lib/src/components/NxTreeView/__tests__/NxTreeView.test.tsx
+++ b/lib/src/components/NxTreeView/__tests__/NxTreeView.test.tsx
@@ -108,23 +108,23 @@ describe('NxTreeView', function() {
       })).toHaveProp('aria-expanded', true);
     });
 
-    it('sets aria-disabled if the disabled prop is set to true or there are no children', function() {
-      expect(getShallowTrigger()).toHaveProp('aria-disabled', true);
-      expect(getShallowTrigger({ disabled: true })).toHaveProp('aria-disabled', true);
-      expect(getShallowTrigger({ disabled: false })).toHaveProp('aria-disabled', true);
-      expect(getShallowTrigger({ disabled: null })).toHaveProp('aria-disabled', true);
-      expect(getShallowTrigger({ disabled: undefined })).toHaveProp('aria-disabled', true);
+    it('sets disabled if the disabled prop is set to true or there are no children', function() {
+      expect(getShallowTrigger()).toHaveProp('disabled', true);
+      expect(getShallowTrigger({ disabled: true })).toHaveProp('disabled', true);
+      expect(getShallowTrigger({ disabled: false })).toHaveProp('disabled', true);
+      expect(getShallowTrigger({ disabled: null })).toHaveProp('disabled', true);
+      expect(getShallowTrigger({ disabled: undefined })).toHaveProp('disabled', true);
 
       expect(getShallowTrigger({
         children: <span>child</span>,
         disabled: true
-      })).toHaveProp('aria-disabled', true);
+      })).toHaveProp('disabled', true);
 
-      expect(getShallowTrigger({ children: <span>child</span> })).toHaveProp('aria-disabled', undefined);
+      expect(getShallowTrigger({ children: <span>child</span> })).toHaveProp('disabled', undefined);
       expect(getShallowTrigger({
         children: <span>child</span>,
         disabled: false
-      })).toHaveProp('aria-disabled', undefined);
+      })).toHaveProp('disabled', undefined);
     });
 
     it('fires the components onToggleCollapse when clicked', function() {
@@ -134,14 +134,6 @@ describe('NxTreeView', function() {
       expect(onToggleCollapse).not.toHaveBeenCalled();
       trigger.simulate('click');
       expect(onToggleCollapse).toHaveBeenCalled();
-    });
-
-    it('does not fire the components onToggleCollapse when disabled', function() {
-      const onToggleCollapse = jest.fn(),
-          trigger = getShallowTrigger({ onToggleCollapse, disabled: true });
-
-      trigger.simulate('click');
-      expect(onToggleCollapse).not.toHaveBeenCalled();
     });
 
     it('contains an nx-tree-view__twisty icon', function() {

--- a/lib/src/components/NxTreeView/__tests__/NxTreeView.test.tsx
+++ b/lib/src/components/NxTreeView/__tests__/NxTreeView.test.tsx
@@ -136,6 +136,14 @@ describe('NxTreeView', function() {
       expect(onToggleCollapse).toHaveBeenCalled();
     });
 
+    it('does not fire the components onToggleCollapse when disabled', function() {
+      const onToggleCollapse = jest.fn(),
+          trigger = getShallowTrigger({ onToggleCollapse, disabled: true });
+
+      trigger.simulate('click');
+      expect(onToggleCollapse).not.toHaveBeenCalled();
+    });
+
     it('contains an nx-tree-view__twisty icon', function() {
       expect(getShallowTrigger().find(NxFontAwesomeIcon)).toHaveClassName('nx-tree-view__twisty');
     });


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-78

The only issue described in this ticket which still exists is that the various NxTreeView*Select components had inconsistent behavior with regards to whether they can collapse or expand when disabled.  To fix this I have added logic to the underlying `NxTreeView` component to disallow it from collapsing or expanding when disabled.  I am not however certain that this is the desired behavior, so I'd like input from Design on that. @dturner32 