### PR TITLE
nx-form accessibility RSC-427

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxFormLayout/NxFormHorizontalLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormHorizontalLayoutExample.tsx
@@ -35,7 +35,7 @@ export default function NxFormLayoutExample() {
   }
 
   return (
-    <form className="nx-form" onSubmit={onSubmit}>
+    <form className="nx-form" onSubmit={onSubmit} aria-label="Horizontal Layout Example">
       <div className="nx-form-row">
         <NxFormGroup label="Username" isRequired>
           <NxStatefulTextInput aria-required={true} validator={validator}/>

--- a/gallery/src/styles/NxFormLayout/NxFormInlineLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormInlineLayoutExample.tsx
@@ -22,7 +22,7 @@ export default function NxFormLayoutExample() {
   }
 
   return (
-    <form className="nx-form" onSubmit={onSubmit}>
+    <form className="nx-form" onSubmit={onSubmit} aria-label="Inline Form Example">
       <div className="nx-form-row">
         <NxFormGroup label="Username" isRequired>
           <NxStatefulTextInput aria-required={true} validator={validator}/>

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
@@ -59,7 +59,7 @@ export default function NxFormLayoutExample() {
   );
 
   return (
-    <form className="nx-form" onSubmit={onSubmit}>
+    <form className="nx-form" onSubmit={onSubmit} title="Default Form Layout Example">
       <NxInfoAlert>This is a sample alert message</NxInfoAlert>
       <NxFormGroup label="A Field to Fill in" isRequired>
         <NxStatefulTextInput aria-required={true} validator={validator}/>

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
@@ -59,7 +59,7 @@ export default function NxFormLayoutExample() {
   );
 
   return (
-    <form className="nx-form" onSubmit={onSubmit} title="Default Form Layout Example">
+    <form className="nx-form" onSubmit={onSubmit} aria-label="Default Form Layout Example">
       <NxInfoAlert>This is a sample alert message</NxInfoAlert>
       <NxFormGroup label="A Field to Fill in" isRequired>
         <NxStatefulTextInput aria-required={true} validator={validator}/>

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTextLink } from '@sonatype/react-shared-components';
 
 import NxFormLayoutExample from './NxFormLayoutExample';
 import NxFormHorizontalLayoutExample from './NxFormHorizontalLayoutExample';
@@ -128,6 +129,19 @@ const NxFormLayoutPage = () =>
           </tr>
         </tbody>
       </table>
+      <section className="nx-tile__subsection">
+        <h2 className="nx-h2">&lt;form&gt; Accessibility</h2>
+        <p className="nx-p">
+          Larger forms should be identified using either the <code className="nx-code">aria-label</code>
+          {' '}attribute to provide a descriptive title, or the <code className="nx-code">aria-labelled-by</code>
+          {' '}attribute when existing text is available. Doing so will include the
+          {' '}<code className="nx-code">&lt;form&gt;</code> element in the{' '}
+          <NxTextLink href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html" external>
+            landmark
+          </NxTextLink>
+          {' '}structure, and will be identified by screen readers.
+        </p>
+      </section>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-427

Per the description in the ticket in order to have the `<form>` tag recognized as part of the landmark structure it must have one of `title`, `aria-label`, or `aria-labelled-by` defined. While `title` works in Voice Over, it is not an accepted attribute of the `<form>` element (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form). Note that while `name` is an attribute of `<form>` it doesn't have any effect where VO is concerned.

I added examples of `aria-label` to the three example pages and wrote a paragraph explaining the addition.