### PR TITLE
Improvement Day: Gallery Sidebar Search

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/GalleryNav.tsx
+++ b/gallery/src/GalleryNav.tsx
@@ -49,19 +49,18 @@ function GalleryNavTreeView(props: GalleryNavTreeViewProps) {
   const { categoryName, categoryEntries, filter, onToggleCollapse, isOpen } = props,
       isFiltering = !!filter,
       filteredEntries: PageMapping = isFiltering ?
-          pickBy((_, pageName) => matchesFilter(filter, pageName), categoryEntries) :
-          categoryEntries,
+        pickBy((_, pageName) => matchesFilter(filter, pageName), categoryEntries) :
+        categoryEntries,
       hasFilteredEntries = keys(filteredEntries).length,
       renderLinksWithFilter = renderLinks(filter);
 
   return hasFilteredEntries ? (
-      <NxTreeView onToggleCollapse={onToggleCollapse}
-                  isOpen={isOpen}
-                  triggerContent={categoryName}>
-        {renderLinksWithFilter(filteredEntries)}
-      </NxTreeView>
-    ) :
-    null;
+    <NxTreeView onToggleCollapse={onToggleCollapse}
+                isOpen={isOpen}
+                triggerContent={categoryName}>
+      {renderLinksWithFilter(filteredEntries)}
+    </NxTreeView>
+  ) : null;
 }
 
 function GalleryNav() {
@@ -72,10 +71,10 @@ function GalleryNav() {
       // Have the tree for the current page expanded. if we are on a page that doesn't appear in the nav (e.g. the
       // home page) then expand the first tree
       initialOpenTreeViews: Record<string, boolean> = mapObjIndexed(
-        (categoryEntries, treeName) => currentPageName ?
+          (categoryEntries, treeName) => currentPageName ?
             includes(currentPageName, keys(categoryEntries)) :
             treeName === firstTree,
-        pageConfig
+          pageConfig
       ),
 
       [filter, setFilter] = useState(''),

--- a/gallery/src/GalleryNav.tsx
+++ b/gallery/src/GalleryNav.tsx
@@ -100,8 +100,6 @@ function matchesFilter(filter: string, pageName: string) {
 
 function GalleryNav() {
   const [filter, setFilter] = useState(''),
-      // create a GalleryNavTreeView for each entry in the pageConfig that matches the filter.
-      // Expand the tree views with matching contents, or expand the first one if no filtering is being done
       categories = pipe<PageConfig, [string, PageMapping][], ReactNode[]>(
           toPairs,
           addIndex<[string, PageMapping], ReactNode>(map)(([categoryName, categoryEntries], idx) =>

--- a/gallery/src/GalleryNav.tsx
+++ b/gallery/src/GalleryNav.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { useState, ReactNode } from 'react';
+import React, { useState, ReactNode, useEffect } from 'react';
 import { addIndex, toPairs, keys, map, pipe, includes, pickBy, isEmpty, toLower, reduce, head, tail, append } from 'ramda';
 import { NxTreeView, NxTreeViewChild, NxFilterInput } from '@sonatype/react-shared-components';
 
@@ -64,6 +64,12 @@ function GalleryNavTreeView({ categoryName, categoryEntries, filter, defaultOpen
       [toggleCheck, setToggleCheck] = useState(isInitiallyOpen),
       onToggleCollapse = () => setToggleCheck(!toggleCheck),
       renderLinksWithFilter = renderLinks(filter);
+
+  useEffect(() => {
+    // When filtering, this tree view will only be rendered at all if its a filter match, so ensure it is
+    // open.  When filtering is cancelled, fall back to isInitiallyOpen logic
+    setToggleCheck(!!filter || isInitiallyOpen);
+  }, [filter]);
 
   return (
     <NxTreeView onToggleCollapse={onToggleCollapse}

--- a/gallery/src/filterUtil.tsx
+++ b/gallery/src/filterUtil.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import { reduce, head, tail, toLower, isEmpty, append } from "ramda";
+import React, { ReactNode } from "react";
+
+/**
+ * @return a ReactNode containing the input text string with parts which match the filter marked
+ */
+export function markByFilter(filter: string | undefined, text: string): ReactNode {
+  if (filter) {
+    const [marked] = reduce<string, [ReactNode[], string[]]>(
+      ([processed, remainingFilter], textChar) => {
+          const isMatch = head(remainingFilter) === toLower(textChar),
+              processedChar = isMatch ?
+                  <mark key={remainingFilter.length} className="gallery-filter-match">{textChar}</mark> :
+                  textChar,
+              newRemainingFilter = isMatch ? tail(remainingFilter) : remainingFilter;
+
+          return [append(processedChar, processed), newRemainingFilter];
+      },
+      [[], Array.from(toLower(filter))],
+      Array.from(text)
+    );
+
+    return marked;
+  }
+  else {
+    return text;
+  }
+}
+
+/**
+ * @return true if the pageName contains every character present in the filter in the same order, case insensitive
+ */
+export function matchesFilter(filter: string, pageName: string) {
+  const unmatchedFilterChars = reduce(
+    (remainingFilter, pageNameChar) =>
+        head(remainingFilter) === pageNameChar ? tail(remainingFilter) : remainingFilter,
+    Array.from(toLower(filter)),
+    Array.from(toLower(pageName))
+  );
+
+  return isEmpty(unmatchedFilterChars);
+}
+

--- a/gallery/src/filterUtil.tsx
+++ b/gallery/src/filterUtil.tsx
@@ -4,8 +4,8 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import { reduce, head, tail, toLower, isEmpty, splitAt, drop, join } from "ramda";
-import React, { ReactNode } from "react";
+import { reduce, head, tail, toLower, isEmpty, splitAt, drop, join } from 'ramda';
+import React, { ReactNode } from 'react';
 
 /**
  * @return a ReactNode containing the input text string with parts which match the filter marked
@@ -20,10 +20,12 @@ export function markByFilter(filter: string | undefined, text: string): ReactNod
     while (!isEmpty(filterArr) && !isEmpty(textArr)) {
       const markKey = filterArr.length;
 
-      let i: number;
+      let i = 0;
 
       // Count how many immediate chars in the text match the filter
-      for (i = 0; i < Math.min(filterArr.length, textArr.length) && filterArr[i] === toLower(textArr[i]); i++);
+      while (i < Math.min(filterArr.length, textArr.length) && filterArr[i] === toLower(textArr[i])) {
+        i++;
+      }
 
       // if there are matching characters, gather them and wrap them in a <mark>
       if (i) {
@@ -41,7 +43,10 @@ export function markByFilter(filter: string | undefined, text: string): ReactNod
       }
 
       // Count how many immediate chars in the text DO NOT match the filter
-      for (i = 0; i < textArr.length && (!filterArr.length || filterArr[0] !== toLower(textArr[i])); i++);
+      i = 0;
+      while (i < textArr.length && (!filterArr.length || filterArr[0] !== toLower(textArr[i]))) {
+        i++;
+      }
 
       // if there are non-matching characters, gather them into a single text node
       if (i) {
@@ -64,10 +69,10 @@ export function markByFilter(filter: string | undefined, text: string): ReactNod
  */
 export function matchesFilter(filter: string, pageName: string) {
   const unmatchedFilterChars = reduce(
-    (remainingFilter, pageNameChar) =>
+      (remainingFilter, pageNameChar) =>
         head(remainingFilter) === pageNameChar ? tail(remainingFilter) : remainingFilter,
-    Array.from(toLower(filter)),
-    Array.from(toLower(pageName))
+      Array.from(toLower(filter)),
+      Array.from(toLower(pageName))
   );
 
   return isEmpty(unmatchedFilterChars);

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -74,7 +74,8 @@
 }
 
 .gallery-filter-match {
-  background: none;
+  background: initial;
+  color: inherit;
   font-weight: bold;
 }
 

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -73,6 +73,11 @@
   }
 }
 
+.gallery-filter-match {
+  background: none;
+  font-weight: bold;
+}
+
 // This media query selects IE11
 @media (-ms-high-contrast: none), (-ms-high-contrast: active) {
   // hide checkered background checkbox in IE since the background doesn't work there (and we don't care to support

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR adds a search box to the gallery sidebar, allowing users to search all sidebar entries (e.g. all Gallery page names) for some text.  The search is implemented such that any entries that contain all of the filter characters, in the same order, are considered a match.  The matching characters within each result are bolded to make it clear why they matched.

![localhost_4043](https://user-images.githubusercontent.com/3630091/114908345-0400c700-9dea-11eb-8758-c875ed4b7042.png)
![localhost_4043_(Applitools) (1)](https://user-images.githubusercontent.com/3630091/114908617-42968180-9dea-11eb-9683-1211b28164a5.png)
