### PR TITLE
NxGlobalSidebar Expand/Collapse button styling fixes - RSC-558

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -8,6 +8,7 @@ import React, { useEffect } from 'react';
 import { RouteChildrenProps } from 'react-router';
 import { HashRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
 import { mergeAll, values } from 'ramda';
+import { faEdit } from '@fortawesome/free-solid-svg-icons';
 
 // polyfill Array.prototype.includes which is used in query-string
 import 'core-js/features/array/includes';
@@ -25,6 +26,7 @@ import NxViewportSizedExample from './styles/NxViewportSized/NxViewportSizedExam
 import NxViewportSizedExpandingExample
   from './styles/NxViewportSized/NxViewportSizedExpandingExample';
 import SectionScrollingWrapper from './styles/NxViewportSized/SectionScrollingWrapper';
+import { NxGlobalSidebar, useToggle, NxGlobalSidebarNavigation, NxGlobalSidebarNavigationLink } from '@sonatype/react-shared-components';
 
 const pageMappings: PageMapping = mergeAll(values(pageConfig));
 
@@ -57,15 +59,28 @@ function Page({ match, location }: RouteChildrenProps<{ pageName: string }>) {
 }
 
 function Application() {
+  const [sidebarOpen, toggle] = useToggle(true);
+
   return (
     <Router>
       <PageHeader />
-      <div className="nx-page-content">
+      <div className="nx-page-content nx-page-content--full-width">
         <Switch>
           <Route exact path="/PageLevelAlertExample">
             <NxLoadWrapperPageLevelExample/>
           </Route>
           <Route>
+            <NxGlobalSidebar isOpen={sidebarOpen}
+                             toggleOpenIcon={faEdit}
+                             toggleCloseIcon={faEdit}
+                             onToggleClick={toggle}
+                             logoImg="foo"
+                             logoAltText="foo"
+                             logoLink="#">
+              <NxGlobalSidebarNavigation>
+                <NxGlobalSidebarNavigationLink icon={faEdit} href="#" text="Foobar" />
+              </NxGlobalSidebarNavigation>
+            </NxGlobalSidebar>
             <aside className="nx-page-sidebar" id="gallery-sidebar">
               <GalleryNav />
             </aside>

--- a/gallery/src/Application.tsx
+++ b/gallery/src/Application.tsx
@@ -8,7 +8,6 @@ import React, { useEffect } from 'react';
 import { RouteChildrenProps } from 'react-router';
 import { HashRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
 import { mergeAll, values } from 'ramda';
-import { faEdit } from '@fortawesome/free-solid-svg-icons';
 
 // polyfill Array.prototype.includes which is used in query-string
 import 'core-js/features/array/includes';
@@ -26,7 +25,6 @@ import NxViewportSizedExample from './styles/NxViewportSized/NxViewportSizedExam
 import NxViewportSizedExpandingExample
   from './styles/NxViewportSized/NxViewportSizedExpandingExample';
 import SectionScrollingWrapper from './styles/NxViewportSized/SectionScrollingWrapper';
-import { NxGlobalSidebar, useToggle, NxGlobalSidebarNavigation, NxGlobalSidebarNavigationLink } from '@sonatype/react-shared-components';
 
 const pageMappings: PageMapping = mergeAll(values(pageConfig));
 
@@ -59,28 +57,15 @@ function Page({ match, location }: RouteChildrenProps<{ pageName: string }>) {
 }
 
 function Application() {
-  const [sidebarOpen, toggle] = useToggle(true);
-
   return (
     <Router>
       <PageHeader />
-      <div className="nx-page-content nx-page-content--full-width">
+      <div className="nx-page-content">
         <Switch>
           <Route exact path="/PageLevelAlertExample">
             <NxLoadWrapperPageLevelExample/>
           </Route>
           <Route>
-            <NxGlobalSidebar isOpen={sidebarOpen}
-                             toggleOpenIcon={faEdit}
-                             toggleCloseIcon={faEdit}
-                             onToggleClick={toggle}
-                             logoImg="foo"
-                             logoAltText="foo"
-                             logoLink="#">
-              <NxGlobalSidebarNavigation>
-                <NxGlobalSidebarNavigationLink icon={faEdit} href="#" text="Foobar" />
-              </NxGlobalSidebarNavigation>
-            </NxGlobalSidebar>
             <aside className="nx-page-sidebar" id="gallery-sidebar">
               <GalleryNav />
             </aside>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -7,11 +7,11 @@
 @import '../../scss-shared/nx-variables';
 @import '../../scss-shared/nx-text-helpers';
 @import '../../scss-shared/nx-container-helpers';
+@import '../../scss-shared/nx-button-helpers';
 
 $nx-global-sidebar-width-open: 250px;
 $nx-global-sidebar-width-closed: 72px;
 $nx-global-sidebar-logo-height: 34px;
-$nx-global-sidebar-toggle-size: 32px;
 
 $nx-global-sidebar-text-color: $nx-white;
 $nx-global-sidebar-background-color: $nx-blue-1000;
@@ -49,13 +49,12 @@ $nx-global-sidebar-separator-color: $nx-grey-900;
 }
 
 .nx-global-sidebar__toggle {
+  @include nx-small-icon-btn;
   border-color: transparent;
   border-radius: 50%;
   color: $nx-global-sidebar-text-color;
   flex: none;
-  height: $nx-global-sidebar-toggle-size;
   margin: 0;
-  width: $nx-global-sidebar-toggle-size;
 
   &:focus {
     border-color: $nx-focus-border-color;

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -133,8 +133,7 @@ $nx-global-sidebar-separator-color: $nx-grey-900;
   width: $nx-global-sidebar-width-closed;
 
   .nx-global-sidebar__expanded-content {
-    display: inline-block;
-    visibility: hidden;
+    display: none;
   }
 
   .nx-global-sidebar__header {
@@ -144,5 +143,10 @@ $nx-global-sidebar-separator-color: $nx-grey-900;
   .nx-global-sidebar__navigation-link {
     text-align: center;
     text-overflow: revert;
+  }
+
+  .nx-global-sidebar__navigation-text {
+    display: inline-block;
+    visibility: hidden;
   }
 }

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebarNavigationLink.tsx
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebarNavigationLink.tsx
@@ -19,7 +19,7 @@ const NxGlobalSidebarNavigationLink: FunctionComponent<Props> = function NxNavig
   const classes = classnames(className, 'nx-global-sidebar__navigation-link nx-text-link', {
     'selected': isSelected
   });
-  const textClasses = 'nx-global-sidebar__navigation-text nx-global-sidebar__expanded-content';
+  const textClasses = 'nx-global-sidebar__navigation-text';
 
   return (
     <NxOverflowTooltip>

--- a/lib/src/components/NxGlobalSidebar/__tests__/NxGlobalSidebarNavigationLink.test.tsx
+++ b/lib/src/components/NxGlobalSidebar/__tests__/NxGlobalSidebarNavigationLink.test.tsx
@@ -43,6 +43,11 @@ describe('NxGlobalSidebarNavigationLink', function() {
     expect(getShallowComponent().find('.nx-global-sidebar__navigation-text')).toHaveText('textLink');
   });
 
+  it('renders the specified text with `nx-global-sidebar__expanded-content` class', function() {
+    expect(getShallowComponent().find('.nx-global-sidebar__expanded-content'))
+        .toHaveText('textLink');
+  });
+
   it('renders the specified icon inside the link', function() {
     expect(getShallowComponent().find(NxFontAwesomeIcon)).toHaveProp('icon', faCrow);
     expect(getShallowComponent({ icon: faBiohazard }).find(NxFontAwesomeIcon))

--- a/lib/src/components/NxGlobalSidebar/__tests__/NxGlobalSidebarNavigationLink.test.tsx
+++ b/lib/src/components/NxGlobalSidebar/__tests__/NxGlobalSidebarNavigationLink.test.tsx
@@ -43,11 +43,6 @@ describe('NxGlobalSidebarNavigationLink', function() {
     expect(getShallowComponent().find('.nx-global-sidebar__navigation-text')).toHaveText('textLink');
   });
 
-  it('renders the specified text with `nx-global-sidebar__expanded-content` class', function() {
-    expect(getShallowComponent().find('.nx-global-sidebar__expanded-content'))
-        .toHaveText('textLink');
-  });
-
   it('renders the specified icon inside the link', function() {
     expect(getShallowComponent().find(NxFontAwesomeIcon)).toHaveProp('icon', faCrow);
     expect(getShallowComponent({ icon: faBiohazard }).find(NxFontAwesomeIcon))


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-558

There were two problems here:

1. the centering issue, which was caused by the fix for RSC-539 being applied too broadly
2. the button sizing/icon internal layout issue, which was caused by RSC-398

Before:
![image](https://user-images.githubusercontent.com/3630091/115404924-c15d3700-a1bb-11eb-867d-2551dc49c824.png)


After:
![image](https://user-images.githubusercontent.com/3630091/115404750-9ecb1e00-a1bb-11eb-9865-63eed00cdce6.png)
