### PR TITLE
Centre collapsed buttons RSC-503

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.1.7",
+  "version": "7.1.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.1.6",
+  "version": "7.1.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.1.7",
+  "version": "7.1.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.1.6",
+  "version": "7.1.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -95,6 +95,8 @@ $nx-global-sidebar-separator-color: var(--nx-swatch-indigo-40);
   padding: var(--nx-spacing-base)
            $nx-global-sidebar-left-right-spacing
            var(--nx-spacing-base)
+           // We need to add an extra pixel to the left to properly centre
+           // the icons when the sidebar is collapsed
            calc(#{$nx-global-sidebar-left-right-spacing} + 1px);
 
   .nx-icon {

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -10,8 +10,6 @@
 
 $nx-global-sidebar-width-open: 250px;
 $nx-global-sidebar-width-closed: 72px;
-
-$nx-global-sidebar-width-closed: 70px;
 $nx-global-sidebar-logo-height: 34px;
 $nx-global-sidebar-left-right-spacing: var(--nx-spacing-6x);
 
@@ -95,7 +93,9 @@ $nx-global-sidebar-separator-color: var(--nx-swatch-indigo-40);
   border: 1px solid transparent;
   display: block;
   padding: var(--nx-spacing-base)
-           $nx-global-sidebar-left-right-spacing;
+           $nx-global-sidebar-left-right-spacing
+           var(--nx-spacing-base)
+           calc(#{$nx-global-sidebar-left-right-spacing} + 1px);
 
   .nx-icon {
     margin: 0;

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -96,8 +96,6 @@ $nx-global-sidebar-separator-color: var(--nx-swatch-indigo-40);
   display: block;
   padding: var(--nx-spacing-base)
            $nx-global-sidebar-left-right-spacing;
-          //  var(--nx-spacing-base)
-          //  calc(#{$nx-global-sidebar-left-right-spacing} + 1px);
 
   .nx-icon {
     margin: 0;

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -10,6 +10,8 @@
 
 $nx-global-sidebar-width-open: 250px;
 $nx-global-sidebar-width-closed: 72px;
+
+$nx-global-sidebar-width-closed: 70px;
 $nx-global-sidebar-logo-height: 34px;
 $nx-global-sidebar-left-right-spacing: var(--nx-spacing-6x);
 
@@ -92,7 +94,10 @@ $nx-global-sidebar-separator-color: var(--nx-swatch-indigo-40);
 
   border: 1px solid transparent;
   display: block;
-  padding: var(--nx-spacing-base) $nx-global-sidebar-left-right-spacing;
+  padding: var(--nx-spacing-base)
+           $nx-global-sidebar-left-right-spacing;
+          //  var(--nx-spacing-base)
+          //  calc(#{$nx-global-sidebar-left-right-spacing} + 1px);
 
   .nx-icon {
     margin: 0;
@@ -147,13 +152,18 @@ $nx-global-sidebar-separator-color: var(--nx-swatch-indigo-40);
   }
 
   .nx-global-sidebar__navigation-link {
-    text-align: center;
     text-overflow: revert;
   }
 
   .nx-global-sidebar__navigation-text {
     display: inline-block;
     visibility: hidden;
+  }
+
+  .nx-global-sidebar__support {
+    .nx-icon {
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-603

For the main nav buttons I added a single pixel of padding to the left and that centres the icons in the collapsed state.

The support icon had right margin on the icon that I had to remove when the sidebar is collapsed.