### PR TITLE
NxDropdown close handlers/cancellation - RSC-533

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.7.2",
+  "version": "4.8.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxDropdown/NxDropdownCloseHandlerExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownCloseHandlerExample.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { KeyboardEvent } from 'react';
+
+import { NxDropdown, useToggle } from '@sonatype/react-shared-components';
+
+function NxDropdownCloseHandlerExample() {
+  const [isOpen, onToggleCollapse] = useToggle(false),
+      onClick = () => { alert('click'); };
+
+  return (
+    <NxDropdown label="Navigation"
+                isOpen={isOpen}
+                onToggleCollapse={onToggleCollapse}
+                onCloseClick={(evt: MouseEvent) => evt.preventDefault()}
+                onCloseKeyDown={(evt: KeyboardEvent) => evt.preventDefault()}>
+      <a onClick={onClick} href="#/pages/NxDropdown" className="nx-dropdown-button">
+        Link
+      </a>
+      <button onClick={onClick} className="nx-dropdown-button">
+        Button
+      </button>
+    </NxDropdown>
+  );
+}
+
+export default NxDropdownCloseHandlerExample;

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -111,8 +111,12 @@ const NxDropdownPage = () =>
               <td className="nx-cell">
                 A callback function to execute when a click is detected anywhere on the document which would by
                 default close this dropdown (i.e. any click while the dropdown is open). This callback is dispatched
-                before the dropdown is closed and is provided with the <em>native</em> MouseEvent object. Calling
-                <code className="nx-code">preventDefault</code> on this MouseEvent will cause the dropdown not to close.
+                before the dropdown is closed and is provided with a proxy of the <em>native</em> MouseEvent object.
+                Calling <code className="nx-code">preventDefault</code> on this MouseEvent will cause the dropdown
+                not to close. Note however that the event is proxied in such a way that
+                calling <code className="nx-code">preventDefault</code> <em>will not</em> have any other
+                effects – that is, the true native MouseEvent's <code className="nx-code">defautlPrevented</code> flag
+                will be untouched, and only the logic within the dropdown will be affected.
               </td>
             </tr>
             <tr className="nx-table-row">

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -115,7 +115,7 @@ const NxDropdownPage = () =>
                 Calling <code className="nx-code">preventDefault</code> on this MouseEvent will cause the dropdown
                 not to close. Note however that the event is proxied in such a way that
                 calling <code className="nx-code">preventDefault</code> <em>will not</em> have any other
-                effects – that is, the true native MouseEvent's <code className="nx-code">defautlPrevented</code> flag
+                effects – that is, the true native MouseEvent's <code className="nx-code">defaultPrevented</code> flag
                 will be untouched, and only the logic within the dropdown will be affected.
               </td>
             </tr>

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -15,13 +15,15 @@ import NxDropdownDisabledExample from './NxDropdownDisabledExample';
 import NxDropdownRightButtonsExample from './NxDropdownRightButtonsExample';
 import NxDropdownCustomLabelExample from './NxDropdownCustomLabelExample';
 import NxDropdownLinksExample from './NxDropdownLinksExample';
+import NxDropdownCloseHandlerExample from './NxDropdownCloseHandlerExample';
 
 const nxDropdownNavigationExampleCode = require('./NxDropdownNavigationExample?raw'),
     nxDropdownScrollingExampleCode = require('./NxDropdownScrollingExample?raw'),
     nxDropdownDisabledExampleCode = require('./NxDropdownDisabledExample?raw'),
     nxDropdownCustomLabelExampleCode = require('./NxDropdownCustomLabelExample?raw'),
     nxDropdownRightButtonsExampleCode = require('./NxDropdownRightButtonsExample?raw'),
-    nxDropdownLinksExampleCode = require('./NxDropdownLinksExample?raw');
+    nxDropdownLinksExampleCode = require('./NxDropdownLinksExample?raw'),
+    nxDropdownCloseHandlerExampleCode = require('./NxDropdownCloseHandlerExample?raw');
 
 const NxDropdownPage = () =>
   <>
@@ -100,6 +102,29 @@ const NxDropdownPage = () =>
                 to specify the tooltip: the simpler way is to simply specify the tooltip text as a string. If control
                 of more complex tooltip options is desired, an object can be passed which will serve as the props for
                 NxTooltip
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell">onCloseClick</td>
+              <td className="nx-cell">Function (MouseEvent =&lt; void)</td>
+              <td className="nx-cell">No</td>
+              <td className="nx-cell">
+                A callback function to execute when a click is detected anywhere on the document which would by
+                default close this dropdown (i.e. any click while the dropdown is open). This callback is dispatched
+                before the dropdown is closed and is provided with the <em>native</em> MouseEvent object. Calling
+                <code className="nx-code">preventDefault</code> on this MouseEvent will cause the dropdown not to close.
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell">onCloseKeyDown</td>
+              <td className="nx-cell">Function (KeyboardEvent =&lt; void)</td>
+              <td className="nx-cell">No</td>
+              <td className="nx-cell">
+                A callback function to execute when a key press is detected which would by
+                default close this dropdown (i.e. an ESC keypress occurring within the dropdown while it is open).
+                This callback is dispatched before the dropdown is closed and is provided with the React KeyboardEvent
+                object.  Calling <code className="nx-code">preventDefault</code> on this event object will cause the
+                dropdown not to close.
               </td>
             </tr>
             <tr className="nx-table-row">
@@ -242,6 +267,16 @@ const NxDropdownPage = () =>
       from the browser that prevent them from working with the styling here. Additionally, note that
       the <code className="nx-code">nx-dropdown-button-content</code> is present on all menu items, even those that
       do not have icon buttons, in order to get consistent menu item heights.
+    </GalleryExampleTile>
+
+    <GalleryExampleTile title="Example with disabled close handlers"
+                        liveExample={NxDropdownCloseHandlerExample}
+                        codeExamples={nxDropdownCloseHandlerExampleCode}>
+      This example demonstrates the usage of the <code className="nx-code">onCloseClick</code>{' '}
+      and <code className="nx-code">onCloseKeyDown</code> props. These props can be used to disable the
+      close-on-click and close-on-ESC behaviors that the dropdown has by default, by
+      calling <code className="nx-code">preventDefault()</code> on the event. This example demonstrates both props
+      simulataneously, but either can be used independently if desired.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxSegmentedButton/NxSegmentedButtonCloseHandlerExample.tsx
+++ b/gallery/src/components/NxSegmentedButton/NxSegmentedButtonCloseHandlerExample.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { KeyboardEvent } from 'react';
+
+import { NxSegmentedButton, useToggle } from '@sonatype/react-shared-components';
+
+export default function NxSegmentedButtonPrimaryExample() {
+  const [isOpen, onToggleOpen] = useToggle(false);
+
+  function onMainClick() {
+    alert('Clicked the main button!');
+  }
+
+  return (
+    <div className="nx-btn-bar">
+      <NxSegmentedButton variant="primary"
+                         isOpen={isOpen}
+                         onToggleOpen={onToggleOpen}
+                         onClick={onMainClick}
+                         buttonContent="Click Here"
+                         onCloseClick={(evt: MouseEvent) => evt.preventDefault()}
+                         onCloseKeyDown={(evt: KeyboardEvent) => evt.preventDefault()}>
+        <button className="nx-dropdown-button">
+          Dropdown item 1
+        </button>
+        <button className="nx-dropdown-button">
+          Dropdown item 2
+        </button>
+      </NxSegmentedButton>
+    </div>
+  );
+}

--- a/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
+++ b/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
@@ -11,11 +11,13 @@ import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-componen
 import NxSegmentedButtonPrimaryExample from './NxSegmentedButtonPrimaryExample';
 import NxSegmentedButtonSecondaryExample from './NxSegmentedButtonSecondaryExample';
 import NxSegmentedButtonTertiaryExample from './NxSegmentedButtonTertiaryExample';
+import NxSegmentedButtonCloseHandlerExample from './NxSegmentedButtonCloseHandlerExample';
 import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody } from '@sonatype/react-shared-components';
 
 const nxSegmentedButtonPrimaryCode = require('./NxSegmentedButtonPrimaryExample?raw'),
     nxSegmentedButtonSecondaryCode = require('./NxSegmentedButtonSecondaryExample?raw'),
-    nxSegmentedButtonTertiaryCode = require('./NxSegmentedButtonTertiaryExample?raw');
+    nxSegmentedButtonTertiaryCode = require('./NxSegmentedButtonTertiaryExample?raw'),
+    nxSegmentedButtonCloseHandlerExampleCode = require('./NxSegmentedButtonCloseHandlerExample?raw');
 
 export default function NxSegmentedButtonPage() {
   return (
@@ -98,6 +100,35 @@ export default function NxSegmentedButtonPage() {
               <NxTableCell>Disables both segments of the button when true.</NxTableCell>
             </NxTableRow>
             <NxTableRow>
+              <NxTableCell>onCloseClick</NxTableCell>
+              <NxTableCell>Function (MouseEvent =&lt; void)</NxTableCell>
+              <NxTableCell>No</NxTableCell>
+              <NxTableCell/>
+              <NxTableCell>
+                A callback function to execute when a click is detected anywhere on the document which would by
+                default close this dropdown (i.e. any click while the dropdown is open). This callback is dispatched
+                before the dropdown is closed and is provided with a proxy of the <em>native</em> MouseEvent object.
+                Calling <code className="nx-code">preventDefault</code> on this MouseEvent will cause the dropdown
+                not to close. Note however that the event is proxied in such a way that
+                calling <code className="nx-code">preventDefault</code> <em>will not</em> have any other
+                effects – that is, the true native MouseEvent's <code className="nx-code">defaultPrevented</code> flag
+                will be untouched, and only the logic within the dropdown will be affected.
+              </NxTableCell>
+            </NxTableRow>
+            <NxTableRow>
+              <NxTableCell>onCloseKeyDown</NxTableCell>
+              <NxTableCell>Function (KeyboardEvent =&lt; void)</NxTableCell>
+              <NxTableCell>No</NxTableCell>
+              <NxTableCell/>
+              <NxTableCell>
+                A callback function to execute when a key press is detected which would by
+                default close this dropdown (i.e. an ESC keypress occurring within the dropdown while it is open).
+                This callback is dispatched before the dropdown is closed and is provided with the React KeyboardEvent
+                object.  Calling <code className="nx-code">preventDefault</code> on this event object will cause the
+                dropdown not to close.
+              </NxTableCell>
+            </NxTableRow>
+            <NxTableRow>
               <NxTableCell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTableCell>
               <NxTableCell>
                 <a target="_blank"
@@ -142,6 +173,16 @@ export default function NxSegmentedButtonPage() {
         An <code className="nx-code">NxSegmentedButton</code> using secondary styling, a disabled
         secondary-styled <code className="nx-code">NxSegmentedButton</code>, and a normal button to demonstrate
         alignment.
+      </GalleryExampleTile>
+
+      <GalleryExampleTile title="Example with disabled close handlers"
+                          liveExample={NxSegmentedButtonCloseHandlerExample}
+                          codeExamples={nxSegmentedButtonCloseHandlerExampleCode}>
+        This example demonstrates the usage of the <code className="nx-code">onCloseClick</code>{' '}
+        and <code className="nx-code">onCloseKeyDown</code> props. These props can be used to disable the
+        close-on-click and close-on-ESC behaviors that the dropdown has by default, by
+        calling <code className="nx-code">preventDefault()</code> on the event. This example demonstrates both props
+        simulataneously, but either can be used independently if desired.
       </GalleryExampleTile>
     </>
   );

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.7.2",
+  "version": "4.8.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxDropdown/NxDropdown.tsx
+++ b/lib/src/components/NxDropdown/NxDropdown.tsx
@@ -28,11 +28,13 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
     toggleTooltip,
     onToggleCollapse: externalOnToggleCollapse,
     onKeyDown: externalOnKeyDown,
+    onCloseClick,
+    onCloseKeyDown,
     ...attrs
   } = props;
 
   const { onKeyDown, onToggleCollapse } =
-      useDropdownEvents(isOpen, disabled, externalOnToggleCollapse, externalOnKeyDown);
+      useDropdownEvents(isOpen, disabled, externalOnToggleCollapse, onCloseClick, onCloseKeyDown, externalOnKeyDown);
 
   const buttonClasses = classnames('nx-dropdown__toggle', { disabled, open: isOpen });
 

--- a/lib/src/components/NxDropdown/__tests__/NxDropdown.test.tsx
+++ b/lib/src/components/NxDropdown/__tests__/NxDropdown.test.tsx
@@ -221,4 +221,59 @@ describe('NxDropdown', () => {
         expect(onToggleCollapse).not.toHaveBeenCalled();
       }
   );
+
+  it('does not call onToggleCollapse if ESC is pressed within the component and onCloseKeyDown preventsDefault',
+      function() {
+        const onToggleCollapse = jest.fn(),
+            component = getMountedComponent({
+              onToggleCollapse,
+              isOpen: true,
+              onCloseKeyDown: e => e.preventDefault()
+            }, { attachTo: container });
+
+        act(() => {
+          component.find('button.nx-dropdown__toggle').getDOMNode()
+              .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        });
+        component.update();
+        expect(onToggleCollapse).not.toHaveBeenCalled();
+      }
+  );
+
+  it('does not call onToggleCollapse if a click happens anywhere other than the dropdown button when onCloseClick ' +
+      'preventsDefault', function() {
+    const onToggleCollapse = jest.fn(),
+        component = getMountedComponent({
+          children: <button className="nx-dropdown-button">Foo</button>,
+          onToggleCollapse,
+          isOpen: true,
+          onCloseClick: e => e.preventDefault()
+        }, { attachTo: container });
+
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('click', {
+        bubbles: true
+      }));
+    });
+    component!.update();
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+
+    act(() => {
+      component.find('.nx-dropdown-button').getDOMNode().dispatchEvent(new MouseEvent('click', {
+        bubbles: true
+      }));
+    });
+    component!.update();
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+
+    act(() => {
+      component.find('button.nx-dropdown__toggle').getDOMNode().dispatchEvent(new MouseEvent('click', {
+        bubbles: true
+      }));
+    });
+    component!.update();
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/src/components/NxDropdown/types.ts
+++ b/lib/src/components/NxDropdown/types.ts
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import {ReactNode, HTMLAttributes, ReactElement, WeakValidationMap} from 'react';
+import {ReactNode, HTMLAttributes, ReactElement, WeakValidationMap, KeyboardEventHandler} from 'react';
 import * as PropTypes from 'prop-types';
 
 import { NX_BUTTON_VARIANTS, NX_BUTTON_VARIANT_TYPE } from '../NxButton/types';
@@ -18,6 +18,8 @@ export type Props = Omit<HTMLAttributes<HTMLDivElement>, 'className'> & {
   children?: ReactElement | ReactElement[] | null;
   disabled?: boolean | null;
   onToggleCollapse?: (() => void) | null;
+  onCloseKeyDown?: KeyboardEventHandler | null;
+  onCloseClick?: ((e: MouseEvent) => void) | null;
   toggleTooltip?: TooltipConfigProps | string | null;
 };
 
@@ -35,5 +37,7 @@ export const propTypes: WeakValidationMap<Props> = {
   ]),
   disabled: PropTypes.bool,
   onToggleCollapse: PropTypes.func,
+  onCloseKeyDown: PropTypes.func,
+  onCloseClick: PropTypes.func,
   toggleTooltip: PropTypes.oneOfType([tooltipPropTypesShape, PropTypes.string])
 };

--- a/lib/src/components/NxSegmentedButton/NxSegmentedButton.tsx
+++ b/lib/src/components/NxSegmentedButton/NxSegmentedButton.tsx
@@ -29,6 +29,8 @@ const NxSegmentedButton = forwardRef<HTMLDivElement, Props>(
             isOpen,
             onToggleOpen: externalOnToggleCollapse,
             onKeyDown: externalOnKeyDown,
+            onCloseClick,
+            onCloseKeyDown,
             ...attrs
           } = props,
           classes = classnames('nx-segmented-btn', className, {
@@ -37,8 +39,8 @@ const NxSegmentedButton = forwardRef<HTMLDivElement, Props>(
           wrappedMenuItems = React.Children.map<ReactElement, ReactElement>(children, item => (
             <NxOverflowTooltip>{item}</NxOverflowTooltip>
           )),
-          { onKeyDown, onToggleCollapse } =
-              useDropdownEvents(isOpen, disabled, externalOnToggleCollapse, externalOnKeyDown);
+          { onKeyDown, onToggleCollapse } = useDropdownEvents(isOpen, disabled, externalOnToggleCollapse,
+              onCloseClick, onCloseKeyDown, externalOnKeyDown);
 
       return (
         <div ref={ref} className={classes} onKeyDown={onKeyDown} { ...attrs }>

--- a/lib/src/components/NxSegmentedButton/__tests__/NxSegmentedButton.test.tsx
+++ b/lib/src/components/NxSegmentedButton/__tests__/NxSegmentedButton.test.tsx
@@ -277,4 +277,59 @@ describe('NxSegmentedButton', function() {
     component.simulate('keyDown', { key: 'Escape' });
     expect(onToggleOpen).not.toHaveBeenCalled();
   });
+
+  it('does not call onToggleOpen if ESC is pressed within the component and onCloseKeyDown preventsDefault',
+      function() {
+        const onToggleOpen = jest.fn(),
+            component = getMounted({
+              onToggleOpen,
+              isOpen: true,
+              onCloseKeyDown: e => e.preventDefault()
+            }, { attachTo: container });
+
+        act(() => {
+          component.find('button.nx-segmented-btn__dropdown-btn').getDOMNode()
+              .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        });
+        component.update();
+        expect(onToggleOpen).not.toHaveBeenCalled();
+      }
+  );
+
+  it('does not call onToggleOpen if a click happens anywhere other than the dropdown button when onCloseClick ' +
+      'preventsDefault', function() {
+    const onToggleOpen = jest.fn(),
+        component = getMounted({
+          children: <button className="nx-dropdown-button">Foo</button>,
+          onToggleOpen,
+          isOpen: true,
+          onCloseClick: e => e.preventDefault()
+        }, { attachTo: container });
+
+    expect(onToggleOpen).not.toHaveBeenCalled();
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('click', {
+        bubbles: true
+      }));
+    });
+    component!.update();
+    expect(onToggleOpen).not.toHaveBeenCalled();
+
+    act(() => {
+      component.find('.nx-dropdown-button').getDOMNode().dispatchEvent(new MouseEvent('click', {
+        bubbles: true
+      }));
+    });
+    component!.update();
+    expect(onToggleOpen).not.toHaveBeenCalled();
+
+    act(() => {
+      component.find('button.nx-segmented-btn__dropdown-btn').getDOMNode().dispatchEvent(new MouseEvent('click', {
+        bubbles: true
+      }));
+    });
+    component!.update();
+    expect(onToggleOpen).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/src/components/NxSegmentedButton/types.ts
+++ b/lib/src/components/NxSegmentedButton/types.ts
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import * as PropTypes from 'prop-types';
-import { ReactElement, HTMLAttributes, ReactNode, KeyboardEventHandler } from 'react';
+import React, { ReactElement, HTMLAttributes, ReactNode, KeyboardEventHandler } from 'react';
 import { without } from 'ramda';
 
 import { NX_BUTTON_VARIANTS, NX_BUTTON_VARIANT_TYPE } from '../NxButton/types';

--- a/lib/src/components/NxSegmentedButton/types.ts
+++ b/lib/src/components/NxSegmentedButton/types.ts
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import * as PropTypes from 'prop-types';
-import { ReactElement, HTMLAttributes, MouseEvent, ReactNode } from 'react';
+import { ReactElement, HTMLAttributes, ReactNode, KeyboardEventHandler } from 'react';
 import { without } from 'ramda';
 
 import { NX_BUTTON_VARIANTS, NX_BUTTON_VARIANT_TYPE } from '../NxButton/types';
@@ -25,7 +25,9 @@ export interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'onClick'> {
   buttonContent: ReactNode;
   isOpen: boolean;
   onToggleOpen: () => void;
-  onClick: (evt: MouseEvent<HTMLButtonElement>) => void;
+  onClick: (evt: React.MouseEvent<HTMLButtonElement>) => void;
+  onCloseKeyDown?: KeyboardEventHandler | null;
+  onCloseClick?: ((e: MouseEvent) => void) | null;
   disabled?: boolean | null;
 }
 
@@ -39,5 +41,7 @@ export const propTypes: PropTypes.ValidationMap<Props> = {
   isOpen: PropTypes.bool.isRequired,
   onToggleOpen: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
+  onCloseKeyDown: PropTypes.func,
+  onCloseClick: PropTypes.func,
   disabled: PropTypes.bool
 };

--- a/lib/src/util/useDropdownEvents.ts
+++ b/lib/src/util/useDropdownEvents.ts
@@ -10,7 +10,15 @@ import { KeyboardEventHandler, useEffect, useRef } from 'react';
  * Dropdown global event handling, abstracted into a hook for use in various dropdown-like
  * components (e.g. NxDropdown and NxSegmentedButton)
  * @param externalOnToggleCollapse - The onToggleCollapse function that was provided from outside of the component
- * @param externalOnKeyDown - Any onKeyDown function that might have been provided from outside of the component
+ * @param externalOnCloseClick - A callback provided from outside the component that should fire when a click
+ *    is detected that would result in the dropdown getting closed. The Mouse event is passed to this handler,
+ *    and if the handler calls `preventDefault` on it, the close is cancelled
+ * @param externalOnCloseKeyDown - A callback provided from outside the component that should fire when a key press
+ *    is detected that would result in the dropdown getting closed. The Keyboard event is passed to this handler,
+ *    and if the handler calls `preventDefault` on it, the close is cancelled
+ * @param externalOnToggleCollapse - The onToggleCollapse function that was provided from outside of the component
+ * @param externalOnKeyDown - Any onKeyDown function that might have been provided from outside of the component.
+ *    Note that this fires after the close processing occurs
  * @return Object containing the following:
  * onKeyDown function to set on the dropdown to handle ESC keypresses within it
  * onToggleCollapse function to set as the click handler on the dropdown toggle
@@ -19,13 +27,21 @@ export default function useDropdownEvents(
   isOpen: boolean,
   disabled: boolean | undefined | null,
   externalOnToggleCollapse?: (() => void) | null,
+  externalOnCloseClick?: ((e: MouseEvent) => void) | null,
+  externalOnCloseKeyDown?: KeyboardEventHandler | null,
   externalOnKeyDown?: KeyboardEventHandler
 ) {
   const isToggling = useRef(false);
 
   const onKeyDown: KeyboardEventHandler = event => {
     if (isOpen && !disabled && event.key === 'Escape' && externalOnToggleCollapse) {
-      externalOnToggleCollapse();
+      if (externalOnCloseKeyDown) {
+        externalOnCloseKeyDown(event);
+      }
+
+      if (!event.defaultPrevented) {
+        externalOnToggleCollapse();
+      }
     }
 
     if (externalOnKeyDown) {
@@ -33,9 +49,15 @@ export default function useDropdownEvents(
     }
   };
 
-  const handleDocumentClick = () => {
+  const handleDocumentClick = (event: MouseEvent) => {
     if (isOpen && !isToggling.current && externalOnToggleCollapse) {
-      externalOnToggleCollapse();
+      if (externalOnCloseClick) {
+        externalOnCloseClick(event);
+      }
+
+      if (!event.defaultPrevented) {
+        externalOnToggleCollapse();
+      }
     }
 
     isToggling.current = false;

--- a/lib/src/util/useDropdownEvents.ts
+++ b/lib/src/util/useDropdownEvents.ts
@@ -59,14 +59,9 @@ export default function useDropdownEvents(
          * native event could have a wide variety of other effects, so we proxy the event object overriding
          * preventDefault with our own impl that only affects a locally-scoped variable
          */
-        const proxiedClickEvent = new Proxy(event, {
-          get(target, prop, receiver) {
-            if (prop === 'preventDefault') {
-              return () => { defaultPrevented = true };
-            }
-            else {
-              return Reflect.get(target, prop, receiver);
-            }
+        const proxiedClickEvent = Object.create(event, {
+          preventDefault: {
+            value: () => { defaultPrevented = true; }
           }
         });
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-533

Adds `onCloseClick` and `onCloseKeyDown` handlers that can call `preventDefault` to cancel the default close-on-click and close-on-ESC behavior of `NxDropdown` and `NxSegmentedButton`.

Note that the click event gets proxied so that calling `preventDefault` on it does not cause unintended side-effects (that click could be coming from anywhere on the page, so the default action could be any number of things involving unrelated elements).  As a point of technical interest, I ended up doing this proxying via prototype inheritance set up using `Object.create`.  However prior to implementing it that way I tried using a Proxy object.  You can see that implementation in commit 98a74a4fd64.  I ultimately moved away from it as it was more complicated than the prototype approach, and likely less performant since it uses reflection.