### PR TITLE
clean up html attribute docs RSC-576 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -36,10 +36,6 @@ const NxAccordionPage = () =>
         <header className="nx-tile-subsection__header">
           <h3 className="nx-h3">NxAccordion</h3>
         </header>
-        <p className="nx-p">
-          In addition to all standard HTML <code className="nx-code">&lt;details&gt;</code> attributes,{' '}
-          <code className="nx-code">NxAccordion</code> can receive the following props:
-        </p>
         <NxTable>
           <NxTableHead>
             <NxTableRow>
@@ -73,6 +69,20 @@ const NxAccordionPage = () =>
               <NxTableCell>
                 Whether or not the accordion should be rendered "open" with its full content visible, as
                 opposed to collapsed.
+              </NxTableCell>
+            </NxTableRow>
+            <NxTableRow>
+              <NxTableCell>Details HTML Attributes</NxTableCell>
+              <NxTableCell>
+                <a target="_blank"
+                   rel="noopener"
+                   href="https://developer.mozilla.org/en/docs/Web/HTML/Element/details">
+                  HTML details Attributes
+                </a>
+              </NxTableCell>
+              <NxTableCell>No</NxTableCell>
+              <NxTableCell>
+                NxAccordion supports any html attribute that's normally supported by the Details element
               </NxTableCell>
             </NxTableRow>
           </NxTableBody>

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxInfoAlert }
+import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxInfoAlert, NxCode }
   from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
@@ -72,7 +72,7 @@ const NxAccordionPage = () =>
               </NxTableCell>
             </NxTableRow>
             <NxTableRow>
-              <NxTableCell>Details HTML Attributes</NxTableCell>
+              <NxTableCell>HTML <NxCode>&lt;details&gt;</NxCode> Attributes</NxTableCell>
               <NxTableCell>
                 <a target="_blank"
                    rel="noopener"
@@ -82,7 +82,8 @@ const NxAccordionPage = () =>
               </NxTableCell>
               <NxTableCell>No</NxTableCell>
               <NxTableCell>
-                NxAccordion supports any html attribute that's normally supported by the Details element
+                NxAccordion supports any html attribute that's normally supported by the
+                {' '}<NxCode>&lt;details&gt;</NxCode> element
               </NxTableCell>
             </NxTableRow>
           </NxTableBody>

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -14,7 +14,7 @@ import NxButtonTertiaryExample from './NxButtonTertiaryExample';
 import NxButtonErrorExample from './NxButtonErrorExample';
 import NxButtonIconExample from './NxButtonIconExample';
 import NxButtonIconOnlyExample from './NxButtonIconOnlyExample';
-import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody } from '@sonatype/react-shared-components';
+import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody, NxCode } from '@sonatype/react-shared-components';
 
 const NxButtonDefaultCode = require('./NxButtonDefaultExample?raw'),
     nxButtonPrimaryCode = require('./NxButtonPrimaryExample?raw'),
@@ -63,17 +63,19 @@ export default function NxButtonPage() {
               </NxTableCell>
             </NxTableRow>
             <NxTableRow>
-              <NxTableCell>Button HTML Attributes</NxTableCell>
+              <NxTableCell>HTML <NxCode>&lt;button&gt;</NxCode> Attributes</NxTableCell>
               <NxTableCell>
                 <a target="_blank"
                    rel="noopener"
-                   href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
-                  HTML Attributes
+                   href="https://developer.mozilla.org/en/docs/Web/HTML/Element/button">
+                  HTML button Attributes
                 </a>
               </NxTableCell>
               <NxTableCell>No</NxTableCell>
+              <NxTableCell></NxTableCell>
               <NxTableCell>
-                NxButton supports any html attribute that's normally supported by the Button element
+                <NxCode>NxButton</NxCode> supports any html attribute that's normally supported by the
+                {' '}<NxCode>&lt;button&gt;</NxCode> element.
               </NxTableCell>
             </NxTableRow>
           </NxTableBody>

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -30,8 +30,7 @@ export default function NxButtonPage() {
         <p className="nx-p">
           <code className="nx-code">NxButton</code> is a react wrapper around
           HTML <code className="nx-code">&lt;button&gt;</code> elements using
-          the <code className="nx-code">.nx-btn</code> CSS class. It accepts
-          any <code className="nx-code">&lt;button&gt;</code> attribute as well as the following props:
+          the <code className="nx-code">.nx-btn</code> CSS class.
         </p>
         <NxTable>
           <NxTableHead>
@@ -61,6 +60,20 @@ export default function NxButtonPage() {
                 for buttons that include text content, but icon-only buttons should use this to make the button's
                 meaning clear in all contexts. Omitting this prop when using an icon-only button is deprecated and will
                 become unsupported in a future release.
+              </NxTableCell>
+            </NxTableRow>
+            <NxTableRow>
+              <NxTableCell>Button HTML Attributes</NxTableCell>
+              <NxTableCell>
+                <a target="_blank"
+                   rel="noopener"
+                   href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
+                  HTML Attributes
+                </a>
+              </NxTableCell>
+              <NxTableCell>No</NxTableCell>
+              <NxTableCell>
+                NxButton supports any html attribute that's normally supported by the Button element
               </NxTableCell>
             </NxTableRow>
           </NxTableBody>

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -19,10 +19,6 @@ const NxCheckboxPage = () =>
     <GalleryDescriptionTile>
       <p className="nx-p">Custom checkbox input.</p>
       <p className="nx-p">Child VDOM will be used as a label following the checkbox button itself.</p>
-      <p className="nx-p">
-        NxCheckbox can receive any attribute that would be valid on an
-        HTML <code className="nx-code">&lt;label&gt;</code> as well as the following prop
-      </p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">
@@ -82,6 +78,21 @@ const NxCheckboxPage = () =>
                  className="nx-text-link">
                 phrasing content
               </a>
+            </td>
+          </tr>
+          <tr className="nx-table-row">
+            <td className="nx-cell">Label HTML Attributes</td>
+            <td className="nx-cell">
+              <a target="_blank"
+                 rel="noopener"
+                 href="https://developer.mozilla.org/en/docs/Web/HTML/Element/label">
+                HTML label Attributes
+              </a>
+            </td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
+              NxCheckbox supports any html attribute that's normally supported by the
+              <code className="nx-code">label</code> element.
             </td>
           </tr>
         </tbody>

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -81,7 +81,7 @@ const NxCheckboxPage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell">Label HTML Attributes</td>
+            <td className="nx-cell">HTML <code className="nx-code">&lt;label&gt;</code> Attributes</td>
             <td className="nx-cell">
               <a target="_blank"
                  rel="noopener"

--- a/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
+++ b/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
@@ -79,7 +79,7 @@ const NxColorPickerPage = () =>
             </NxTableCell>
           </NxTableRow>
           <NxTableRow>
-            <NxTableCell>HTML fieldset Attributes</NxTableCell>
+            <NxTableCell>HTML <code className="nx-code">&lt;fieldset&gt;</code> Attributes</NxTableCell>
             <NxTableCell>
               <a className="nx-text-link"
                  target="_blank"
@@ -92,7 +92,7 @@ const NxColorPickerPage = () =>
             <NxTableCell></NxTableCell>
             <NxTableCell>
               NxColorPicker supports any html attribute that's normally supported by
-              {' '}<code className="nx-code">fieldset</code> elements.
+              {' '}<code className="nx-code">&lt;fieldset&gt;</code> elements.
             </NxTableCell>
           </NxTableRow>
         </NxTableBody>

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -132,7 +132,7 @@ const NxDropdownPage = () =>
               </td>
             </tr>
             <tr className="nx-table-row">
-              <td className="nx-cell">HTML div Attributes</td>
+              <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
               <td className="nx-cell">
                 <a target="_blank"
                    rel="noopener"
@@ -143,7 +143,7 @@ const NxDropdownPage = () =>
               <td className="nx-cell">No</td>
               <td className="nx-cell">
                 NxDropdown supports any html attribute that's normally supported by
-                {' '}<code className="nx-code">div</code> elements.
+                {' '}<code className="nx-code">&lt;div&gt;</code> elements.
               </td>
             </tr>
           </tbody>

--- a/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
+++ b/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
@@ -75,7 +75,7 @@ const NxFilterInputPage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell">Input HTML Attributes</td>
+            <td className="nx-cell">HTML <code className="nx-code">&lt;input&gt;</code> Attributes</td>
             <td className="nx-cell">
               <a target="_blank"
                  rel="noopener"

--- a/gallery/src/components/NxGlobalSidebar/NxGlobalSidebarPage.tsx
+++ b/gallery/src/components/NxGlobalSidebar/NxGlobalSidebarPage.tsx
@@ -104,6 +104,21 @@ export default function NxGlobalSidebarPage() {
                   When the logo is clicked it navigates to a page (typically Home) specified here.
                 </NxTable.Cell>
               </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
+                    HTML div Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxGlobalSidebar</code> supports any HTML attribute that's normally
+                  supported by <code className="nx-code">&lt;div&gt;</code>.
+                </NxTable.Cell>
+              </NxTable.Row>
             </NxTable.Body>
           </NxTable>
         </NxTile.Subsection>
@@ -113,17 +128,39 @@ export default function NxGlobalSidebarPage() {
           </NxTile.SubsectionHeader>
           <NxP>
             <NxCode>NxGlobalSidebarNavigation</NxCode> is a container for navigation links.
-            It accepts all standard <NxCode>&lt;div&gt;</NxCode> HTML attributes.
           </NxP>
+          <NxTable>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
+                    HTML div Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxGlobalSidebar</code> supports any HTML attribute that's normally
+                  supported by <code className="nx-code">&lt;div&gt;</code>.
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
+          </NxTable>
         </NxTile.Subsection>
         <NxTile.Subsection>
           <NxTile.SubsectionHeader>
             <h3 className="nx-h3"><NxCode>NxGlobalSidebarNavigationLink</NxCode> Props</h3>
           </NxTile.SubsectionHeader>
-          <NxP>
-            In addition to all standard <NxCode>&lt;a&gt;</NxCode> HTML attributes,
-            <NxCode>NxGlobalSidebarNavigationLink</NxCode> can receive the following props:
-          </NxP>
           <NxTable>
             <NxTable.Head>
               <NxTable.Row>
@@ -159,6 +196,21 @@ export default function NxGlobalSidebarPage() {
                 <NxTable.Cell>string</NxTable.Cell>
                 <NxTable.Cell>Yes</NxTable.Cell>
                 <NxTable.Cell>URL</NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;a&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/a">
+                    HTML a Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxGlobalSidebarNavigationLink</code> supports any HTML attribute that's
+                  normally supported by <code className="nx-code">&lt;a&gt;</code>.
+                </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
           </NxTable>

--- a/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
+++ b/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
@@ -19,10 +19,6 @@ const NxIndeterminatePaginationPage = () =>
         A pagination control for use in cases where the current page number and total number of pages is indeterminate.
         This component simply allows the user to navigate to the next and previous pages.
       </p>
-      <p className="nx-p">
-        In addition to all native attributes allowed on a <code className="nx-code">div</code>, the following props
-        are supported.
-      </p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">
@@ -49,6 +45,21 @@ const NxIndeterminatePaginationPage = () =>
             <td className="nx-cell">
               The callback handler for when the next page button is clicked. The mouse event is passed as
               an argument.
+            </td>
+          </tr>
+          <tr className="nx-table-row">
+            <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
+            <td className="nx-cell">
+              <a target="_blank"
+                 rel="noopener"
+                 href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
+                HTML div Attributes
+              </a>
+            </td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
+              <code className="nx-code">NxIndeterminatePagination</code> supports any HTML attribute that's normally
+              supported by <code className="nx-code">&lt;div&gt;</code> elements.
             </td>
           </tr>
         </tbody>

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -32,6 +32,67 @@ export default function NxModalPage() {
           <code className="nx-code">NxModal</code> is the preferred way to handle modals. It creates a foreground modal
           window along with a backdrop mask over the rest of the page.
         </NxP>
+        <h3>Props</h3>
+        <table className="nx-table nx-table--gallery-props">
+          <thead>
+            <tr className="nx-table-row">
+              <th className="nx-cell nx-cell--header">Prop</th>
+              <th className="nx-cell nx-cell--header">Type</th>
+              <th className="nx-cell nx-cell--header">Required</th>
+              <th className="nx-cell nx-cell--header">Default</th>
+              <th className="nx-cell nx-cell--header">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="nx-table-row">
+              <td className="nx-cell">className</td>
+              <td className="nx-cell">string</td>
+              <td className="nx-cell">No</td>
+              <td className="nx-cell"></td>
+              <td className="nx-cell">
+                Any <code className="nx-code">className</code> attributes passed in on
+                the <code className="nx-code">NxModal</code> element will be added to
+                the <code className="nx-code">nx-modal</code> class on the modal div.
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell">onClose</td>
+              <td className="nx-cell">Function (() =&gt; void)</td>
+              <td className="nx-cell">Yes</td>
+              <td className="nx-cell"></td>
+              <td className="nx-cell">
+                The function to be called to close the modal when pressing
+                the <code className="nx-code">Escape</code> key.
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell">variant</td>
+              <td className="nx-cell">"wide" | "narrow" | "normal"</td>
+              <td className="nx-cell">No</td>
+              <td className="nx-cell">"normal"</td>
+              <td className="nx-cell">
+                This prop specifies a style variant for the modal. Currently, variants only differ in width.
+                "wide" modals are 1000px wide, "normal" modals are 800px wide, and "narrow" modals are 600px wide.
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
+              <td className="nx-cell">
+                <a target="_blank"
+                   rel="noopener"
+                   href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
+                  HTML Attributes
+                </a>
+              </td>
+              <td className="nx-cell">No</td>
+              <td className="nx-cell"></td>
+              <td className="nx-cell">
+                NxModal supports any html attribute that's normally supported by
+                {' '}<code className="nx-code">&lt;div&gt;</code> elements.
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <h3>Modal Style Classes</h3>
         <table className="nx-table nx-table--gallery-props">
           <thead>
@@ -82,64 +143,6 @@ export default function NxModalPage() {
                 you want to use tabs within an <code className="nx-code">NxModal</code> as the sole contents of
                 the modal body. The modifier keeps the tabs "sticky" while allowing the tab content to scroll.
               </td>
-            </tr>
-          </tbody>
-        </table>
-        <h3>Props</h3>
-        <table className="nx-table nx-table--gallery-props">
-          <thead>
-            <tr className="nx-table-row">
-              <th className="nx-cell nx-cell--header">Prop</th>
-              <th className="nx-cell nx-cell--header">Type</th>
-              <th className="nx-cell nx-cell--header">Required</th>
-              <th className="nx-cell nx-cell--header">Default</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell">className</td>
-              <td className="nx-cell">string</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">
-                Any <code className="nx-code">className</code> attributes passed in on
-                the <code className="nx-code">NxModal</code> element will be added to
-                the <code className="nx-code">nx-modal</code> class on the modal div.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onClose</td>
-              <td className="nx-cell">Function (() =&gt; void)</td>
-              <td className="nx-cell">Yes</td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">
-                The function to be called to close the modal when pressing
-                the <code className="nx-code">Escape</code> key.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">variant</td>
-              <td className="nx-cell">"wide" | "narrow" | "normal"</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">"normal"</td>
-              <td className="nx-cell">
-                This prop specifies a style variant for the modal. Currently, variants only differ in width.
-                "wide" modals are 1000px wide, "normal" modals are 800px wide, and "narrow" modals are 600px wide.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">Div HTML Attributes</td>
-              <td className="nx-cell">
-                <a target="_blank"
-                   rel="noopener"
-                   href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
-                  HTML Attributes
-                </a>
-              </td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">NxModal supports any html attribute that's normally supported by Div elements</td>
             </tr>
           </tbody>
         </table>

--- a/gallery/src/components/NxPagination/NxPaginationPage.tsx
+++ b/gallery/src/components/NxPagination/NxPaginationPage.tsx
@@ -69,10 +69,6 @@ const NxPaginationPage = () =>
           </span>
         </li>
       </ul>
-      <p className="nx-p">
-        In addition to all native attributes allowed on a <code className="nx-code">div</code>, the following props
-        are supported.
-      </p>
       <table className="nx-table nx-table--gallery-props">
         <thead>
           <tr className="nx-table-row">
@@ -108,6 +104,21 @@ const NxPaginationPage = () =>
               Handler function which gets called whenever the user selects a different page. Receives the selected
               page as its first argument (using zero-based counting), and the button's click event as its
               second argument.
+            </td>
+          </tr>
+          <tr className="nx-table-row">
+            <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
+            <td className="nx-cell">
+              <a target="_blank"
+                 rel="noopener"
+                 href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
+                HTML div Attributes
+              </a>
+            </td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
+              <code className="nx-code">NxPagination</code> supports any HTML attribute that's normally
+              supported by <code className="nx-code">&lt;div&gt;</code> elements.
             </td>
           </tr>
         </tbody>

--- a/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
+++ b/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
@@ -65,7 +65,6 @@ const NxPolicyViolationIndicatorPage = () =>
               </a>
             </td>
             <td className="nx-cell">No</td>
-            <td className="nx-cell">N/A</td>
             <td className="nx-cell">
               NxPolicyViolationIndicator supports any HTML attribute that's normally supported
               by <code className="nx-code">&lt;div&gt;</code>.

--- a/gallery/src/components/NxRadio/NxRadioPage.tsx
+++ b/gallery/src/components/NxRadio/NxRadioPage.tsx
@@ -97,7 +97,7 @@ const NxRadioPage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell">Label HTML Attributes</td>
+            <td className="nx-cell">HTML <code className="nx-code">&lt;label&gt;</code> Attributes</td>
             <td className="nx-cell">
               <a target="_blank"
                  rel="noopener"
@@ -106,7 +106,10 @@ const NxRadioPage = () =>
               </a>
             </td>
             <td className="nx-cell">No</td>
-            <td className="nx-cell">NxRadio supports any html attribute that's normally supported by Label element</td>
+            <td className="nx-cell">
+              NxRadio supports any html attribute that's normally supported by
+              {' '}<code className="nx-code">&lt;label&gt;</code> elements.
+            </td>
           </tr>
         </tbody>
       </table>

--- a/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
+++ b/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
@@ -69,7 +69,7 @@ const NxStatefulDropdownPage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell">HTML div Attributes</td>
+            <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
             <td className="nx-cell">
               <a target="_blank"
                  rel="noopener"
@@ -80,7 +80,7 @@ const NxStatefulDropdownPage = () =>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
               NxStatefulDropdown supports any html attribute that's normally supported by
-              {' '}<code className="nx-code">div</code> elements.
+              {' '}<code className="nx-code">&lt;div&gt;</code> elements.
             </td>
           </tr>
         </tbody>

--- a/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
+++ b/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
@@ -57,7 +57,10 @@ const NxStatefulTextInputPage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell">Input HTML Attributes | Textarea HTML Attributes</td>
+            <td className="nx-cell">
+              HTML <code className="nx-code">&lt;input&gt;</code> Attributes |
+              HTML <code className="nx-code">&lt;textarea&gt;</code> Attributes
+            </td>
             <td className="nx-cell">
               <code className="nx-code">NxTextInput</code> props
             </td>

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -61,9 +61,35 @@ export default function NxTablePage() {
           <p className="nx-p">
             The top-level component to use when displaying tables of data.
             It can have <code className="nx-code">NxTable.Head</code> and
-            {' '}<code className="nx-code">NxTable.Body</code> components as children. It can receive any attribute
-            that would be valid on a <code className="nx-code">&lt;table&gt;</code>.
+            {' '}<code className="nx-code">NxTable.Body</code> components as children.
           </p>
+          <NxTable>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;table&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/table">
+                    HTML table Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxTable</code> supports any HTML attribute that's normally
+                  supported by <code className="nx-code">&lt;table&gt;</code>.
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
+          </NxTable>
         </section>
 
         <section className="nx-tile-subsection">
@@ -72,9 +98,35 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;thead&gt;</code> element.
-            The <code className="nx-code">NxTable.Row</code> component is the only valid child. This component can
-            receive any attribute that would be valid on a <code className="nx-code">&lt;thead&gt;</code>.
+            The <code className="nx-code">NxTable.Row</code> component is the only valid child.
           </p>
+          <NxTable>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;thead&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/thead">
+                    HTML thead Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxTable.Head</code> supports any HTML attribute that's normally
+                  supported by <code className="nx-code">&lt;thead&gt;</code>.
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
+          </NxTable>
         </section>
 
         <section className="nx-tile-subsection">
@@ -83,9 +135,7 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;tbody&gt;</code> element.
-            It should have <code className="nx-code">NxTable.Row</code> for children. This component can
-            receive any attribute that would be valid on a <code className="nx-code">&lt;tbody&gt;</code> as well as the
-            following props:
+            It should have <code className="nx-code">NxTable.Row</code> for children.
           </p>
           <NxTable>
             <NxTable.Head>
@@ -129,6 +179,21 @@ export default function NxTablePage() {
                   In essence, the best practice is to specify this prop on all tables which <em>may</em> be empty.
                 </NxTable.Cell>
               </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;tbody&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tbody">
+                    HTML tbody Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxTable.Body</code> supports any HTML attribute that's normally
+                  supported by <code className="nx-code">&lt;tbody&gt;</code>.
+                </NxTable.Cell>
+              </NxTable.Row>
             </NxTable.Body>
           </NxTable>
         </section>
@@ -139,9 +204,7 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;tr&gt;</code> element.
-            It should have <code className="nx-code">NxTable.Cell</code> for children. This component can
-            receive any attribute that would be valid on a <code className="nx-code">&lt;tr&gt;</code> as well as the
-            following props:
+            It should have <code className="nx-code">NxTable.Cell</code> for children.
           </p>
           <NxTable>
             <NxTable.Head>
@@ -183,6 +246,21 @@ export default function NxTablePage() {
                   content of all cells in the row will be used as the label.
                 </NxTable.Cell>
               </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;tr&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tr">
+                    HTML tr Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxTable.Row</code> supports any HTML attribute that's normally
+                  supported by <code className="nx-code">&lt;tr&gt;</code>.
+                </NxTable.Cell>
+              </NxTable.Row>
             </NxTable.Body>
           </NxTable>
         </section>
@@ -193,9 +271,7 @@ export default function NxTablePage() {
           </header>
           <p className="nx-p">
             Equivalent to the <code className="nx-code">&lt;th&gt;</code> or
-            {' '}<code className="nx-code">&lt;td&gt;</code> element. This component can
-            receive any attribute that would be valid on a <code className="nx-code">&lt;td&gt;</code> as well as the
-            following:
+            {' '}<code className="nx-code">&lt;td&gt;</code> element.
           </p>
 
           <NxTable>
@@ -270,6 +346,21 @@ export default function NxTablePage() {
                   will be wrapped in a button for accessibility purposes, with the button's accessible name set by
                   the row's <NxCode>clickAccessibleLabel</NxCode> prop or generated from the text contents of the
                   rest of the row.
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>HTML <code className="nx-code">&lt;td&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/td">
+                    HTML td Attributes
+                  </a>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
+                  <code className="nx-code">NxTable.Cell</code> supports any HTML attribute that's normally
+                  supported by <code className="nx-code">&lt;td&gt;</code>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>

--- a/gallery/src/components/NxTabs/NxTabsPage.tsx
+++ b/gallery/src/components/NxTabs/NxTabsPage.tsx
@@ -13,7 +13,8 @@ import {
   NxTableBody,
   NxTableCell,
   NxTableHead,
-  NxTableRow
+  NxTableRow,
+  NxCode
 } from '@sonatype/react-shared-components';
 
 import NxTabsTileHeaderExample from './NxTabsTileHeaderExample';
@@ -74,18 +75,20 @@ export default function NxTabsPage() {
                 </NxTableCell>
               </NxTableRow>
               <NxTableRow>
-                <NxTableCell>div, ul, li HTML Attributes</NxTableCell>
+                <NxTableCell>
+                  <NxCode>&lt;div&gt;</NxCode>, <NxCode>&lt;ul&gt;</NxCode>, <NxCode>&lt;li&gt;</NxCode> HTML Attributes
+                </NxTableCell>
                 <NxTableCell>
                   <a target="_blank"
                      rel="noopener"
                      href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                     HTML div Attributes
-                  </a>
+                  </a><br/>
                   <a target="_blank"
                      rel="noopener"
                      href="https://developer.mozilla.org/en/docs/Web/HTML/Element/ul">
                     HTML ul Attributes
-                  </a>
+                  </a><br/>
                   <a target="_blank"
                      rel="noopener"
                      href="https://developer.mozilla.org/en/docs/Web/HTML/Element/li">

--- a/gallery/src/components/NxTabs/NxTabsPage.tsx
+++ b/gallery/src/components/NxTabs/NxTabsPage.tsx
@@ -45,7 +45,6 @@ export default function NxTabsPage() {
             The top-level container for tabbed navigation.
             It can have <code className="nx-code">&lt;NxTabList&gt;</code> and
             {' '}<code className="nx-code">&lt;NxTabPanel&gt;</code> components as children.
-            Support native <code className="nx-code">&lt;div&gt;</code> attributes as well as the following props:
           </p>
 
           <NxTable className="nx-table--gallery-props">
@@ -74,6 +73,30 @@ export default function NxTabsPage() {
                   Called with the index of the newly selected tab when the currently selected tab changes.
                 </NxTableCell>
               </NxTableRow>
+              <NxTableRow>
+                <NxTableCell>div, ul, li HTML Attributes</NxTableCell>
+                <NxTableCell>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
+                    HTML div Attributes
+                  </a>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/ul">
+                    HTML ul Attributes
+                  </a>
+                  <a target="_blank"
+                     rel="noopener"
+                     href="https://developer.mozilla.org/en/docs/Web/HTML/Element/li">
+                    HTML li Attributes
+                  </a>
+                </NxTableCell>
+                <NxTableCell>No</NxTableCell>
+                <NxTableCell>
+                  NxTab supports any html attributes that are normally supported by the div, ul, and li elements.
+                </NxTableCell>
+              </NxTableRow>
             </NxTableBody>
           </NxTable>
         </section>
@@ -85,7 +108,7 @@ export default function NxTabsPage() {
 
           <p className="nx-p">
             The parent container for the <code className="nx-code">&lt;NxTab&gt;</code> components.
-            Passes through all attributes to an underlying ul element.
+            Passes through all attributes to an underlying <code className="nx-code">ul</code> element.
           </p>
         </section>
 

--- a/gallery/src/components/NxTag/NxTagPage.tsx
+++ b/gallery/src/components/NxTag/NxTagPage.tsx
@@ -50,7 +50,7 @@ const NxTagPage = () =>
             </NxTableCell>
           </NxTableRow>
           <NxTableRow>
-            <NxTableCell>HTML div Attributes</NxTableCell>
+            <NxTableCell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTableCell>
             <NxTableCell>
               <a target="_blank"
                  rel="noopener"
@@ -62,7 +62,7 @@ const NxTagPage = () =>
             <NxTableCell></NxTableCell>
             <NxTableCell>
               NxTag supports any html attribute that's normally supported by
-              {' '}<code className="nx-code">div</code> elements.
+              {' '}<code className="nx-code">&lt;div&gt;</code> elements.
             </NxTableCell>
           </NxTableRow>
         </NxTableBody>

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -113,7 +113,10 @@ const NxTextInputPage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell">Input HTML Attributes | Textarea HTML Attributes</td>
+            <td className="nx-cell">
+              HTML <code className="nx-code">&lt;input&gt;</code> Attributes |
+              HTML <code className="nx-code">&lt;textarea&gt;</code> Attributes
+            </td>
             <td className="nx-cell">
               <a target="_blank"
                  rel="noopener"
@@ -123,8 +126,9 @@ const NxTextInputPage = () =>
             </td>
             <td className="nx-cell">No</td>
             <td className="nx-cell">
-              NxTextInput supports any html attribute that's normally supported by either HTML Inputs or HTML
-              Textareas. The only notable exceptions are:
+              NxTextInput supports any html attribute that's normally supported by either HTML
+              <code className="nx-code">&lt;input&gt;</code> or HTML
+              <code className="nx-code">&lt;textarea&gt;</code>. The only notable exceptions are:
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
                   <code className="nx-code">defaultValue</code> which is left out because it creates what's commonly

--- a/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
+++ b/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
@@ -70,6 +70,21 @@ const NxThreatCounterPage = () =>
               options are <code className="nx-code">column</code> and <code className="nx-code">grid</code>.
             </td>
           </tr>
+          <tr className="nx-table-row">
+            <td className="nx-cell">HTML <code className="nx-code">&lt;dl&gt;</code> Attributes</td>
+            <td className="nx-cell">
+              <a target="_blank"
+                 rel="noopener"
+                 href="https://developer.mozilla.org/en/docs/Web/HTML/Element/dl">
+                HTML dl Attributes
+              </a>
+            </td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
+              <code className="nx-code">NxPagination</code> supports any HTML attribute that's normally
+              supported by <code className="nx-code">&lt;d&gt;</code> elements.
+            </td>
+          </tr>
         </tbody>
       </table>
     </GalleryDescriptionTile>

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -72,18 +72,6 @@ const NxTogglePage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell">Label HTML Attributes</td>
-            <td className="nx-cell">
-              <a target="_blank"
-                 rel="noopener"
-                 href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
-                HTML Attributes
-              </a>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">NxToggle supports any html attribute that's normally supported by Label element</td>
-          </tr>
-          <tr className="nx-table-row">
             <td className="nx-cell">HTML <code className="nx-code">&lt;label&gt;</code> Attributes</td>
             <td className="nx-cell">
               <a target="_blank"

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -21,10 +21,6 @@ const NxTogglePage = () =>
         Custom toggle control, which uses a hidden checkbox input for its on/checked &amp; off/unselected states.
       </p>
       <p className="nx-p">Child VDOM will be used as a label preceeding the toggle control.</p>
-      <p className="nx-p">
-        NxToggle can receive any attribute that would be valid on an
-        HTML <code className="nx-code">&lt;label&gt;</code> as well as the following props:
-      </p>
       <table className="nx-table">
         <thead>
           <tr className="nx-table-row">
@@ -73,6 +69,33 @@ const NxTogglePage = () =>
                  className="nx-text-link">
                 phrasing content
               </a>
+            </td>
+          </tr>
+          <tr className="nx-table-row">
+            <td className="nx-cell">Label HTML Attributes</td>
+            <td className="nx-cell">
+              <a target="_blank"
+                 rel="noopener"
+                 href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
+                HTML Attributes
+              </a>
+            </td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">NxToggle supports any html attribute that's normally supported by Label element</td>
+          </tr>
+          <tr className="nx-table-row">
+            <td className="nx-cell">HTML <code className="nx-code">&lt;label&gt;</code> Attributes</td>
+            <td className="nx-cell">
+              <a target="_blank"
+                 rel="noopener"
+                 href="https://developer.mozilla.org/en/docs/Web/HTML/Element/label">
+                HTML label Attributes
+              </a>
+            </td>
+            <td className="nx-cell">No</td>
+            <td className="nx-cell">
+              <code className="nx-code">NxToggle</code> supports any HTML attribute that's normally
+              supported by <code className="nx-code">&lt;label&gt;</code> elements.
             </td>
           </tr>
         </tbody>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-576

Added props table rows for the few components that were missing a row for their HTML attributes. 

Some components referenced their HTML attributes in the documentation above the props tables. In that case I removed those references and added a table row.

I then went through and used consistent styling on the HTML attributes i.e. made sure that they were wrapped in `<NxCode>` with `<>`.