### PR TITLE
Safari card fixes RSC-467

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxCard/NxCardLayoutExample.tsx
+++ b/gallery/src/styles/NxCard/NxCardLayoutExample.tsx
@@ -39,23 +39,21 @@ export default function NxCardRowLayoutExample() {
           </div>
           <footer className="nx-card__footer"><a href="#" className="nx-text-link">Link</a></footer>
         </section>
-        <section className="nx-card" aria-label="Card with NxReadOnly">
+        <section className="nx-card" aria-label="Server card">
+          <header className="nx-card__header">
+            <h3 className="nx-h3">Card header</h3>
+          </header>
           <div className="nx-card__content">
-            <dl className="nx-read-only">
-              <dt className="nx-read-only__label">
-                Component Foo
-              </dt>
-              <dd className="nx-read-only__data">
-                Component Foo does not contain proprietary packages
-              </dd>
-              <dt className="nx-read-only__label">
-                Component Bar
-              </dt>
-              <dd className="nx-read-only__data">
-                Component Bar does not contain proprietary packages
-              </dd>
-            </dl>
+            <div className="nx-status-indicator">
+              <span>Server one</span>
+            </div>
+            <div className="nx-status-indicator">
+              <span>Server two</span>
+            </div>
           </div>
+          <footer className="nx-card__footer">
+            <a href="#" className="nx-text-link">Link</a>
+          </footer>
         </section>
         <section className="nx-card" aria-label="Icon in callout">
           <header className="nx-card__header">
@@ -87,21 +85,23 @@ export default function NxCardRowLayoutExample() {
             <a href="#" className="nx-text-link">Link</a>
           </footer>
         </section>
-        <section className="nx-card" aria-label="Server card">
-          <header className="nx-card__header">
-            <h3 className="nx-h3">Card header</h3>
-          </header>
+        <section className="nx-card" aria-label="Card with NxReadOnly">
           <div className="nx-card__content">
-            <div className="nx-status-indicator">
-              <span>Server one</span>
-            </div>
-            <div className="nx-status-indicator">
-              <span>Server two</span>
-            </div>
+            <dl className="nx-read-only">
+              <dt className="nx-read-only__label">
+                Component Foo
+              </dt>
+              <dd className="nx-read-only__data">
+                Component Foo does not contain proprietary packages
+              </dd>
+              <dt className="nx-read-only__label">
+                Component Bar
+              </dt>
+              <dd className="nx-read-only__data">
+                Component Bar does not contain proprietary packages
+              </dd>
+            </dl>
           </div>
-          <footer className="nx-card__footer">
-            <a href="#" className="nx-text-link">Link</a>
-          </footer>
         </section>
         <section className="nx-card" aria-label="Card with content in columns">
           <header className="nx-card__header">

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-card.scss
+++ b/lib/src/base-styles/_nx-card.scss
@@ -35,7 +35,7 @@
   @supports (-webkit-appearance:none) and (display:flow-root) {
     .nx-card-container {
       @include container-horizontal;
-      margin-bottom: 0;
+      margin: 0;
     }
 
     .nx-card {

--- a/lib/src/base-styles/_nx-card.scss
+++ b/lib/src/base-styles/_nx-card.scss
@@ -6,12 +6,11 @@
  */
 
 .nx-card-container {
-  column-gap: $nx-spacing-md;
   display: flex;
   flex-wrap: wrap;
+  gap: $nx-spacing-md;
   justify-content: space-between;
   margin: $nx-spacing-md 0;
-  row-gap: $nx-spacing-md;
 }
 
 .nx-card-container--no-wrap {
@@ -29,6 +28,34 @@
   text-align: center;
   min-width: 230px;
   max-width: 330px;
+}
+
+// Safari does not support gap in flex layouts so we need to use this query and margin for Safari.
+@media not all and (min-resolution:.001dpcm) {
+  @supports (-webkit-appearance:none) and (display:flow-root) {
+    .nx-card-container {
+      @include container-horizontal;
+      margin-bottom: 0;
+    }
+
+    .nx-card {
+      margin-right: $nx-spacing-md;
+      margin-bottom: $nx-spacing-md;
+    }
+
+    .nx-card__content {
+      > :first-child {
+        margin-bottom: $nx-spacing-md;
+      }
+    }
+
+    .nx-card__content--columns {
+      > :first-child {
+        margin-right: $nx-spacing-md;
+        margin-bottom: 0;
+      }
+    }
+  }
 }
 
 .nx-card__header {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-467

Safari does not support the use of `gap` for `flex` layouts. I added a media query to target Safari which allows us to use `margin` for both internal and external spacing in Safari and `gap` for other browsers.

I also tweaked the examples because the last card in the first row _always_ wrapped but what I wanted to demonstrate was the first row wrapping at smaller viewport sizes.