### PR TITLE
Use css variables for page size values RSC-506 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.3.7",
+  "version": "4.4.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.3.7",
+  "version": "4.4.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-globals.scss
+++ b/lib/src/base-styles/_nx-globals.scss
@@ -77,7 +77,8 @@ $nx-scrollable-default-height: 400px;
   --page-width-max: 1600px;
   --page-width-min: 1366px;
   --content-width: 76%;
-  --sidebar-width: 100% - var(--content-width);
+  --sidebar-width: calc(100% - var(--content-width));
+  --scrollbar-width: 15px;
 
   --nx-component-background-color: #{$nx-white};
 }

--- a/lib/src/base-styles/_nx-globals.scss
+++ b/lib/src/base-styles/_nx-globals.scss
@@ -71,7 +71,13 @@ $nx-scrollable-default-height: 400px;
   @extend %nx-blockquote;
 }
 
+// global CSS variables/custom properties
 :root {
-  // global CSS variables/custom properties
+  // page dimensions
+  --page-width-max: 1600px;
+  --page-width-min: 1366px;
+  --content-width: 76%;
+  --sidebar-width: 100% - var(--content-width);
+
   --nx-component-background-color: #{$nx-white};
 }

--- a/lib/src/base-styles/_nx-page-header.scss
+++ b/lib/src/base-styles/_nx-page-header.scss
@@ -35,7 +35,7 @@ $main-header-product-version-row-height: 1fr;
   margin: 0 auto;
   padding: 0 $nx-spacing-l;
   width: 100%;
-  max-width: $nx-page-width-max;
+  max-width: var(--page-width-max);
 }
 
 .nx-page-header__links {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -29,7 +29,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  min-width: $nx-page-width-min;
+  min-width: var(--page-width-max);
 }
 
 .nx-page-content {
@@ -38,7 +38,7 @@
   box-sizing: border-box;
   display: flex;
   flex-grow: 1;
-  max-width: $nx-page-width-max;
+  max-width: var(--page-width-max);
   overflow-y: hidden;
   width: 100%;
 
@@ -54,7 +54,7 @@
 
   background-color: $nx-sidebar-background-color;
   box-sizing: border-box;
-  flex-basis: $nx-sidebar-width;
+  flex-basis: var(--sidebar-width);
   min-width: 0;
   overflow-x: hidden;
   padding: $nx-spacing-xl $nx-spacing-l $nx-spacing-xs $nx-spacing-l;
@@ -66,7 +66,7 @@
   @include container-vertical;
 
   box-sizing: border-box;
-  flex: 1 0 $nx-content-width;
+  flex: 1 0 var(--content-width);
   min-width: 0;
   overflow-x: hidden;
   overflow-y: auto;
@@ -83,7 +83,7 @@
   }
 
   .nx-page {
-    min-width: $nx-page-width-min - $nx-scrollbar-width;
+    min-width: var(--page-width-max) - $nx-scrollbar-width;
   }
 
   .nx-page-header {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -8,6 +8,13 @@
 /*
   #Layout
 */
+:root {
+  --page-width-max: 1600px;
+  --page-width-min: 1366px;
+  --content-width: 76%;
+  --sidebar-width: 100% - var(--content-width);
+}
+
 .nx-html, .nx-body {
   box-sizing: border-box;
   height: 100%;

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -29,7 +29,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  min-width: var(--page-width-max);
+  min-width: var(--page-width-min);
 }
 
 .nx-page-content {
@@ -83,7 +83,7 @@
   }
 
   .nx-page {
-    min-width: var(--page-width-max) - $nx-scrollbar-width;
+    min-width: var(--page-width-min) - $nx-scrollbar-width;
   }
 
   .nx-page-header {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -8,13 +8,6 @@
 /*
   #Layout
 */
-:root {
-  --page-width-max: 1600px;
-  --page-width-min: 1366px;
-  --content-width: 76%;
-  --sidebar-width: 100% - var(--content-width);
-}
-
 .nx-html, .nx-body {
   box-sizing: border-box;
   height: 100%;

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -83,7 +83,7 @@
   }
 
   .nx-page {
-    min-width: var(--page-width-min) - $nx-scrollbar-width;
+    min-width: calc(var(--page-width-min) - var(--scrollbar-width));
   }
 
   .nx-page-header {

--- a/lib/src/scss-shared/_nx-variables.scss
+++ b/lib/src/scss-shared/_nx-variables.scss
@@ -9,13 +9,6 @@
 /*
   #Page elements
 */
-:root {
-  --page-width-max: 1600px;
-  --page-width-min: 1366px;
-  --content-width: 76%;
-  --sidebar-width: 100% - var(--content-width);
-}
-
 $nx-main-header-height: 72px;
 $nx-paragraph-width-maximum: 562px;
 $nx-form-label-width-maximum: 562px;

--- a/lib/src/scss-shared/_nx-variables.scss
+++ b/lib/src/scss-shared/_nx-variables.scss
@@ -9,16 +9,16 @@
 /*
   #Page elements
 */
+:root {
+  --page-width-max: 1600px;
+  --page-width-min: 1366px;
+  --content-width: 76%;
+  --sidebar-width: 100% - var(--content-width);
+}
+
 $nx-main-header-height: 72px;
-
-$nx-page-width-max: 1600px;
-$nx-page-width-min: 1366px;
-$nx-content-width: 76%;
-$nx-sidebar-width: 100% - $nx-content-width;
-
 $nx-paragraph-width-maximum: 562px;
 $nx-form-label-width-maximum: 562px;
-
 $nx-scrollbar-width: 15px;
 
 $nx-border-radius: 6px;

--- a/lib/src/scss-shared/_nx-variables.scss
+++ b/lib/src/scss-shared/_nx-variables.scss
@@ -12,7 +12,6 @@
 $nx-main-header-height: 72px;
 $nx-paragraph-width-maximum: 562px;
 $nx-form-label-width-maximum: 562px;
-$nx-scrollbar-width: 15px;
 
 $nx-border-radius: 6px;
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-506

I created CSS variables to replace the SCSS variables used for page layout.

In doing so I learned that CSS variables are emitting code, so to get around the repetition problem I moved the CSS variables into the `_page-layout.scss` file.

I also replaced instances of the SCSS variables with the appropriate CSS variables.