### PR TITLE
Update NxTable exports - RSC-543

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxTable/NxTableClickableExample.tsx
+++ b/gallery/src/components/NxTable/NxTableClickableExample.tsx
@@ -6,13 +6,7 @@
  */
 import React from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow
-} from '@sonatype/react-shared-components';
+import { NxTable } from '@sonatype/react-shared-components';
 
 const NxTableClickableExample = () => {
   const rows = [
@@ -23,22 +17,22 @@ const NxTableClickableExample = () => {
 
   return (
     <NxTable>
-      <NxTableHead>
-        <NxTableRow>
-          <NxTableCell>Name</NxTableCell>
-          <NxTableCell>Header 2</NxTableCell>
-          <NxTableCell chevron />
-        </NxTableRow>
-      </NxTableHead>
-      <NxTableBody>
+      <NxTable.Head>
+        <NxTable.Row>
+          <NxTable.Cell>Name</NxTable.Cell>
+          <NxTable.Cell>Header 2</NxTable.Cell>
+          <NxTable.Cell chevron />
+        </NxTable.Row>
+      </NxTable.Head>
+      <NxTable.Body>
         {rows.map(({ name, selected = false }) =>
-          <NxTableRow key={name} isClickable selected={selected} onClick={() => alert(`Clicked ${name}`)}>
-            <NxTableCell>{name}</NxTableCell>
-            <NxTableCell>Content</NxTableCell>
-            <NxTableCell chevron/>
-          </NxTableRow>
+          <NxTable.Row key={name} isClickable selected={selected} onClick={() => alert(`Clicked ${name}`)}>
+            <NxTable.Cell>{name}</NxTable.Cell>
+            <NxTable.Cell>Content</NxTable.Cell>
+            <NxTable.Cell chevron/>
+          </NxTable.Row>
         )}
-      </NxTableBody>
+      </NxTable.Body>
     </NxTable>
   );
 };

--- a/gallery/src/components/NxTable/NxTableEmptyExample.tsx
+++ b/gallery/src/components/NxTable/NxTableEmptyExample.tsx
@@ -6,28 +6,21 @@
  */
 import React from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow
-} from '@sonatype/react-shared-components';
+import { NxTable } from '@sonatype/react-shared-components';
 
 const NxTableLoadingExample = () => {
   return (
     <NxTable>
-      <NxTableHead>
-        <NxTableRow>
-          <NxTableCell>Header 1</NxTableCell>
-          <NxTableCell>Header 2</NxTableCell>
-          <NxTableCell>Header 3</NxTableCell>
-          <NxTableCell isNumeric>Header 4</NxTableCell>
-          <NxTableCell>Header 5</NxTableCell>
-        </NxTableRow>
-      </NxTableHead>
-      <NxTableBody emptyMessage="No data found.">
-      </NxTableBody>
+      <NxTable.Head>
+        <NxTable.Row>
+          <NxTable.Cell>Header 1</NxTable.Cell>
+          <NxTable.Cell>Header 2</NxTable.Cell>
+          <NxTable.Cell>Header 3</NxTable.Cell>
+          <NxTable.Cell isNumeric>Header 4</NxTable.Cell>
+          <NxTable.Cell>Header 5</NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Head>
+      <NxTable.Body emptyMessage="No data found." />
     </NxTable>
   );
 };

--- a/gallery/src/components/NxTable/NxTableErrorExample.tsx
+++ b/gallery/src/components/NxTable/NxTableErrorExample.tsx
@@ -6,28 +6,21 @@
  */
 import React from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow
-} from '@sonatype/react-shared-components';
+import { NxTable } from '@sonatype/react-shared-components';
 
 const NxTableLoadingExample = () => {
   return (
     <NxTable>
-      <NxTableHead>
-        <NxTableRow>
-          <NxTableCell>Header 1</NxTableCell>
-          <NxTableCell>Header 2</NxTableCell>
-          <NxTableCell>Header 3</NxTableCell>
-          <NxTableCell isNumeric>Header 4</NxTableCell>
-          <NxTableCell>Header 5</NxTableCell>
-        </NxTableRow>
-      </NxTableHead>
-      <NxTableBody error="Failed to load list message" retryHandler={() => {}}>
-      </NxTableBody>
+      <NxTable.Head>
+        <NxTable.Row>
+          <NxTable.Cell>Header 1</NxTable.Cell>
+          <NxTable.Cell>Header 2</NxTable.Cell>
+          <NxTable.Cell>Header 3</NxTable.Cell>
+          <NxTable.Cell isNumeric>Header 4</NxTable.Cell>
+          <NxTable.Cell>Header 5</NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Head>
+      <NxTable.Body error="Failed to load list message" retryHandler={() => {}} />
     </NxTable>
   );
 };

--- a/gallery/src/components/NxTable/NxTableFilterExample.tsx
+++ b/gallery/src/components/NxTable/NxTableFilterExample.tsx
@@ -6,14 +6,7 @@
  */
 import React, {useState} from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow,
-  NxFilterInput
-} from '@sonatype/react-shared-components';
+import { NxTable, NxFilterInput } from '@sonatype/react-shared-components';
 import { toLower, uniq } from 'ramda';
 
 const tableData = [
@@ -72,18 +65,18 @@ const NxTableFilterExample = () => {
   return (
     <div className="nx-scrollable nx-table-container">
       <NxTable className="nx-table">
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Name</NxTableCell>
-            <NxTableCell>Country</NxTableCell>
-          </NxTableRow>
-          <NxTableRow isFilterHeader>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Name</NxTable.Cell>
+            <NxTable.Cell>Country</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row isFilterHeader>
+            <NxTable.Cell>
               <NxFilterInput placeholder="Type a name"
                              onChange={onFilterNameChange}
                              value={nameFilter}/>
-            </NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>
               <NxFilterInput placeholder="Select a country"
                              list={listId}
                              onChange={onFilterCountryChange}
@@ -95,17 +88,17 @@ const NxTableFilterExample = () => {
                   ))
                 }
               </datalist>
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody emptyMessage="No data">
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body emptyMessage="No data">
           {rows.map((row: Row) =>
-            <NxTableRow key={row.name.concat(row.country)}>
-              <NxTableCell>{row.name}</NxTableCell>
-              <NxTableCell>{row.country}</NxTableCell>
-            </NxTableRow>
+            <NxTable.Row key={row.name.concat(row.country)}>
+              <NxTable.Cell>{row.name}</NxTable.Cell>
+              <NxTable.Cell>{row.country}</NxTable.Cell>
+            </NxTable.Row>
           )}
-        </NxTableBody>
+        </NxTable.Body>
       </NxTable>
     </div>
   );

--- a/gallery/src/components/NxTable/NxTableLoadingExample.tsx
+++ b/gallery/src/components/NxTable/NxTableLoadingExample.tsx
@@ -6,29 +6,21 @@
  */
 import React from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow
-} from '@sonatype/react-shared-components';
+import { NxTable } from '@sonatype/react-shared-components';
 
 const NxTableLoadingExample = () => {
   return (
     <NxTable>
-      <NxTableHead>
-        <NxTableRow>
-          <NxTableCell>Header 1</NxTableCell>
-          <NxTableCell>Header 2</NxTableCell>
-          <NxTableCell>Header 3</NxTableCell>
-          <NxTableCell isNumeric>Header 4</NxTableCell>
-          <NxTableCell>Header 5</NxTableCell>
-        </NxTableRow>
-      </NxTableHead>
-      <NxTableBody isLoading>
-
-      </NxTableBody>
+      <NxTable.Head>
+        <NxTable.Row>
+          <NxTable.Cell>Header 1</NxTable.Cell>
+          <NxTable.Cell>Header 2</NxTable.Cell>
+          <NxTable.Cell>Header 3</NxTable.Cell>
+          <NxTable.Cell isNumeric>Header 4</NxTable.Cell>
+          <NxTable.Cell>Header 5</NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Head>
+      <NxTable.Body isLoading />
     </NxTable>
   );
 };

--- a/gallery/src/components/NxTable/NxTableMetaInfoExample.tsx
+++ b/gallery/src/components/NxTable/NxTableMetaInfoExample.tsx
@@ -6,36 +6,29 @@
  */
 import React from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow,
-  NxWarningAlert
-} from '@sonatype/react-shared-components';
+import { NxTable, NxWarningAlert } from '@sonatype/react-shared-components';
 
 const NxTableLoadingExample = () => {
   return (
     <NxTable>
-      <NxTableHead>
-        <NxTableRow>
-          <NxTableCell>Header 1</NxTableCell>
-          <NxTableCell>Header 2</NxTableCell>
-          <NxTableCell>Header 3</NxTableCell>
-          <NxTableCell isNumeric>Header 4</NxTableCell>
-          <NxTableCell>Header 5</NxTableCell>
-        </NxTableRow>
-      </NxTableHead>
-      <NxTableBody>
-        <NxTableRow>
-          <NxTableCell colSpan={5} metaInfo>
+      <NxTable.Head>
+        <NxTable.Row>
+          <NxTable.Cell>Header 1</NxTable.Cell>
+          <NxTable.Cell>Header 2</NxTable.Cell>
+          <NxTable.Cell>Header 3</NxTable.Cell>
+          <NxTable.Cell isNumeric>Header 4</NxTable.Cell>
+          <NxTable.Cell>Header 5</NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Head>
+      <NxTable.Body>
+        <NxTable.Row>
+          <NxTable.Cell colSpan={5} metaInfo>
             <NxWarningAlert>
               This table data cannot be displayed due to quantum entanglement, or something.
             </NxWarningAlert>
-          </NxTableCell>
-        </NxTableRow>
-      </NxTableBody>
+          </NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Body>
     </NxTable>
   );
 };

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -8,13 +8,7 @@ import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow
-} from '@sonatype/react-shared-components';
+import { NxTable } from '@sonatype/react-shared-components';
 
 import NxTableSimpleExample from './NxTableSimpleExample';
 import NxTableClickableExample from './NxTableClickableExample';
@@ -66,134 +60,126 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             The top-level component to use when displaying tables of data.
-            It can have <code className="nx-code">NxTableHead</code> and
-            {' '}<code className="nx-code">NxTableBody</code> components as children. It can receive any attribute
+            It can have <code className="nx-code">NxTable.Head</code> and
+            {' '}<code className="nx-code">NxTable.Body</code> components as children. It can receive any attribute
             that would be valid on a <code className="nx-code">&lt;table&gt;</code>.
           </p>
         </section>
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTableHead</h3>
+            <h3 className="nx-h3">NxTable.Head</h3>
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;thead&gt;</code> element.
-            The <code className="nx-code">NxTableRow</code> component is the only valid child. This component can
+            The <code className="nx-code">NxTable.Row</code> component is the only valid child. This component can
             receive any attribute that would be valid on a <code className="nx-code">&lt;thead&gt;</code>.
           </p>
         </section>
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTableBody</h3>
+            <h3 className="nx-h3">NxTable.Body</h3>
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;tbody&gt;</code> element.
-            It should have <code className="nx-code">NxTableRow</code> for children. This component can
+            It should have <code className="nx-code">NxTable.Row</code> for children. This component can
             receive any attribute that would be valid on a <code className="nx-code">&lt;tbody&gt;</code> as well as the
             following props:
           </p>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Prop</NxTableCell>
-                <NxTableCell>Type</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Details</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell>isLoading</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>Used to show a loading spinner instead of the table content</NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>error</NxTableCell>
-                <NxTableCell>string</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>Used to show an error message instead of the table content</NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>retryHandler</NxTableCell>
-                <NxTableCell>Function</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>isLoading</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>Used to show a loading spinner instead of the table content</NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>error</NxTable.Cell>
+                <NxTable.Cell>string</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>Used to show an error message instead of the table content</NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>retryHandler</NxTable.Cell>
+                <NxTable.Cell>Function</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Used to provide the handler for the Retry button that appears when the error state is active.
                   Required when <code className="nx-code">error</code> is present.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>emptyMessage</NxTableCell>
-                <NxTableCell>string</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>emptyMessage</NxTable.Cell>
+                <NxTable.Cell>string</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Used to show a message when the table is otherwise empty (i.e. when it has no externally specified
                   child rows, is not loading, and is not in an error state. This prop must be specified if the
                   table is empty. If this table is not empty, this prop may be specified, having no effect.
                   In essence, the best practice is to specify this prop on all tables which <em>may</em> be empty.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
         </section>
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTableRow</h3>
+            <h3 className="nx-h3">NxTable.Row</h3>
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;tr&gt;</code> element.
-            It should have <code className="nx-code">NxTableCell</code> for children. This component can
+            It should have <code className="nx-code">NxTable.Cell</code> for children. This component can
             receive any attribute that would be valid on a <code className="nx-code">&lt;tr&gt;</code> as well as the
             following props:
           </p>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Prop</NxTableCell>
-                <NxTableCell>Type</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Details</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell>isClickable</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>Indicates that a table row is clickable.</NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>isFilterHeader</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>Indicates that this row is a table header row containing filter inputs.</NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>selected</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>isClickable</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>Indicates that a table row is clickable.</NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>isFilterHeader</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>Indicates that this row is a table header row containing filter inputs.</NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>selected</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   For clickable table rows, indicates that this row is the currently selected one.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>isHeader</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
-                  Automatically set to true when in an <code className="nx-code">NxTableHead</code> component
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
         </section>
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTableCell</h3>
+            <h3 className="nx-h3">NxTable.Cell</h3>
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;th&gt;</code> or
@@ -203,77 +189,77 @@ export default function NxTablePage() {
           </p>
 
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Prop</NxTableCell>
-                <NxTableCell>Type</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Details</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell>metaInfo</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>metaInfo</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Sets the <code className="nx-code">.nx-cell--meta-info</code> class on the cell. This class is
                   applied to table cells that provide meta-information about the table data, such as loading, error,
                   and empty table states. For those three states, the caller of
                   the <code className="nx-code">NxTable</code> react component does not manage the table cells
-                  directly (instead using the appropriate props on <code className="nx-code">NxTableBody</code>), and
+                  directly (instead using the appropriate props on <code className="nx-code">NxTable.Body</code>), and
                   therefore does not need to use this prop. However, the prop is available for any
                   other meta-info states that the caller might wish to convey. The intended usage is that a cell
                   using this prop would be the only cell in the only row in the table body, and would have
                   a <code className="nx-code">colspan</code> attribute causing it to span all the way across the
                   table.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>isNumeric</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>Used for columns that contain numeric information</NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>isSortable</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>isNumeric</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>Used for columns that contain numeric information</NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>isSortable</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Used for column headers that can be sorted. Should not be applied to data cells
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>sortDir</NxTableCell>
-                <NxTableCell style={{whiteSpace: 'nowrap'}}>asc | desc</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>sortDir</NxTable.Cell>
+                <NxTable.Cell style={{whiteSpace: 'nowrap'}}>asc | desc</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Used to indicate the sorting direction applied.
                   A null value indicates the column is not yet sorted.
-                  This should only be used for <code className="nx-code">NxTableCell</code> components
-                  in the <code className="nx-code">NxTableHead</code>
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>hasIcon</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+                  This should only be used for <code className="nx-code">NxTable.Cell</code> components
+                  in the <code className="nx-code">NxTable.Head</code>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>hasIcon</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Used to indicate a column whose data cells contain only one or
                   more <code className="nx-code">NxFontAwesomeIcon</code>s
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>chevron</NxTableCell>
-                <NxTableCell>boolean</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>chevron</NxTable.Cell>
+                <NxTable.Cell>boolean</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Desginates a cell that should contain only the right-facing chevron icon used at that end of
-                  clickable table cells. <code className="nx-code">NxTableCell</code>s with this prop set will
+                  clickable table cells. <code className="nx-code">NxTable.Cell</code>s with this prop set will
                   self-populate with the icon, and do not take <code className="nx-code">children</code>.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
         </section>
         <section className="nx-tile-subsection">
@@ -293,43 +279,43 @@ export default function NxTablePage() {
             <code className="nx-code">pagination-table-height</code>. See the description of its parameters below.
           </p>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Name</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Default Value</NxTableCell>
-                <NxTableCell>Description</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell><code className="nx-code">$body-row-count</code></NxTableCell>
-                <NxTableCell>Yes</NxTableCell>
-                <NxTableCell>N/A</NxTableCell>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Name</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Default Value</NxTable.Cell>
+                <NxTable.Cell>Description</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell><code className="nx-code">$body-row-count</code></NxTable.Cell>
+                <NxTable.Cell>Yes</NxTable.Cell>
+                <NxTable.Cell>N/A</NxTable.Cell>
+                <NxTable.Cell>
                   The number of rows of content that the table body should have room for. This assumes that each
                   row contains only a single line of text. Wrapping text or other elements that expand the size
                   of any row will throw off the calculation.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell><code className="nx-code">$header-filter-row-count</code></NxTableCell>
-                <NxTableCell>No</NxTableCell>
-                <NxTableCell>0</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell><code className="nx-code">$header-filter-row-count</code></NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>0</NxTable.Cell>
+                <NxTable.Cell>
                   The number of filter header rows on the table.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell><code className="nx-code">$header-row-count</code></NxTableCell>
-                <NxTableCell>No</NxTableCell>
-                <NxTableCell>1</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell><code className="nx-code">$header-row-count</code></NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>1</NxTable.Cell>
+                <NxTable.Cell>
                   The number of standard header rows on the table. This number should not include the count of any
                   filter header rows.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
         </section>
 

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
-import { NxTable } from '@sonatype/react-shared-components';
+import { NxTable, NxTile, NxH3, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxTableSimpleExample from './NxTableSimpleExample';
 import NxTableClickableExample from './NxTableClickableExample';
@@ -262,6 +262,21 @@ export default function NxTablePage() {
             </NxTable.Body>
           </NxTable>
         </section>
+
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
+            <NxH3>Deprecated Component Names</NxH3>
+          </NxTile.SubsectionHeader>
+          <NxP>
+            As seen above, the various child components of <NxCode>NxTable</NxCode> are attached as properties on the
+            <NxCode>NxTable</NxCode> object and typically accessed using JavaScript dot notation. In previous versions
+            of RSC, this was not the case and the subobjects were instead exposed as top level exports with names along
+            the lines of <NxCode>NxTableRow</NxCode>, <NxCode>NxTableCell</NxCode>, and so on. These old names are still
+            exported by RSC for backwards compatibility, but are deprecated and may be removed in a future major version
+            release.
+          </NxP>
+        </NxTile.Subsection>
+
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
             <h3 className="nx-h3">SCSS Helper Functions</h3>

--- a/gallery/src/components/NxTable/NxTablePaginationExample.tsx
+++ b/gallery/src/components/NxTable/NxTablePaginationExample.tsx
@@ -6,14 +6,7 @@
  */
 import React, {useState} from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow,
-  NxPagination
-} from '@sonatype/react-shared-components';
+import { NxTable, NxPagination } from '@sonatype/react-shared-components';
 import { slice } from 'ramda';
 
 interface Row { name: string; country: string }
@@ -40,20 +33,20 @@ const NxTablePaginationExample = () => {
   return (
     <div className="nx-table-container gallery-pagination-table-example">
       <NxTable id="pagination-table" aria-live="polite">
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Name</NxTableCell>
-            <NxTableCell>Country</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Name</NxTable.Cell>
+            <NxTable.Cell>Country</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
           {rows.map((row: Row) =>
-            <NxTableRow key={row.name.concat(row.country)}>
-              <NxTableCell>{row.name}</NxTableCell>
-              <NxTableCell>{row.country}</NxTableCell>
-            </NxTableRow>
+            <NxTable.Row key={row.name.concat(row.country)}>
+              <NxTable.Cell>{row.name}</NxTable.Cell>
+              <NxTable.Cell>{row.country}</NxTable.Cell>
+            </NxTable.Row>
           )}
-        </NxTableBody>
+        </NxTable.Body>
       </NxTable>
       <div className="nx-table-container__footer">
         <NxPagination aria-controls="pagination-table"

--- a/gallery/src/components/NxTable/NxTablePaginationFilterExample.tsx
+++ b/gallery/src/components/NxTable/NxTablePaginationFilterExample.tsx
@@ -6,15 +6,7 @@
  */
 import React, {useState} from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow,
-  NxPagination,
-  NxFilterInput
-} from '@sonatype/react-shared-components';
+import { NxTable, NxPagination, NxFilterInput } from '@sonatype/react-shared-components';
 import { slice, toLower, pipe, prop, includes, filter, both } from 'ramda';
 
 interface Row { name: string; country: string }
@@ -48,34 +40,34 @@ const NxTablePaginationFilterExample = () => {
   return (
     <div className="nx-table-container gallery-pagination-filter-table-example">
       <NxTable id="pagination-filter-table" aria-live="polite">
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Name</NxTableCell>
-            <NxTableCell>Country</NxTableCell>
-          </NxTableRow>
-          <NxTableRow isFilterHeader>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Name</NxTable.Cell>
+            <NxTable.Cell>Country</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row isFilterHeader>
+            <NxTable.Cell>
               <NxFilterInput placeholder="Type a name"
                              onChange={setNameFilter}
                              value={nameFilter}
                              aria-controls="pagination-filter-table"/>
-            </NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>
               <NxFilterInput placeholder="Select a country"
                              onChange={setCountryFilter}
                              value={countryFilter}
                              aria-controls="pagination-filter-table"/>
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody emptyMessage="No rows match the current filter">
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body emptyMessage="No rows match the current filter">
           { rows && rows.map((row: Row) =>
-            <NxTableRow key={row.name.concat(row.country)}>
-              <NxTableCell>{row.name}</NxTableCell>
-              <NxTableCell>{row.country}</NxTableCell>
-            </NxTableRow>
+            <NxTable.Row key={row.name.concat(row.country)}>
+              <NxTable.Cell>{row.name}</NxTable.Cell>
+              <NxTable.Cell>{row.country}</NxTable.Cell>
+            </NxTable.Row>
           )}
-        </NxTableBody>
+        </NxTable.Body>
       </NxTable>
       <div className="nx-table-container__footer">
         <NxPagination aria-controls="pagination-filter-table" { ...{ pageCount, currentPage } } onChange={setPage} />

--- a/gallery/src/components/NxTable/NxTableSimpleExample.tsx
+++ b/gallery/src/components/NxTable/NxTableSimpleExample.tsx
@@ -6,49 +6,42 @@
  */
 import React from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow,
-  NxFontAwesomeIcon
-} from '@sonatype/react-shared-components';
+import { NxTable, NxFontAwesomeIcon } from '@sonatype/react-shared-components';
 import { faAtom, faBatteryEmpty, faCarBattery } from '@fortawesome/free-solid-svg-icons';
 
 const NxTableSimpleExample = () => {
   return (
     <NxTable>
-      <NxTableHead>
-        <NxTableRow>
-          <NxTableCell>Header 1</NxTableCell>
-          <NxTableCell>Header 2</NxTableCell>
-          <NxTableCell>Header 3</NxTableCell>
-          <NxTableCell isNumeric>Header 4</NxTableCell>
-          <NxTableCell hasIcon>Header 5 - icons</NxTableCell>
-        </NxTableRow>
-      </NxTableHead>
-      <NxTableBody>
-        <NxTableRow>
-          <NxTableCell>Content 1</NxTableCell>
-          <NxTableCell>Content 2</NxTableCell>
-          <NxTableCell>Content 3</NxTableCell>
-          <NxTableCell isNumeric>4</NxTableCell>
-          <NxTableCell hasIcon>
+      <NxTable.Head>
+        <NxTable.Row>
+          <NxTable.Cell>Header 1</NxTable.Cell>
+          <NxTable.Cell>Header 2</NxTable.Cell>
+          <NxTable.Cell>Header 3</NxTable.Cell>
+          <NxTable.Cell isNumeric>Header 4</NxTable.Cell>
+          <NxTable.Cell hasIcon>Header 5 - icons</NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Head>
+      <NxTable.Body>
+        <NxTable.Row>
+          <NxTable.Cell>Content 1</NxTable.Cell>
+          <NxTable.Cell>Content 2</NxTable.Cell>
+          <NxTable.Cell>Content 3</NxTable.Cell>
+          <NxTable.Cell isNumeric>4</NxTable.Cell>
+          <NxTable.Cell hasIcon>
             <NxFontAwesomeIcon icon={faAtom} />
             <NxFontAwesomeIcon icon={faCarBattery} />
-          </NxTableCell>
-        </NxTableRow>
-        <NxTableRow>
-          <NxTableCell>Content 1</NxTableCell>
-          <NxTableCell>Content 2</NxTableCell>
-          <NxTableCell>Content 3</NxTableCell>
-          <NxTableCell isNumeric>4</NxTableCell>
-          <NxTableCell hasIcon>
+          </NxTable.Cell>
+        </NxTable.Row>
+        <NxTable.Row>
+          <NxTable.Cell>Content 1</NxTable.Cell>
+          <NxTable.Cell>Content 2</NxTable.Cell>
+          <NxTable.Cell>Content 3</NxTable.Cell>
+          <NxTable.Cell isNumeric>4</NxTable.Cell>
+          <NxTable.Cell hasIcon>
             <NxFontAwesomeIcon icon={faBatteryEmpty} />
-          </NxTableCell>
-        </NxTableRow>
-      </NxTableBody>
+          </NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Body>
     </NxTable>
   );
 };

--- a/gallery/src/components/NxTable/NxTableSortableExample.tsx
+++ b/gallery/src/components/NxTable/NxTableSortableExample.tsx
@@ -6,13 +6,7 @@
  */
 import React, {useState} from 'react';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow
-} from '@sonatype/react-shared-components';
+import { NxTable } from '@sonatype/react-shared-components';
 
 const initialState = ['A', '1', 'B', '2', 'C', '3', 'D', '4'];
 
@@ -37,18 +31,18 @@ const NxTableSortableExample = () => {
 
   return (
     <NxTable>
-      <NxTableHead>
-        <NxTableRow>
-          <NxTableCell isSortable sortDir={sortDir} onClick={sort}>Name</NxTableCell>
-        </NxTableRow>
-      </NxTableHead>
-      <NxTableBody>
+      <NxTable.Head>
+        <NxTable.Row>
+          <NxTable.Cell isSortable sortDir={sortDir} onClick={sort}>Name</NxTable.Cell>
+        </NxTable.Row>
+      </NxTable.Head>
+      <NxTable.Body>
         {rows.map(row =>
-          <NxTableRow key={row}>
-            <NxTableCell>{row}</NxTableCell>
-          </NxTableRow>
+          <NxTable.Row key={row}>
+            <NxTable.Cell>{row}</NxTable.Cell>
+          </NxTable.Row>
         )}
-      </NxTableBody>
+      </NxTable.Body>
     </NxTable>
   );
 };

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTable/NxTable.tsx
+++ b/lib/src/components/NxTable/NxTable.tsx
@@ -11,6 +11,7 @@ import {only} from '../../util/childUtil';
 import NxTableHead from './NxTableHead';
 import NxTableBody from './NxTableBody';
 import NxTableRow from './NxTableRow';
+import NxTableCell from './NxTableCell';
 import { ColumnCountContext } from './contexts';
 
 import { NxTableProps, nxTablePropTypes } from './types';
@@ -32,6 +33,11 @@ const NxTable = function NxTableElement(props: NxTableProps) {
     </table>
   );
 };
+
+NxTable.Body = NxTableBody;
+NxTable.Head = NxTableHead;
+NxTable.Row = NxTableRow;
+NxTable.Cell = NxTableCell;
 
 NxTable.propTypes = nxTablePropTypes;
 

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -59,6 +59,8 @@ export { default as NxStatefulSubmitMask }
   from './components/NxSubmitMask/stateful/NxStatefulSubmitMask';
 
 export { default as NxTable, NxTableProps } from './components/NxTable/NxTable';
+
+// deprecated, use NxTable.Body etc now
 export { default as NxTableBody, NxTableBodyProps } from './components/NxTable/NxTableBody';
 export { default as NxTableCell, NxTableCellProps } from './components/NxTable/NxTableCell';
 export { default as NxTableHead, NxTableHeadProps } from './components/NxTable/NxTableHead';


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-543

Switches the `NxTable` subcomponents to a `NxTable.*` style of organization to match our other component families.