### PR TITLE
focused radio checkbox RSC-600

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.1.8",
+  "version": "7.2.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.1.7",
+  "version": "7.1.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.1.5",
+  "version": "7.1.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/visualtests/nxCheckbox.js
+++ b/gallery/visualtests/nxCheckbox.js
@@ -19,7 +19,7 @@ describe('NxCheckbox', function() {
     it('has a light grey border and white background by default', simpleTest(selector));
     it('has a black border when hovered', hoverTest(selector));
 
-    it('has a blue background and white checkmark and a light blue outer border when clicked', async function() {
+    it('has a blue background and white checkmark when clicked', async function() {
       const targetElement = await browser.$(selector);
 
       await targetElement.scrollIntoView({ block: 'center' });

--- a/gallery/visualtests/nxCheckbox.js
+++ b/gallery/visualtests/nxCheckbox.js
@@ -20,13 +20,14 @@ describe('NxCheckbox', function() {
     it('has a black border when hovered', hoverTest(selector));
 
     it('has a blue background and white checkmark when clicked', async function() {
-      const targetElement = await browser.$(selector);
+      const blurSelector = `${selector} input`,
+          [targetElement, blurElement] = await Promise.all([browser.$(selector), browser.$(blurSelector)]);
 
       await targetElement.scrollIntoView({ block: 'center' });
       await targetElement.click();
       await browser.execute(function(el) {
         el.blur();
-      }, targetElement);
+      }, blurElement);
 
       try {
         await browser.eyesRegionSnapshot(null, Target.region(targetElement));

--- a/gallery/visualtests/nxCheckbox.js
+++ b/gallery/visualtests/nxCheckbox.js
@@ -24,6 +24,9 @@ describe('NxCheckbox', function() {
 
       await targetElement.scrollIntoView({ block: 'center' });
       await targetElement.click();
+      await browser.execute(function(el) {
+        el.blur();
+      }, targetElement);
 
       try {
         await browser.eyesRegionSnapshot(null, Target.region(targetElement));

--- a/gallery/visualtests/nxCheckbox.js
+++ b/gallery/visualtests/nxCheckbox.js
@@ -19,7 +19,7 @@ describe('NxCheckbox', function() {
     it('has a light grey border and white background by default', simpleTest(selector));
     it('has a black border when hovered', hoverTest(selector));
 
-    it('has a blue background and white checkmark when clicked', async function() {
+    it('has a blue background and white checkmark and a light blue outer border when clicked', async function() {
       const targetElement = await browser.$(selector);
 
       await targetElement.scrollIntoView({ block: 'center' });
@@ -34,7 +34,8 @@ describe('NxCheckbox', function() {
       }
     });
 
-    it('has a blue background, white checkmark, and glow when clicked and focused', async function() {
+    it(`has a blue background, white checkmark, a light blue outer border,
+      and glow when clicked and focused`, async function() {
       const focusSelector = `${selector} input`,
           [targetElement, focusElement] = await Promise.all([browser.$(selector), browser.$(focusSelector)]);
 
@@ -54,7 +55,8 @@ describe('NxCheckbox', function() {
       }
     });
 
-    it('has a blue background and white checkmark when clicked, focused, and hovered', async function() {
+    it(`has a blue background and white checkmark with a light blue outer border
+      when clicked, focused, and hovered`, async function() {
       const focusSelector = `${selector} input`,
           [targetElement, focusElement] = await Promise.all([browser.$(selector), browser.$(focusSelector)]);
 
@@ -74,8 +76,8 @@ describe('NxCheckbox', function() {
       }
     });
 
-    it('has a light blue border and glow when focused', focusTest(selector));
-    it('has a dark border when focused and hovered', focusAndHoverTest(selector));
+    it('has a light blue outer border and glow when focused', focusTest(selector));
+    it('has a light blue outer border and a dark border when focused and hovered', focusAndHoverTest(selector));
   });
 
   describe('Attribute-Disabled NxCheckbox', function() {

--- a/gallery/visualtests/nxRadio.js
+++ b/gallery/visualtests/nxRadio.js
@@ -26,6 +26,9 @@ describe('NxRadio', function() {
 
       await targetElement.scrollIntoView({ block: 'center' });
       await targetElement.click();
+      await browser.execute(function(el) {
+        el.blur();
+      }, targetElement);
 
       try {
         await browser.eyesRegionSnapshot(null, Target.region(targetElement));

--- a/gallery/visualtests/nxRadio.js
+++ b/gallery/visualtests/nxRadio.js
@@ -21,7 +21,7 @@ describe('NxRadio', function() {
 
     it('has a light grey border and white background by default', simpleTest(selector));
     it('has a black border when hovered', hoverTest(selector));
-    it('has a thick blue border and white background when clicked', async function() {
+    it('has a thick blue border and white background with a light blue outer border when clicked', async function() {
       const [targetElement, otherElement] = await Promise.all([browser.$(selector), browser.$(otherRadioSelector)]);
 
       await targetElement.scrollIntoView({ block: 'center' });
@@ -36,7 +36,8 @@ describe('NxRadio', function() {
       }
     });
 
-    it('has a thick blue border, white background, and glow when clicked and focused', async function() {
+    it(`has a thick blue border, white background, with a light blue outer border and glow
+      when clicked and focused`, async function() {
       const focusSelector = `${selector} input`,
           [targetElement, otherElement, focusElement] =
             await Promise.all([browser.$(selector), browser.$(otherRadioSelector), browser.$(focusSelector)]);
@@ -57,7 +58,8 @@ describe('NxRadio', function() {
       }
     });
 
-    it('has a thick blue border and white background when clicked, focused, and hovered', async function() {
+    it(`has a thick blue border and white background with a light blue outer border
+      when clicked, focused, and hovered`, async function() {
       const focusSelector = `${selector} input`,
           [targetElement, otherElement, focusElement] =
             await Promise.all([browser.$(selector), browser.$(otherRadioSelector), browser.$(focusSelector)]);
@@ -78,8 +80,8 @@ describe('NxRadio', function() {
       }
     });
 
-    it('has a light blue border and glow when focused', focusTest(selector));
-    it('has a dark border when focused and hovered', focusAndHoverTest(selector));
+    it('has a light blue outer border and glow when focused', focusTest(selector));
+    it('has a light blue outer border and a dark border when focused and hovered', focusAndHoverTest(selector));
   });
 
   describe('Attribute-Disabled NxRadio', function() {

--- a/gallery/visualtests/nxRadio.js
+++ b/gallery/visualtests/nxRadio.js
@@ -22,13 +22,16 @@ describe('NxRadio', function() {
     it('has a light grey border and white background by default', simpleTest(selector));
     it('has a black border when hovered', hoverTest(selector));
     it('has a thick blue border and white background when clicked', async function() {
-      const [targetElement, otherElement] = await Promise.all([browser.$(selector), browser.$(otherRadioSelector)]);
+
+      const blurSelector = `${selector} input`,
+        [targetElement, otherElement, blurElement] = await Promise.all([browser.$(selector),
+          browser.$(otherRadioSelector), browser.$(blurSelector)]);
 
       await targetElement.scrollIntoView({ block: 'center' });
       await targetElement.click();
       await browser.execute(function(el) {
         el.blur();
-      }, targetElement);
+      }, blurElement);
 
       try {
         await browser.eyesRegionSnapshot(null, Target.region(targetElement));

--- a/gallery/visualtests/nxRadio.js
+++ b/gallery/visualtests/nxRadio.js
@@ -21,7 +21,7 @@ describe('NxRadio', function() {
 
     it('has a light grey border and white background by default', simpleTest(selector));
     it('has a black border when hovered', hoverTest(selector));
-    it('has a thick blue border and white background with a light blue outer border when clicked', async function() {
+    it('has a thick blue border and white background when clicked', async function() {
       const [targetElement, otherElement] = await Promise.all([browser.$(selector), browser.$(otherRadioSelector)]);
 
       await targetElement.scrollIntoView({ block: 'center' });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.1.7",
+  "version": "7.1.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.1.8",
+  "version": "7.2.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.1.5",
+  "version": "7.1.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -22,10 +22,6 @@
   max-width: max-content;
   position: relative;
 
-  &::after {
-    display: none;
-  }
-
   &:hover {
     cursor: pointer;
 

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -23,14 +23,7 @@
   position: relative;
 
   &::after {
-    border: 1px solid var(--nx-color-interactive-border-focus);
-    box-shadow: var(--nx-box-shadow-focus);
-    content: '';
     display: none;
-    height: 22px;
-    position:absolute;
-    left: -4px;
-    width: 22px;
   }
 
   &:hover {
@@ -44,7 +37,11 @@
 
   &:focus-within {
     &::after {
+      border: 1px solid var(--nx-color-interactive-border-focus);
+      box-shadow: var(--nx-box-shadow-focus);
+      content: '';
       display: block;
+      position: absolute;
     }
 
     .nx-radio-checkbox__control {

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -40,10 +40,6 @@
       position: absolute;
     }
 
-    .nx-radio-checkbox__control {
-      filter: drop-shadow(var(--nx-drop-shadow-focus));
-    }
-
     &:hover {
       .nx-radio-checkbox__control {
         border-color: var(--nx-color-form-element-border);

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -24,13 +24,13 @@
 
   &::after {
     border: 1px solid var(--nx-color-interactive-border-focus);
-    filter: drop-shadow(var(--nx-drop-shadow-focus));
     content: '';
-    width: 22px;
+    display: none;
+    filter: drop-shadow(var(--nx-drop-shadow-focus));
     height: 22px;
     position:absolute;
     left: -4px;
-    display: none;
+    width: 22px;
   }
 
   &:hover {

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -20,6 +20,18 @@
   // the end of the text
   width: calc(min(#{$max-width}, 100%));
   max-width: max-content;
+  position: relative;
+
+  &::after {
+    border: 1px solid var(--nx-color-interactive-border-focus);
+    filter: drop-shadow(var(--nx-drop-shadow-focus));
+    content: '';
+    width: 22px;
+    height: 22px;
+    position:absolute;
+    left: -4px;
+    display: none;
+  }
 
   &:hover {
     cursor: pointer;
@@ -31,9 +43,11 @@
   }
 
   &:focus-within {
+    &::after {
+      display: block;
+    }
+
     .nx-radio-checkbox__control {
-      border-color: var(--nx-color-interactive-border-focus);
-      stroke: var(--nx-color-interactive-border-focus);
       filter: drop-shadow(var(--nx-drop-shadow-focus));
     }
 

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -24,9 +24,9 @@
 
   &::after {
     border: 1px solid var(--nx-color-interactive-border-focus);
+    box-shadow: var(--nx-box-shadow-focus);
     content: '';
     display: none;
-    filter: drop-shadow(var(--nx-drop-shadow-focus));
     height: 22px;
     position:absolute;
     left: -4px;

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -30,8 +30,11 @@
   }
 }
 
-.nx-checkbox {
+.nx-checkbox:focus-within {
   &::after{
     border-radius: 4px;
+    height: 22px;
+    left: -4px;
+    width: 22px;
   }
 }

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -29,3 +29,9 @@
     }
   }
 }
+
+.nx-checkbox {
+  &::after{
+    border-radius: 4px;
+  }
+}

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -31,3 +31,9 @@
     }
   }
 }
+
+.nx-radio {
+  &::after{
+    border-radius: 12px;
+  }
+}

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -32,8 +32,11 @@
   }
 }
 
-.nx-radio {
+.nx-radio:focus-within {
   &::after{
     border-radius: 12px;
+    height: 22px;
+    left: -4px;
+    width: 22px;
   }
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-600

- Added focus styles on checked radio buttons and checkboxes.
- Modified visual tests to align with new design spec.

Achieved by using an absolutely positioned `::after` pseudoelement that is visible on focus. 