### PR TITLE
NxToggle gapless RSC-484 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxToggle/NxToggleGaplessExample.tsx
+++ b/gallery/src/components/NxToggle/NxToggleGaplessExample.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { useState } from 'react';
+
+import { NxToggle } from '@sonatype/react-shared-components';
+
+function NxToggleExample() {
+  // this example uses the `useState` hook for succinctness, but you could also manage the state manually
+  // in a class component
+  const [isWarpOn, setIsWarpOn] = useState(false),
+      [isKrakenOut, setIsKrakenOut] = useState(false),
+      [isShapes, setIsShapes] = useState(false),
+      toggleWarp = () => setIsWarpOn(!isWarpOn),
+      toggleKraken = () => setIsKrakenOut(!isKrakenOut),
+      toggleShapes = () => setIsShapes(!isShapes);
+
+  return (
+    <>
+      <NxToggle className="nx-toggle--no-gap" inputId="subscribe-check" onChange={toggleWarp} isChecked={isWarpOn}>
+        Start Epstein Drive
+      </NxToggle>
+      <NxToggle className="nx-toggle--no-gap" inputId="no-label-check" onChange={toggleKraken} isChecked={isKrakenOut}>
+        Release all the Krakens immediately
+      </NxToggle>
+      <NxToggle className="nx-toggle--no-gap" inputId="children-check" onChange={toggleShapes} isChecked={isShapes}>
+        Allow shapes - like a circle, a perfectly round SVG circle, pleasing to the eye, not too big and not too
+        small, just right to appear beside a checkbox and demonstrate that the label wraps
+      </NxToggle>
+      <p>
+        {isWarpOn && 'Warp drive started'} {isKrakenOut && ' The Kraken is out!'}
+      </p>
+    </>
+  );
+}
+
+export default NxToggleExample;

--- a/gallery/src/components/NxToggle/NxToggleGaplessExample.tsx
+++ b/gallery/src/components/NxToggle/NxToggleGaplessExample.tsx
@@ -9,8 +9,6 @@ import React, { useState } from 'react';
 import { NxToggle } from '@sonatype/react-shared-components';
 
 function NxToggleExample() {
-  // this example uses the `useState` hook for succinctness, but you could also manage the state manually
-  // in a class component
   const [isWarpOn, setIsWarpOn] = useState(false),
       [isKrakenOut, setIsKrakenOut] = useState(false),
       [isShapes, setIsShapes] = useState(false),
@@ -31,7 +29,7 @@ function NxToggleExample() {
         small, just right to appear beside a checkbox and demonstrate that the label wraps
       </NxToggle>
       <p>
-        {isWarpOn && 'Warp drive started'} {isKrakenOut && ' The Kraken is out!'}
+        {isWarpOn && 'Warp drive started'} {isKrakenOut && ' The Kraken is out!'} {isShapes && ' Shapes are allowed.'}
       </p>
     </>
   );

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -9,8 +9,10 @@ import React from 'react';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxToggleExample from './NxToggleExample';
+import NxToggleGaplessExample from './NxToggleGaplessExample';
 
-const exampleCode = require('!!raw-loader!./NxToggleExample').default;
+const exampleCode = require('!!raw-loader!./NxToggleExample').default,
+    exampleGaplessCode = require('!!raw-loader!./NxToggleGaplessExample').default;
 
 const NxTogglePage = () =>
   <>
@@ -83,6 +85,12 @@ const NxTogglePage = () =>
                         liveExample={NxToggleExample}>
       This example shows a series of toggle controls in a typical vertical layout with
       different label content. Note that one of the toggle controls is disabled.
+    </GalleryExampleTile>
+    <GalleryExampleTile title="General NxToggle Gapless Example"
+                        id="nx-toggle-gapless-example"
+                        codeExamples={exampleGaplessCode}
+                        liveExample={NxToggleGaplessExample}>
+      This example demonstrates a toggle control with only a small spacing gap between the text and the toggle itself.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -77,6 +77,30 @@ const NxTogglePage = () =>
           </tr>
         </tbody>
       </table>
+
+      <h3 className="nx-h3">CSS classes</h3>
+      <table className="nx-table">
+        <thead>
+          <tr className="nx-table-row">
+            <th className="nx-cell nx-cell--header">Class</th>
+            <th className="nx-cell nx-cell--header">Type</th>
+            <th className="nx-cell nx-cell--header">Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr className="nx-table-row">
+            <td className="nx-cell">.nx-toggle--no-gap</td>
+            <td className="nx-cell">Modifier of <code className="nx-code">.nx-toggle</code></td>
+            <td className="nx-cell">
+              When this class is applied to an <code className="nx-code">NxToggle</code> it causes the toggle to appear
+              immediately after the label text rather than appearing to float to the right of the toggle's container.
+              Note that the maximum width of the toggle remains in effect as do the rules around the length and
+              wrapping of the toggle's label. See the example below for a demonstration.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General NxToggle Example"
@@ -90,7 +114,7 @@ const NxTogglePage = () =>
                         id="nx-toggle-gapless-example"
                         codeExamples={exampleGaplessCode}
                         liveExample={NxToggleGaplessExample}>
-      This example demonstrates a toggle control with only a small spacing gap between the text and the toggle itself.
+      This example demonstrates a toggle control with only a small spacing gap between the label and the toggle control.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -92,15 +92,14 @@ const NxTogglePage = () =>
             <td className="nx-cell">.nx-toggle--no-gap</td>
             <td className="nx-cell">Modifier of <code className="nx-code">.nx-toggle</code></td>
             <td className="nx-cell">
-              When this class is applied to an <code className="nx-code">NxToggle</code> it causes the toggle to appear
-              immediately after the label text rather than appearing to float to the right of the toggle's container.
-              Note that the maximum width of the toggle remains in effect as do the rules around the length and
-              wrapping of the toggle's label. See the example below for a demonstration.
+              When this class is applied to an <code className="nx-code">NxToggle</code> it causes the toggle control
+              to appear immediately after the label text rather than appearing to float to the right of the toggle's
+              container. Note that the maximum width of the toggle remains in effect as do the rules around the length
+              and wrapping of the toggle's label. See the example below for a demonstration.
             </td>
           </tr>
         </tbody>
       </table>
-      
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General NxToggle Example"

--- a/gallery/visualtests/nxToggle.js
+++ b/gallery/visualtests/nxToggle.js
@@ -13,7 +13,8 @@ describe('NxToggle', function() {
   });
 
   const selector = '#nx-toggle-example .gallery-example-live label:nth-of-type(2)',
-      disabledSelector = '#nx-toggle-example .gallery-example-live label:nth-of-type(4)';
+      disabledSelector = '#nx-toggle-example .gallery-example-live label:nth-of-type(4)',
+      gaplessSelector = '#nx-toggle-gapless-example .gallery-example-live';
 
   describe('Default NxToggle', function() {
     it('has a blue border, blue indicator, and white background by default', simpleTest(selector));
@@ -81,5 +82,9 @@ describe('NxToggle', function() {
   describe('Attribute-Disabled NxToggle', function() {
     it('looks disabled by default', simpleTest(disabledSelector));
     it('looks disabled when hovered', hoverTest(disabledSelector));
+  });
+
+  describe('Gapless NxToggle', function() {
+    it('looks correct', simpleTest(gaplessSelector));
   });
 });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxToggle/NxToggle.scss
+++ b/lib/src/components/NxToggle/NxToggle.scss
@@ -95,3 +95,9 @@
 .nx-legend + .nx-toggle {
   margin-top: 0;
 }
+
+.nx-toggle--no-gap {
+  .nx-toggle__content {
+    flex-grow: 0;
+  }
+}


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-484

In the end I went with "gap" because I thought that changing the `max-width` of the control would be a mistake if the label was long.

