### PR TITLE
Fix min-height props on nx-viewport-sized - RSC-446

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-viewport-sized.scss
+++ b/lib/src/base-styles/_nx-viewport-sized.scss
@@ -16,7 +16,6 @@
     flex: none;
     margin-top: 0;
     width: 100%;
-    min-height: 0;
   }
 }
 
@@ -24,10 +23,13 @@
 .nx-viewport-sized__container {
   display: flex;
   flex-direction: column;
+}
+
+.nx-viewport-sized__container, .nx-viewport-sized__scrollable {
   flex: auto;
+  min-height: 0;
 }
 
 .nx-viewport-sized__scrollable {
-  flex: auto;
   max-height: unset;
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-446

The flex items within the `nx-viewport-sized` system need to be able to shrink to fit, beyond their min instrinsic width.  The way we accomplish this is with `min-height: auto` (sidenote: `overflow: hidden` is another way but has side-effects).  Before this PR, however, `min-height: 0` was being applied via 
```
.nx-viewport-sized__container > *, .nx-viewport-sized > *
```

This was problematic on two fronts.  One, it was applying it to all children, not just the one that needs to shrink.  Two, it would fail to apply to the appropriate element where are are intevening elements with `display: contents` as is often the case in IQ due to angular components rendered by the ui-router.

This PR fixes this by simply applying the `min-height` directly to `.nx-viewport-sized__container` and `.nx-viewport-sized__scrollable`.