### PR TITLE
Color Swatch Variables: pink green orange yellow red turquoise - RSC-61 RSC-456 RSC-457 RSC-458 RSC-459 RSC-460 RSC-461

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.3.12",
+  "version": "3.4.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.3.12",
+  "version": "3.4.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -7,7 +7,7 @@
 
 // Blues
 $nx-blue-1000: #15203e;
-$nx-blue-900: #00306F;
+$nx-blue-900: #00306f;
 $nx-blue-800: #034396;
 $nx-blue-700: #0055c3;
 $nx-blue-600: #045dd1;

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -96,3 +96,15 @@ $nx-yellow-300: #ffe3a0;
 $nx-yellow-200: #ffebba;
 $nx-yellow-100: #fff3d5;
 $nx-yellow-50: #fff8e8;
+
+// Red
+$nx-red-1000: #a80222;
+$nx-red-900: #be0226;
+$nx-red-700: #e20833;
+$nx-red-600: #f42951;
+$nx-red-500: #fc496c;
+$nx-red-400: #ff656a;
+$nx-red-300: #ff8286;
+$nx-red-200: #ff979a;
+$nx-red-100: #ffb6b8;
+$nx-red-50: #ffcbcc;

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -44,3 +44,16 @@ $nx-teal-300: #02a6d9;
 $nx-teal-200: #00ade2;
 $nx-teal-100: #07baf1;
 $nx-teal-50: #38d0ff;
+
+// Pinks
+$nx-pink-1000: #b6006b;
+$nx-pink-900: #cd0079;
+$nx-pink-800: #e10486;
+$nx-pink-700: #e5379c;
+$nx-pink-600: #f245ab;
+$nx-pink-500: #ea5db0;
+$nx-pink-400: #f677c2;
+$nx-pink-300: #ff90d1;
+$nx-pink-200: #ffacdd;
+$nx-pink-100: #ffd7ef;
+$nx-pink-50: #ffecf7;

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -108,3 +108,16 @@ $nx-red-300: #ff8286;
 $nx-red-200: #ff979a;
 $nx-red-100: #ffb6b8;
 $nx-red-50: #ffcbcc;
+
+// Turquoise
+$nx-turquoise-1000: #02847a;
+$nx-turquoise-900: #019085;
+$nx-turquoise-800: #049f93;
+$nx-turquoise-700: #00ada0;
+$nx-turquoise-600: #21c3b7;
+$nx-turquoise-500: #29ccc0;
+$nx-turquoise-400: #3cd6cb;
+$nx-turquoise-300: #5bddd3;
+$nx-turquoise-200: #79e2da;
+$nx-turquoise-100: #8eece4;
+$nx-turquoise-50: #affaf4;

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -83,3 +83,16 @@ $nx-orange-300: #ffcd96;
 $nx-orange-200: #ffdbb4;
 $nx-orange-100: #ffe7cc;
 $nx-orange-50: #fff0e0;
+
+// Yellow
+$nx-yellow-1000: #d99b07;
+$nx-yellow-900: #eaaa12;
+$nx-yellow-800: #f5b827;
+$nx-yellow-700: #ffbf27;
+$nx-yellow-600: #ffcb4e;
+$nx-yellow-500: #ffd267;
+$nx-yellow-400: #ffda82;
+$nx-yellow-300: #ffe3a0;
+$nx-yellow-200: #ffebba;
+$nx-yellow-100: #fff3d5;
+$nx-yellow-50: #fff8e8;

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -57,3 +57,16 @@ $nx-pink-300: #ff90d1;
 $nx-pink-200: #ffacdd;
 $nx-pink-100: #ffd7ef;
 $nx-pink-50: #ffecf7;
+
+// Green
+$nx-green-1000: #005118;
+$nx-green-900: #005f1c;
+$nx-green-800: #006a20;
+$nx-green-700: #007623;
+$nx-green-600: #008728;
+$nx-green-500: #00962c;
+$nx-green-400: #00ab32;
+$nx-green-300: #09bd3e;
+$nx-green-200: #2dcc5c;
+$nx-green-100: #86ee5c;
+$nx-green-50: #b2f795;

--- a/lib/src/scss-shared/_nx-color-swatches.scss
+++ b/lib/src/scss-shared/_nx-color-swatches.scss
@@ -70,3 +70,16 @@ $nx-green-300: #09bd3e;
 $nx-green-200: #2dcc5c;
 $nx-green-100: #86ee5c;
 $nx-green-50: #b2f795;
+
+// Orange
+$nx-orange-1000: #c96900;
+$nx-orange-900: #e37d0d;
+$nx-orange-800: #ec8c24;
+$nx-orange-700: #fe9522;
+$nx-orange-600: #ffa440;
+$nx-orange-500: #ffb15c;
+$nx-orange-400: #ffbd74;
+$nx-orange-300: #ffcd96;
+$nx-orange-200: #ffdbb4;
+$nx-orange-100: #ffe7cc;
+$nx-orange-50: #fff0e0;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-61
https://issues.sonatype.org/browse/RSC-456
https://issues.sonatype.org/browse/RSC-457
https://issues.sonatype.org/browse/RSC-458
https://issues.sonatype.org/browse/RSC-459
https://issues.sonatype.org/browse/RSC-460
https://issues.sonatype.org/browse/RSC-461

Adds the color variables for 6 different swatches.  This PR _does not_ replace existing color literals with the new variables; I will do that in one or more additional PRs