### PR TITLE
Colour docs safari fixes RSC-143

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/guidelines/ColorPalette/Swatcher.scss
+++ b/gallery/src/guidelines/ColorPalette/Swatcher.scss
@@ -52,7 +52,7 @@
 @media not all and (min-resolution:.001dpcm) {
   @supports (-webkit-appearance:none) and (display:flow-root) {
     // override a default .nx-card style
-    .nx-card__content > :not(:last-child) {
+    .nx-card__content > .gallery-swatch {
       margin-bottom: 0;
     }
 

--- a/gallery/src/guidelines/ColorPalette/Swatcher.scss
+++ b/gallery/src/guidelines/ColorPalette/Swatcher.scss
@@ -19,12 +19,16 @@
   .nx-card__content {
     align-items: stretch;
     gap: 0;
+
+    // override Safari rule from .nx-card
+    & > .gallery-swatch {
+      margin-bottom: 0;
+    }
   }
 }
 
 .gallery-swatch {
   align-items: center;
-  column-gap: $nx-spacing-l;
   display: flex;
   flex-direction: row;
   text-align: left;
@@ -33,6 +37,7 @@
 .gallery-swatch__thumb {
   flex-shrink: 0;
   height: 64px;
+  margin-right: $nx-spacing-l;
   width: 64px;
 }
 
@@ -46,22 +51,5 @@
 
 .gallery-swatch__hex {
   flex-basis: 7ch;
-}
-
-// Safari does not support gap in flex layouts so we need to use this query and margin for Safari.
-@media not all and (min-resolution:.001dpcm) {
-  @supports (-webkit-appearance:none) and (display:flow-root) {
-    // override a default .nx-card style
-    .nx-card__content > .gallery-swatch {
-      margin-bottom: 0;
-    }
-
-    .gallery-swatch__thumb {
-      margin-right: $nx-spacing-l;
-    }
-
-    .gallery-swatch__hex {
-      margin-right: $nx-spacing-l;
-    }
-  }
+  margin-right: $nx-spacing-l;
 }

--- a/gallery/src/guidelines/ColorPalette/Swatcher.scss
+++ b/gallery/src/guidelines/ColorPalette/Swatcher.scss
@@ -47,3 +47,21 @@
 .gallery-swatch__hex {
   flex-basis: 7ch;
 }
+
+// Safari does not support gap in flex layouts so we need to use this query and margin for Safari.
+@media not all and (min-resolution:.001dpcm) {
+  @supports (-webkit-appearance:none) and (display:flow-root) {
+    // override a default .nx-card style
+    .nx-card__content > :first-child {
+      margin-bottom: 0;
+    }
+
+    .gallery-swatch__thumb {
+      margin-right: $nx-spacing-l;
+    }
+
+    .gallery-swatch__hex {
+      margin-right: $nx-spacing-l;
+    }
+  }
+}

--- a/gallery/src/guidelines/ColorPalette/Swatcher.scss
+++ b/gallery/src/guidelines/ColorPalette/Swatcher.scss
@@ -21,7 +21,7 @@
     gap: 0;
 
     // override Safari rule from .nx-card
-    & > .gallery-swatch {
+    > .gallery-swatch {
       margin-bottom: 0;
     }
   }

--- a/gallery/src/guidelines/ColorPalette/Swatcher.scss
+++ b/gallery/src/guidelines/ColorPalette/Swatcher.scss
@@ -52,7 +52,7 @@
 @media not all and (min-resolution:.001dpcm) {
   @supports (-webkit-appearance:none) and (display:flow-root) {
     // override a default .nx-card style
-    .nx-card__content > :first-child {
+    .nx-card__content > :not(:last-child) {
       margin-bottom: 0;
     }
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-143

Safari doesn't support `gap` in flex layouts so I had to employ the same fixes to this issue as we did with the `.nx-card` layouts.