### PR TITLE
Document supported node version - RSC-452

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,8 @@ The RSC code is split into two separate codebases: the library itself which live
 
 ## Building
 
-### Required software
-Node 10.16.0
-npm 6.7.0
+### Required Software
+Node 10.x or 12.x.  Node 14.x is known not to work currently.
 yarn 1.21.1
 
 ### Installation of Dependencies

--- a/README.md
+++ b/README.md
@@ -157,19 +157,19 @@ yarn 1.21.1
 In the lib/ directory, run `yarn install`
 
 ### Build
-For a one-time build, `npm run build` in the lib/ directory.
+For a one-time build, `yarn run build` in the lib/ directory.
 
-When developing, you probably want to use `npm run watch` instead.
+When developing, you probably want to use `yarn run watch` instead.
 
 ## Running Unit Tests
 
 Run the following commands in the lib/ directory
 
 ### Single run
-`npm run test`
+`yarn run test`
 
 ### Watch in console
-`npm run test-watch`
+`yarn run test-watch`
 
 ### Watch in console, debug in browser
 
@@ -177,7 +177,7 @@ Jest runs in node, as opposed to in a browser like some other test setups. This 
 a little bit more difficult.
 
 To debug the unit tests, take the following steps
-* Run `npm run test-watch-debug` in the console
+* Run `yarn run test-watch-debug` in the console
 * Go to `chrome://inspect` in Google Chrome
 * Find and connect to the node process in Chrome by clicking Inspect in Chrome (this will open up a Chrome Dev Tools
 window)
@@ -192,11 +192,11 @@ hits.
 You can view components in your browser by running the gallery.
 
 ### Installation
-First, ensure the component library is built using `npm run build` or `npm run watch` from the lib/ dir. Then, from
+First, ensure the component library is built using `yarn run build` or `yarn run watch` from the lib/ dir. Then, from
 gallery/, run `yarn install`.
 
 ### Running the Gallery
-From gallery/, run `npm start`.
+From gallery/, run `yarn start`.
 
 To view the gallery, point your browser to `http://localhost:4043/`.
 
@@ -207,6 +207,6 @@ number from what is on master - this way, when the branch is merged, a new relea
 human-specified semantic version from the branch_.
 
 To increment the version on your branch, use the following command in the lib/ directory:
-`npm version --no-git-tag-version <new_version>`.
+`yarn version --no-git-tag-version (--patch|--minor|--major)`.
 This will ensure that the version number gets updated in all of the appropriate places (both package.json files and
 both package-lock.json files). Do not create or push git tags for versions, as the master CI build does that.

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-452

Turns out we already do this, but I've updated it and expanded it slightly.