### PR TITLE
Set default monospace font <pre> fix RSC-176

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -83,6 +83,7 @@
 }
 
 %nx-pre {
+  @include monospace();
   background-color: #fff;
   border: 1px solid $nx-grey-900;
   border-left-width: 8px;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-176

I debated directly styling `<pre>` & `<code>` elements but didn't just to stay consistent (as in we rarely directly style HTML elements) with the rest of RSC (though of course I did end up directly styling `<code>` within `.nx-pre` but that's a special case for `NxVulnerabilityDetails`