### PR TITLE
Fix header spacing RSC-555

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -32,10 +32,12 @@
 
       &:first-child {
         border-left-style: solid;
+        padding-left: $nx-spacing-md - $border-width;
       }
 
       &:last-child {
         border-right-style: solid;
+        padding-right: $nx-spacing-md - $border-width;
       }
 
       // Used for table cells container meta-information such as the fact that the table is empty, or
@@ -123,7 +125,6 @@
     width: calc(100% + 0.9999px);
 
     > thead > :first-child {
-      
       > .nx-cell {
         &:first-child, &:last-child {
           border-radius: 0;
@@ -201,11 +202,11 @@
   vertical-align: top;
 
   &:first-child {
-    padding-left: $nx-spacing-md - 1px;
+    padding-left: $nx-spacing-md;
   }
 
   &:last-child {
-    padding-right: $nx-spacing-md - 1px;
+    padding-right: $nx-spacing-md;
   }
 
   > .nx-btn-bar {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-555

The header cells shouldn't have had the single pixel subtracted from the l/r padding, this PR restores that pixel.