### PR TITLE
removing stacking context from NxSegmentedButton RSC-491 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxSegmentedButton/NxSegmentedButton.scss
+++ b/lib/src/components/NxSegmentedButton/NxSegmentedButton.scss
@@ -11,7 +11,6 @@
 
   margin: 0 $nx-spacing-l;
   position: relative;
-  z-index: 0;
 
   .nx-dropdown-menu {
     left: auto;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-491

Removed `z-index: 0;` from the wrapping `<div>` and tested in the Gallery. 