### PR TITLE
POC: Main section scrollbar at edge of viewport - RSC-140

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -59,7 +59,7 @@ $nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2), 0px));
 
   background-color: $nx-sidebar-background-color;
   box-sizing: border-box;
-  flex: 1 0 ($nx-page-width-min * $nx-sidebar-proportion);
+  flex: 1 0 ($nx-page-width-min * $nx-sidebar-proportion - $nx-scrollbar-width);
   max-width: $nx-page-width-max * $nx-sidebar-proportion;
   overflow-x: hidden;
   padding: $nx-spacing-xl $nx-spacing-l $nx-spacing-xs $nx-spacing-l;
@@ -71,8 +71,7 @@ $nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2), 0px));
   @include container-vertical;
 
   box-sizing: content-box;
-  flex: 1 0 ($nx-page-width-min * $nx-content-proportion);
-  //max-width: $nx-page-width-max * $nx-content-proportion - (2 * $nx-spacing-l);
+  flex: 1 0 ($nx-page-width-min * $nx-content-proportion - (2 * $nx-spacing-l) - $nx-scrollbar-width);
   overflow-x: hidden;
   overflow-y: auto;
   padding: $nx-spacing-xl calc(#{$nx-page-side-padding} + #{$nx-spacing-l}) $nx-spacing-md $nx-spacing-l;

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -5,6 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 
+// note: the outer calc call below is just necessary to keep sass from getting confused
+$nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2) + #{$nx-spacing-l}, #{$nx-spacing-l}));
+
 /*
   #Layout
 */
@@ -38,7 +41,7 @@
   box-sizing: border-box;
   display: flex;
   flex-grow: 1;
-  max-width: $nx-page-width-max;
+  justify-content: flex-end;
   overflow-y: hidden;
   width: 100%;
 
@@ -54,7 +57,8 @@
 
   background-color: $nx-sidebar-background-color;
   box-sizing: border-box;
-  flex-basis: $nx-sidebar-width;
+  flex: 1 0 ($nx-page-width-min * $nx-sidebar-proportion);
+  max-width: $nx-page-width-max * $nx-sidebar-proportion;
   overflow-x: hidden;
   padding: $nx-spacing-xl $nx-spacing-l $nx-spacing-xs $nx-spacing-l;
   position: relative;
@@ -64,11 +68,12 @@
 .nx-page-main {
   @include container-vertical;
 
-  box-sizing: border-box;
-  flex: 1 0 $nx-content-width;
+  box-sizing: content-box;
+  flex: 1 0 ($nx-page-width-min * $nx-content-proportion);
+  max-width: $nx-page-width-max * $nx-content-proportion - (2 * $nx-spacing-l);
   overflow-x: hidden;
   overflow-y: auto;
-  padding: $nx-spacing-xl $nx-spacing-l $nx-spacing-md $nx-spacing-l;
+  padding: $nx-spacing-xl $nx-page-side-padding $nx-spacing-md $nx-spacing-l;
   white-space: normal;
 }
 
@@ -93,5 +98,10 @@
 
   .nx-page-content {
     margin: 0 auto;
+    justify-content: center;
+  }
+
+  .nx-page-main {
+    padding-right: $nx-spacing-l;
   }
 }

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -6,7 +6,7 @@
  */
 
 // note: the outer calc call below is just necessary to keep sass from getting confused
-$nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2) + #{$nx-spacing-l}, #{$nx-spacing-l}));
+$nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2), 0px));
 
 /*
   #Layout
@@ -43,7 +43,9 @@ $nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2) + #{$nx-sp
   flex-grow: 1;
   justify-content: flex-end;
   overflow-y: hidden;
+  padding-left: $nx-page-side-padding;
   width: 100%;
+  max-width: $nx-page-width-max;
 
   // page-load errors are often at this level and not encapsulated within a nx-page-sidebar or nx-page-main
   > .nx-alert {
@@ -70,10 +72,10 @@ $nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2) + #{$nx-sp
 
   box-sizing: content-box;
   flex: 1 0 ($nx-page-width-min * $nx-content-proportion);
-  max-width: $nx-page-width-max * $nx-content-proportion - (2 * $nx-spacing-l);
+  //max-width: $nx-page-width-max * $nx-content-proportion - (2 * $nx-spacing-l);
   overflow-x: hidden;
   overflow-y: auto;
-  padding: $nx-spacing-xl $nx-page-side-padding $nx-spacing-md $nx-spacing-l;
+  padding: $nx-spacing-xl calc(#{$nx-page-side-padding} + #{$nx-spacing-l}) $nx-spacing-md $nx-spacing-l;
   white-space: normal;
 }
 
@@ -98,6 +100,7 @@ $nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2) + #{$nx-sp
 
   .nx-page-content {
     margin: 0 auto;
+    padding: 0;
     justify-content: center;
   }
 

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -45,7 +45,6 @@ $nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2), 0px));
   overflow-y: hidden;
   padding-left: $nx-page-side-padding;
   width: 100%;
-  max-width: $nx-page-width-max;
 
   // page-load errors are often at this level and not encapsulated within a nx-page-sidebar or nx-page-main
   > .nx-alert {
@@ -98,9 +97,10 @@ $nx-page-side-padding: calc(max(((100vw - #{$nx-page-width-max}) / 2), 0px));
   }
 
   .nx-page-content {
+    justify-content: center;
     margin: 0 auto;
     padding: 0;
-    justify-content: center;
+    max-width: $nx-page-width-max;
   }
 
   .nx-page-main {

--- a/lib/src/scss-shared/_nx-variables.scss
+++ b/lib/src/scss-shared/_nx-variables.scss
@@ -13,8 +13,8 @@ $nx-main-header-height: 72px;
 
 $nx-page-width-max: 1600px;
 $nx-page-width-min: 1366px;
-$nx-content-width: 76%;
-$nx-sidebar-width: 100% - $nx-content-width;
+$nx-content-proportion: 0.76;
+$nx-sidebar-proportion: 1 - $nx-content-proportion;
 
 $nx-paragraph-width-maximum: 562px;
 $nx-form-label-width-maximum: 562px;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-140

I admit this change does make things look nicer, but it makes the styling much more complicated, and more inconsistent/asymmetrical.

Before:
![image](https://user-images.githubusercontent.com/3630091/105413266-de598c80-5c03-11eb-8871-a3ee0747f0a7.png)

After:
![image](https://user-images.githubusercontent.com/3630091/105073513-28e8d680-5a55-11eb-8c20-6167fdc5aaa3.png)
