### PR TITLE
Avoid position:absolute in checkboxes - RSC-474

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -103,8 +103,9 @@ svg.nx-radio-checkbox__control {
 .nx-radio-checkbox__input {
   margin: 0;
   width: 0;
-  position: absolute;
-  z-index: -1;
+
+  // in FF, the checkboxes don't respect the width: 0 and we need this in order to hide them
+  -moz-appearance: none;
 
   &:focus {
     // less-nice IE11 focus style because IE11 doesn't support :focus-within

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -105,6 +105,7 @@ svg.nx-radio-checkbox__control {
   width: 0;
 
   // in FF, the checkboxes don't respect the width: 0 and we need this in order to hide them
+  // Fix discovered via the title of https://bugzilla.mozilla.org/show_bug.cgi?id=605985
   -moz-appearance: none;
 
   &:focus {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-474

Should fix the double scrollbar issue with the IQ dashboard.