### PR TITLE
Add logoPath and alt props to NxPageHeader RSC-550

### DIFF
--- a/lib/src/components/NxPageHeader/NxPageHeader.tsx
+++ b/lib/src/components/NxPageHeader/NxPageHeader.tsx
@@ -11,7 +11,7 @@ import { Props, ProductInfo, propTypes } from './types';
 
 export { Props };
 
-const logoImg = require('../../assets/img/sonatype-logo-with-hexagon.png');
+const defaultLogo = require('../../assets/img/sonatype-logo-with-hexagon.png');
 
 function HeaderProductInfo({ name, version }: ProductInfo) {
   return (
@@ -22,8 +22,8 @@ function HeaderProductInfo({ name, version }: ProductInfo) {
   );
 }
 
-export default function NxPageHeader({ productInfo, ...otherProps }: Props) {
-  const logo = <img src={logoImg} className="nx-product__logo-image" alt="Sonatype"/>,
+export default function NxPageHeader({ productInfo, logoPath, alt, ...otherProps }: Props) {
+  const logo = <img src={logoPath || defaultLogo} className="nx-product__logo-image" alt={alt || "Sonatype"}/>,
       productInfoContent = productInfo ? <HeaderProductInfo { ...productInfo } /> : null;
 
   return <AbstractNxPageHeader { ...otherProps } { ...{ logo, productInfoContent } } />;

--- a/lib/src/components/NxPageHeader/types.ts
+++ b/lib/src/components/NxPageHeader/types.ts
@@ -18,6 +18,8 @@ export interface ProductInfo {
 
 export type Props = Omit<AbstractNxPageHeaderProps, 'logo' | 'productInfoContent'> & {
   productInfo?: ProductInfo | null;
+  logoPath?: string | null;
+  alt?: string | null;
 };
 
 export const propTypes: ValidationMap<Props> = {
@@ -25,5 +27,7 @@ export const propTypes: ValidationMap<Props> = {
   productInfo: PropTypes.shape({
     name: PropTypes.string.isRequired,
     version: PropTypes.string
-  })
+  }),
+  logoPath: PropTypes.string,
+  alt: PropTypes.string
 };


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-550

Hello!

This PR adds `logoPath` consistent with `NxNexusPageHeader` to `NxPageHeader`, and also adds a `alt` prop, which if absent defaults to `Sonatype` to ensure existing behavior is maintained!

Figured I'd file this to see if the changes are ok and then add some tests to make sure it's good to go!

Also, I did NOT add `logoPath`, `alt` to `AbstractNxPageHeader` because it appears that you pass `logo` in to that, so I didn't see a reason to move them up there (even though they are now common)