### PR TITLE
Overflow Tooltip Firefox Bug - RSC-559

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "6.2.3",
+  "version": "6.3.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "6.2.3",
+  "version": "6.3.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTooltip/NxOverflowTooltip.tsx
+++ b/lib/src/components/NxTooltip/NxOverflowTooltip.tsx
@@ -16,7 +16,9 @@ import { any } from 'ramda';
 export { OverflowTooltipProps };
 
 function isOverflowing(el: Element) {
-  return el.clientWidth < el.scrollWidth;
+  // inline elements always report 0 clientWidth in standards-compliant browsers. At the same time, inline elements
+  // cannot (themselves) overflow.
+  return el.clientWidth < el.scrollWidth && getComputedStyle(el).display !== 'inline';
 }
 
 function selfOrChildrenOverflowing(el: Element): boolean {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-559

Note that as a browser-specific bug, there isn't much we can do to add tests for this unless we wanted to run our visual testing suite on multiple browsers.