### PR TITLE
nx-cards with uniform structure - RSC-467

### DIFF
--- a/gallery/src/styles/NxCard/NxCardHorizontalLayoutExample.tsx
+++ b/gallery/src/styles/NxCard/NxCardHorizontalLayoutExample.tsx
@@ -14,13 +14,13 @@ export default function NxCardColumnLayoutExample() {
   return (
     <div className="nx-card-container nx-card-container--column">
       <section className="nx-card nx-card--horizontal" aria-label="card 1 in column layout">
-        <div className="nx-card__call-out">
-          42
-        </div>
+        <header className="nx-card__header">
+          <h3 className="nx-h3">Header</h3>
+        </header>
         <div className="nx-card__content">
-          <header className="nx-card__header">
-            <h3 className="nx-h3">Header</h3>
-          </header>
+          <div className="nx-card__call-out">
+            42
+          </div>
           <div className="nx-card__text">Text</div>
         </div>
         <div className="nx-card__actions">
@@ -28,13 +28,13 @@ export default function NxCardColumnLayoutExample() {
         </div>
       </section>
       <section className="nx-card nx-card--horizontal" aria-label="card 2 in column layout">
-        <div className="nx-card__call-out">
-          <NxFontAwesomeIcon icon={faShapes} className="nx-card__call-out-icon" />
-        </div>
+        <header className="nx-card__header">
+          <h3 className="nx-h3">Card header</h3>
+        </header>
         <div className="nx-card__content">
-          <header className="nx-card__header">
-            <h3 className="nx-h3">Card header</h3>
-          </header>
+          <div className="nx-card__call-out">
+            <NxFontAwesomeIcon icon={faShapes} className="nx-card__call-out-icon" />
+          </div>
           <div className="nx-card__text">Data point details</div>
         </div>
         <div className="nx-card__actions">
@@ -44,13 +44,13 @@ export default function NxCardColumnLayoutExample() {
         </div>
       </section>
       <section className="nx-card nx-card--horizontal" aria-label="card 3 in column layout">
-        <div className="nx-card__call-out">
-          <NxFontAwesomeIcon icon={faShapes} className="nx-card__call-out-icon--xl" />
-        </div>
+        <header className="nx-card__header">
+          <h3 className="nx-h3">Card header</h3>
+        </header>
         <div className="nx-card__content">
-          <header className="nx-card__header">
-            <h3 className="nx-h3">Card header</h3>
-          </header>
+          <div className="nx-card__call-out">
+            <NxFontAwesomeIcon icon={faShapes} className="nx-card__call-out-icon--xl" />
+          </div>
           <div className="nx-card__text">Large icon</div>
         </div>
         <div className="nx-card__actions">
@@ -62,10 +62,10 @@ export default function NxCardColumnLayoutExample() {
         </div>
       </section>
       <section className="nx-card nx-card--horizontal" aria-label="card 4 in column layout">
-        <div className="nx-card__call-out">
-          XX%
-        </div>
         <div className="nx-card__content">
+          <div className="nx-card__call-out">
+            XX%
+          </div>
           <div className="nx-card__text">Descriptive text</div>
         </div>
         <div className="nx-card__actions">
@@ -73,21 +73,23 @@ export default function NxCardColumnLayoutExample() {
         </div>
       </section>
       <section className="nx-card nx-card--horizontal" aria-label="card 5 in column layout">
+        <header className="nx-card__header">
+          <h3 className="nx-h3">Chiba advert hacker hotdog shoes voodoo god 3D-printed</h3>
+        </header>
         <div className="nx-card__content">
-          <header className="nx-card__header">
-            <h3 className="nx-h3">Chiba advert hacker hotdog shoes voodoo god 3D-printed</h3>
-          </header>
-          <img src={chart}/>
+          <div className="nx-card__text">
+            <img src={chart}/>
+          </div>
         </div>
       </section>
       <section className="nx-card nx-card--horizontal" aria-label="card 6 in column layout">
-        <div className="nx-card__call-out">
-          XXX%
-        </div>
+        <header className="nx-card__header">
+          <h3 className="nx-h3">Render-farm dolphin beef noodles</h3>
+        </header>
         <div className="nx-card__content">
-          <header className="nx-card__header">
-            <h3 className="nx-h3">Render-farm dolphin beef noodles</h3>
-          </header>
+          <div className="nx-card__call-out">
+            XXX%
+          </div>
           <div className="nx-card__text">City advert motion apophenia film skyscraper sentient beef</div>
         </div>
       </section>

--- a/gallery/src/styles/NxCard/NxCardVerticalLayoutExample.tsx
+++ b/gallery/src/styles/NxCard/NxCardVerticalLayoutExample.tsx
@@ -44,14 +44,14 @@ export default function NxCardRowLayoutExample() {
             <h3 className="nx-h3">Read only</h3>
           </header>
           <div className="nx-card__content">
-          <dl className="nx-read-only">
-            <dt className="nx-read-only__label">
-              Component Foo
-            </dt>
-            <dd className="nx-read-only__data">
-              Component Foo does not contain proprietary packages
-            </dd>
-          </dl>
+            <dl className="nx-read-only">
+              <dt className="nx-read-only__label">
+                Component Foo
+              </dt>
+              <dd className="nx-read-only__data">
+                Component Foo does not contain proprietary packages
+              </dd>
+            </dl>
           </div>
         </section>
         <section className="nx-card" aria-label="Icon in callout">

--- a/lib/src/base-styles/_nx-card.scss
+++ b/lib/src/base-styles/_nx-card.scss
@@ -66,10 +66,10 @@
 
 .nx-card--horizontal {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  grid-template-areas:
-    "callout content actions"
-    "callout content actions";
+  grid-template:
+    "callout header actions" auto
+    "callout text actions" 1fr /
+     auto    1fr   auto;
   margin-right: 0;
   margin-bottom: $nx-spacing-md;
   text-align: left;
@@ -77,14 +77,17 @@
 
   .nx-card__header {
     @include container-vertical;
+
+    grid-area: header;
+  }
+
+  .nx-card__text {
+    align-self: center;
+    grid-area: text;
   }
 
   .nx-card__content {
-    align-items: unset;
-    grid-area: content;
-    justify-content: center;
-    margin: 0;
-    row-gap: 0;
+    display: contents;
   }
 
   .nx-card__call-out {


### PR DESCRIPTION
Changes to make nx-card structure the same in both vertical and horizontal cards.  Re this thread: https://github.com/sonatype/sonatype-react-shared-components/pull/307#discussion_r576901741