### PR TITLE
Add workaround for webpack watch issue

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/webpack.config.js
+++ b/gallery/webpack.config.js
@@ -126,6 +126,9 @@ module.exports = function(env = { production: false }) {
       disableHostCheck: true,
       publicPath: '/',
       contentBase: path.join(__dirname, 'src')
+    },
+    snapshot: {
+      managedPaths: []
     }
   };
 };

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Workaround for https://github.com/webpack/webpack/issues/12810 which is preventing changes in the lib from triggering a rebuild of the gallery.