### PR TITLE
NxAccordion remove ::marker in Firefox RSC-492

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxAccordion/NxAccordion.scss
+++ b/lib/src/components/NxAccordion/NxAccordion.scss
@@ -15,6 +15,9 @@
 }
 
 .nx-accordion__header {
+  // removes ::marker from FF
+  list-style-type: none; 
+
   &::-webkit-details-marker {
     display: none;
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-492

Turns out that FF requires different and pretty specific CSS to remove the `::marker`