### PR TITLE
Add border to bottom table row - RSC-470 RSC-477

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -116,7 +116,7 @@
   > .nx-table {
     border-style: none;
     border-radius: 0;
-    margin: 0;
+    margin: 0 0 auto 0;
     overflow: visible;
 
     // In Chrome (at least), tables are forced to have a whole number of pixels for their width. This means that
@@ -125,7 +125,7 @@
     // pixel of width
     width: calc(100% + 0.9999px);
 
-    > thead > :first-child, > tbody > :last-child {
+    > thead > :first-child {
       > .nx-cell {
         &:first-child, &:last-child {
           border-radius: 0;
@@ -133,10 +133,24 @@
       }
     }
 
+    > tbody > :last-child {
+      > .nx-cell {
+        &:first-child, &:last-child {
+          border-radius: 0;
+        }
+
+        border-bottom-style: solid;
+      }
+    }
+
     .nx-cell--header {
       position: sticky;
       top: 0;
       z-index: 1;
+    }
+
+    &:last-child > tbody > :last-child > .nx-cell {
+      border-bottom-style: none;
     }
   }
 }
@@ -151,8 +165,12 @@
 
   background-color: var(--nx-component-background-color);
   border-top: 1px solid #d1d6f0;
-  margin-top: auto;
-  padding: $nx-table-footer-vertical-padding;
+
+  // when following a table with no space between, merge the table's bottom border and the pagination's top border
+  transform: translateY(-1px);
+
+  // subtract 1 from bottom padding to counteract the translateY above
+  padding: $nx-table-footer-vertical-padding $nx-spacing-l ($nx-table-footer-vertical-padding - 1px) $nx-spacing-l;
   position: sticky;
   bottom: 0;
   z-index: 1;

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -116,7 +116,7 @@
   > .nx-table {
     border-style: none;
     border-radius: 0;
-    margin: 0 0 auto 0;
+    margin: 0;
     overflow: visible;
 
     // In Chrome (at least), tables are forced to have a whole number of pixels for their width. This means that
@@ -165,6 +165,7 @@
 
   background-color: var(--nx-component-background-color);
   border-top: 1px solid #d1d6f0;
+  margin-top: auto;
 
   // when following a table with no space between, merge the table's bottom border and the pagination's top border
   transform: translateY(-1px);

--- a/lib/src/components/NxTable/NxTableRow.tsx
+++ b/lib/src/components/NxTable/NxTableRow.tsx
@@ -23,7 +23,7 @@ const NxTableRow = function NxTableRow(props: NxTableRowProps) {
   });
 
   return (
-    <tr tabIndex={isClickable ? 0 : -1} className={classes} {...attrs}>{children}</tr>
+    <tr tabIndex={isClickable ? 0 : undefined} className={classes} {...attrs}>{children}</tr>
   );
 };
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-470
On the IQ dashboard they noticed that when an nx-table-container is stretched to be taller than the actual table content (as typically happens with `nx-viewport-sized` when the table has few rows) the bottom row of the table has now bottom border and just expands into the great white void below.  Design says there should be a border there.  This is tricky, because we don't want that border to be visible in other cases where the last row is immediately adjacent to another border, such as the bottom border of the table or table container itself, or a pagination footer.


https://issues.sonatype.org/browse/RSC-477
This is also fixed in this PR - I discovered this bug while working on RSC-470 and it was small and in the same part of the code so I went ahead and fixed it.