### PR TITLE
Overflow tooltips not showing in global sidebar nav

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -132,7 +132,8 @@ $nx-global-sidebar-separator-color: $nx-grey-900;
   width: $nx-global-sidebar-width-closed;
 
   .nx-global-sidebar__expanded-content {
-    display: none;
+    display: inline-block;
+    visibility: hidden;
   }
 
   .nx-global-sidebar__header {
@@ -141,5 +142,6 @@ $nx-global-sidebar-separator-color: $nx-grey-900;
 
   .nx-global-sidebar__navigation-link {
     text-align: center;
+    text-overflow: revert;
   }
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-539

The issue is that `NxOverflowTooltip` (as its name suggests) relies on the contents overflowing as its trigger, but in this case the text was set to `display: none;` and the so the icon did not cause overflow.

The solution was to use `visibility: hidden`. The rest is just tweaking so the display looks correct.