### PR TITLE
Use Small Size for Icon-only buttons in Page Headers - RSC-560

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
+++ b/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
@@ -13,6 +13,7 @@ import NxNexusPageHeaderCustomLogoExample from './NxNexusPageHeaderCustomLogoExa
 import NxNexusPageHeaderMetaExample from './NxNexusPageHeaderMetaExample';
 import NxNexusPageHeaderVersionExample from './NxNexusPageHeaderVersionExample';
 import NxNexusPageHeaderMinimalExample from './NxNexusPageHeaderMinimalExample';
+import { NxCode } from '@sonatype/react-shared-components';
 
 const nxNexusPageHeaderExampleCode = require('./NxNexusPageHeaderExample?raw');
 const nxNexusPageHeaderCustomLogoExampleCode = require('./NxNexusPageHeaderCustomLogoExample?raw');
@@ -142,7 +143,10 @@ const NxNexusPageHeaderPage = () =>
                         liveExample={NxNexusPageHeaderExample}
                         defaultCheckeredBackground={true}>
       An instance of <code className="nx-code">NxNexusPageHeader</code> with default branding, navigation and
-      examples of extra content.
+      examples of extra content. A note about the extra content: icon-only buttons added in this area will
+      be of the smaller size that is also present in certain other areas (action buttons
+      within <NxCode>nx-list</NxCode>, for example). Placing these buttons alongside other buttons which have actual
+      text content is not supported due to the height difference.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Nexus Page Header with Meta"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-page-header.scss
+++ b/lib/src/base-styles/_nx-page-header.scss
@@ -83,6 +83,10 @@ $main-header-product-version-row-height: 1fr;
   @include container-horizontal;
 
   margin-left: auto;
+
+  .nx-btn--icon-only {
+    @include nx-small-icon-btn;
+  }
 }
 
 .nx-product {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-560

I confirmed with @dturner32 that we want this, though at the same time I'm not sure it'll ever matter as these page headers are going out of style in favor of the one that matches the global sidebar.