### PR TITLE
NxModal Close and Focus refactor - RSC-510

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.1.5",
+  "version": "7.2.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxModal/NxModalAlertExample.tsx
+++ b/gallery/src/components/NxModal/NxModalAlertExample.tsx
@@ -16,7 +16,7 @@ export default function NxModalAlertExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Alert in content</NxButton>
       { showModal &&
-        <NxModal id="nx-modal-alert-example" role="alertdialog" onClose={modalCloseHandler}>
+        <NxModal id="nx-modal-alert-example" role="alertdialog" onCancel={modalCloseHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">Example NxModal with NxAlert</h2>
           </header>

--- a/gallery/src/components/NxModal/NxModalEscExample.tsx
+++ b/gallery/src/components/NxModal/NxModalEscExample.tsx
@@ -17,12 +17,15 @@ export default function NxModalStackedExample() {
       modal1CancelHandler = () => setShowModal(false),
       modal2CancelHandler = () => setShowModal2(false);
 
+  function customComponentKeydownListener(evt: KeyboardEvent) {
+    if (evt.key === 'Escape' || evt.key === 'Esc') {
+      setShowCustomComponent(false);
+    }
+  }
+
   useEffect(() => {
-    document.addEventListener('keydown', (evt) => {
-      if (evt.key === 'Escape' || evt.key === 'Esc') {
-        setShowCustomComponent(false);
-      }
-    });
+    document.addEventListener('keydown', customComponentKeydownListener);
+    return () => { document.removeEventListener('keydown', customComponentKeydownListener); };
   }, []);
 
   return (

--- a/gallery/src/components/NxModal/NxModalEscExample.tsx
+++ b/gallery/src/components/NxModal/NxModalEscExample.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, {useState, useEffect} from 'react';
+
+import {NxModal, NxFontAwesomeIcon, NxButton, NxDropdown, NxP, useToggle} from '@sonatype/react-shared-components';
+import {faAngry} from '@fortawesome/free-solid-svg-icons';
+
+export default function NxModalStackedExample() {
+  const [showModal, setShowModal] = useState(false),
+      [showModal2, setShowModal2] = useState(false),
+      [showDropdown, toggleDropdown] = useToggle(false),
+      [showCustomComponent, setShowCustomComponent] = useState(false),
+      modal1CancelHandler = () => setShowModal(false),
+      modal2CancelHandler = () => setShowModal2(false);
+
+  useEffect(() => {
+    document.addEventListener('keydown', (evt) => {
+      if (evt.key === 'Escape' || evt.key === 'Esc') {
+        setShowCustomComponent(false);
+      }
+    });
+  }, []);
+
+  return (
+    <>
+      <NxButton onClick={() => setShowCustomComponent(true)}>Open Custom Expandable Panel</NxButton>
+      {showCustomComponent &&
+        <div className="gallery-custom-expandable">
+          <NxP>Press ESC anywhere on the page to close me!</NxP>
+          <NxButton onClick={() => setShowModal(true)}>Open Modal 1</NxButton>
+        </div>
+      }
+      {showModal &&
+        <NxModal id="nx-modal-stacked-example" onCancel={modal1CancelHandler}>
+          <header className="nx-modal-header">
+            <h2 className="nx-h2">
+              <NxFontAwesomeIcon icon={faAngry} />
+              <span>NxModal with a dropdown that opens another modal</span>
+            </h2>
+          </header>
+          <div className="nx-modal-content">
+            <NxDropdown label="Click to Expand"
+                        isOpen={showDropdown}
+                        onToggleCollapse={toggleDropdown}
+                        onCloseClick={evt => evt.preventDefault()}>
+              <button onClick={() => setShowModal2(true)} className="nx-dropdown-button">
+                Open Modal 2
+              </button>
+            </NxDropdown>
+            <NxP>
+              Some other content to take up space…
+            </NxP>
+          </div>
+          <footer className="nx-footer">
+            <div className="nx-btn-bar">
+              <NxButton onClick={modal1CancelHandler}>Close</NxButton>
+            </div>
+          </footer>
+        </NxModal>
+      }
+      {showModal2 &&
+        <NxModal id="nx-modal-stacked-example2" onCancel={modal2CancelHandler}>
+          <header className="nx-modal-header">
+            <h2 className="nx-h2">
+              <NxFontAwesomeIcon icon={faAngry} />
+              <span>NxModal stacked example</span>
+            </h2>
+          </header>
+          <div className="nx-modal-content">
+            <p className="nx-p">This is the second modal.</p>
+          </div>
+          <footer className="nx-footer">
+            <div className="nx-btn-bar">
+              <NxButton onClick={modal2CancelHandler} variant="primary">Close</NxButton>
+            </div>
+          </footer>
+        </NxModal>
+      }
+    </>
+  );
+}

--- a/gallery/src/components/NxModal/NxModalEscExample.tsx
+++ b/gallery/src/components/NxModal/NxModalEscExample.tsx
@@ -27,7 +27,10 @@ export default function NxModalStackedExample() {
 
   return (
     <>
-      <NxButton onClick={() => setShowCustomComponent(true)}>Open Custom Expandable Panel</NxButton>
+      <NxButton id="esc-example-initial-btn"
+                onClick={() => setShowCustomComponent(true)}>
+        Open Custom Expandable Panel
+      </NxButton>
       {showCustomComponent &&
         <div className="gallery-custom-expandable">
           <NxP>Press ESC anywhere on the page to close me!</NxP>
@@ -35,7 +38,7 @@ export default function NxModalStackedExample() {
         </div>
       }
       {showModal &&
-        <NxModal id="nx-modal-stacked-example" onCancel={modal1CancelHandler}>
+        <NxModal id="nx-modal-esc-example-modal" onCancel={modal1CancelHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">
               <NxFontAwesomeIcon icon={faAngry} />
@@ -63,7 +66,7 @@ export default function NxModalStackedExample() {
         </NxModal>
       }
       {showModal2 &&
-        <NxModal id="nx-modal-stacked-example2" onCancel={modal2CancelHandler}>
+        <NxModal id="nx-modal-esc-example-modal2" onCancel={modal2CancelHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">
               <NxFontAwesomeIcon icon={faAngry} />

--- a/gallery/src/components/NxModal/NxModalEscExample.tsx
+++ b/gallery/src/components/NxModal/NxModalEscExample.tsx
@@ -12,9 +12,12 @@ import {faAngry} from '@fortawesome/free-solid-svg-icons';
 export default function NxModalStackedExample() {
   const [showModal, setShowModal] = useState(false),
       [showModal2, setShowModal2] = useState(false),
-      [showDropdown, toggleDropdown] = useToggle(false),
+      [showDropdown, toggleDropdown, setShowDropdown] = useToggle(false),
       [showCustomComponent, setShowCustomComponent] = useState(false),
-      modal1CancelHandler = () => setShowModal(false),
+      modal1CancelHandler = () => {
+        setShowModal(false);
+        setShowDropdown(false);
+      },
       modal2CancelHandler = () => setShowModal2(false);
 
   function customComponentKeydownListener(evt: KeyboardEvent) {

--- a/gallery/src/components/NxModal/NxModalExtraWideExample.tsx
+++ b/gallery/src/components/NxModal/NxModalExtraWideExample.tsx
@@ -16,7 +16,7 @@ export default function NxModalExtraWideExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open wide modal</NxButton>
       {showModal &&
-      <NxModal id="nx-modal-wide-example" variant="wide" onClose={modalCloseHandler}>
+      <NxModal id="nx-modal-wide-example" variant="wide" onCancel={modalCloseHandler}>
         <header className="nx-modal-header">
           <h3 className="nx-h3">Vulnerability Information</h3>
         </header>

--- a/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
@@ -26,7 +26,7 @@ export default function NxModalFormErrorExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal with Form and Error Styling</NxButton>
       {showModal &&
-        <NxModal id="nx-modal-form-error-example" onClose={modalCloseHandler}>
+        <NxModal id="nx-modal-form-error-example" onCancel={modalCloseHandler}>
           <NxForm className="nx-form"
                   onSubmit={modalCloseHandler}
                   onCancel={modalCloseHandler}

--- a/gallery/src/components/NxModal/NxModalFormExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormExample.tsx
@@ -39,7 +39,7 @@ export default function NxModalFormExample() {
     <>
       <NxButton onClick={openModal}>Open Modal with Form</NxButton>
       {showModal &&
-        <NxModal id="nx-modal-form-example" onClose={modalCloseHandler}>
+        <NxModal id="nx-modal-form-example" onCancel={modalCloseHandler}>
           <NxForm className="nx-form"
                   onSubmit={modalCloseHandler}
                   onCancel={modalCloseHandler}

--- a/gallery/src/components/NxModal/NxModalNarrowExample.tsx
+++ b/gallery/src/components/NxModal/NxModalNarrowExample.tsx
@@ -17,7 +17,7 @@ export default function NxModalSimpleExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal</NxButton>
       { showModal &&
-        <NxModal variant="narrow" id="nx-modal-narrow-example" onClose={modalCloseHandler}>
+        <NxModal variant="narrow" id="nx-modal-narrow-example" onCancel={modalCloseHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">
               <NxFontAwesomeIcon icon={faAngry} />

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { NxInfoAlert, NxCode, NxP, NxTextLink, NxWarningAlert } from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import NxModalSimpleExample from './NxModalSimpleExample';
@@ -56,13 +56,45 @@ export default function NxModalPage() {
               </td>
             </tr>
             <tr className="nx-table-row">
-              <td className="nx-cell">onClose</td>
-              <td className="nx-cell">Function (() =&gt; void)</td>
+              <td className="nx-cell">onCancel</td>
+              <td className="nx-cell">Function ((Event) =&gt; void)</td>
               <td className="nx-cell">Yes</td>
               <td className="nx-cell"></td>
               <td className="nx-cell">
-                The function to be called to close the modal when pressing
-                the <code className="nx-code">Escape</code> key.
+                <NxP>
+                  A callback to be called when the browser's native <NxCode>cancel</NxCode> event for the
+                  modal's <NxCode>HTMLDialogElement</NxCode> is fired. The circumstances which will fire this event
+                  depend on the user agent, but typically include when the user presses ESC within the modal.
+                </NxP>
+                <NxP>
+                  It is expected that the handler passed for this prop will typically remove the NxModal from the
+                  JSX rendered to the page. If for whatever reason the handler wants to keep the modal open,
+                  it <strong>must</strong> call <NxCode>preventDefault</NxCode> on the event argument. This prevents
+                  the browser's native dialog closing logic, such as the removal of the <NxCode>open</NxCode> attribute
+                  from the dialog element.
+                </NxP>
+                <NxP>
+                  Note that at the time of writing, proper support for <NxCode>HTMLDialogElement</NxCode>, including
+                  its <NxCode>cancel</NxCode> event, is limited to Chromium-based browsers. In other
+                  browsers, <NxCode>NxModal</NxCode> itself listens for the ESC keypress and synthesizes the event
+                  passed to this callback.
+                </NxP>
+                <NxP>
+                  Also note that any components within the modal that have their own ESC handling should
+                  call <NxCode>preventDefault</NxCode> on any ESC keydowns that they handle in order to prevent the
+                  modal from also handling them. <NxCode>NxDropdown</NxCode> does this automatically.
+                </NxP>
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell">onClose</td>
+              <td className="nx-cell">Function (() =&gt; void)</td>
+              <td className="nx-cell">No</td>
+              <td className="nx-cell"></td>
+              <td className="nx-cell">
+                <NxWarningAlert>
+                  Deprecated. Old alias for <NxCode>onCancel</NxCode>. Using both at the same time is not supported.
+                </NxWarningAlert>
               </td>
             </tr>
             <tr className="nx-table-row">

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -15,6 +15,7 @@ import NxModalStackedExample from './NxModalStackedExample';
 import NxModalFormErrorExample from './NxModalFormErrorExample';
 import NxModalExtraWideExample from './NxModalExtraWideExample';
 import NxModalNarrowExample from './NxModalNarrowExample';
+import NxModalEscExample from './NxModalEscExample';
 
 const NxModalSimpleSourceCode = require('./NxModalSimpleExample?raw');
 const NxModalAlertSourceCode = require('./NxModalAlertExample?raw');
@@ -23,6 +24,7 @@ const NxModalStackedSourceCode = require('./NxModalStackedExample?raw');
 const NxModalFormErrorSourceCode = require('./NxModalFormErrorExample?raw');
 const NxModalExtraWideSourceCode = require('./NxModalExtraWideExample?raw');
 const NxModalNarrowSourceCode = require('./NxModalNarrowExample?raw');
+const NxModalEscSourceCode = require('./NxModalEscExample?raw');
 
 export default function NxModalPage() {
   return (
@@ -207,6 +209,17 @@ export default function NxModalPage() {
                           codeExamples={NxModalStackedSourceCode}>
         <code className="nx-code">NxModal</code> also supports stacked or nested modals. A second modal can be
         generated from inside of an <code className="nx-code">NxModal</code>.
+      </GalleryExampleTile>
+
+      <GalleryExampleTile title="NxModal example with other ESC-controller elements"
+                          id="nx-modal-esc-example"
+                          liveExample={NxModalEscExample}
+                          codeExamples={NxModalEscSourceCode}>
+        <NxCode>NxModal</NxCode> can be used in conjunction with other components that can be closed via the ESC key,
+        such as dropdowns. This example demonstrates a convoluted combination of 2 modals, a dropdown, and a custom
+        component all working together such that pressing ESC only closes one of them at a time. Note
+        that <NxCode>NxDropdown</NxCode> is designed so that pressing ESC when it is open only closes it if it is
+        focused.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal Example with form"

--- a/gallery/src/components/NxModal/NxModalSimpleExample.tsx
+++ b/gallery/src/components/NxModal/NxModalSimpleExample.tsx
@@ -17,7 +17,7 @@ export default function NxModalSimpleExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal</NxButton>
       { showModal &&
-        <NxModal id="nx-modal-simple-example" onClose={modalCloseHandler}>
+        <NxModal id="nx-modal-simple-example" onCancel={modalCloseHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">
               <NxFontAwesomeIcon icon={faAngry} />

--- a/gallery/src/components/NxModal/NxModalStackedExample.tsx
+++ b/gallery/src/components/NxModal/NxModalStackedExample.tsx
@@ -19,7 +19,7 @@ export default function NxModalStackedExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open modal with stacked example</NxButton>
       {showModal &&
-        <NxModal id="nx-modal-stacked-example" onClose={modal1CloseHandler}>
+        <NxModal id="nx-modal-stacked-example" onCancel={modal1CloseHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">
               <NxFontAwesomeIcon icon={faAngry} />
@@ -43,7 +43,7 @@ export default function NxModalStackedExample() {
         </NxModal>
       }
       {showModal2 &&
-        <NxModal id="nx-modal-stacked-example2" onClose={modal2CloseHandler}>
+        <NxModal id="nx-modal-stacked-example2" onCancel={modal2CloseHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">
               <NxFontAwesomeIcon icon={faAngry} />

--- a/gallery/src/components/NxTabs/NxTabsModalExample.tsx
+++ b/gallery/src/components/NxTabs/NxTabsModalExample.tsx
@@ -28,7 +28,7 @@ const NxTabsModalExample = () => {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal</NxButton>
       { showModal &&
-        <NxModal onClose={modalCloseHandler}>
+        <NxModal onCancel={modalCloseHandler}>
           <header className="nx-modal-header">
             <h2 className="nx-h2">
               <NxFontAwesomeIcon icon={faAngry} />

--- a/gallery/src/components/NxTabs/NxTabsModalNoHeaderExample.tsx
+++ b/gallery/src/components/NxTabs/NxTabsModalNoHeaderExample.tsx
@@ -25,7 +25,7 @@ const NxTabsModalNoHeaderExample = () => {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal</NxButton>
       { showModal &&
-        <NxModal onClose={modalCloseHandler}>
+        <NxModal onCancel={modalCloseHandler}>
           <div className="nx-modal-content nx-modal-content--tabs">
             <NxTabs activeTab={activeTabId} onTabSelect={setActiveTabId}>
               <NxTabList aria-label="Tabs in a modal with no header">

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.1.5",
+  "version": "7.2.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxDropdown/NxDropdown.scss
+++ b/lib/src/components/NxDropdown/NxDropdown.scss
@@ -7,8 +7,7 @@
 @import '../../scss-shared/nx-text-helpers';
 @import '../../scss-shared/nx-container-helpers';
 @import '../../scss-shared/nx-button-helpers';
-
-$nx-dropdown-width: 250px;
+@import '../../scss-shared/nx-dropdown-variables';
 
 .nx-dropdown {
   display: inline-block;
@@ -47,26 +46,6 @@ $nx-dropdown-width: 250px;
   &.open {
     border-color: var(--nx-swatch-blue-40);
   }
-}
-
-.nx-dropdown-menu {
-  @include container-vertical();
-
-  background: var(--nx-swatch-white);
-  border-radius: var(--nx-border-radius);
-  box-shadow: 0 2px 12px 0 rgba(74, 77, 113, 0.2),
-              0 1px 2px 0 rgba(91, 95, 141, 0.2),
-              0 1px 1px 0 rgba(124, 128, 179, 0.2);
-  box-sizing: border-box;
-  display: block;
-  max-height: 328px;
-  margin: var(--nx-spacing-base) 0 0 0;
-  overflow-y: auto;
-  padding: var(--nx-spacing-base) 0;
-  position: absolute;
-  top: 100%;
-  width: $nx-dropdown-width;
-  z-index: 1;
 }
 
 .nx-dropdown-link, .nx-dropdown-button {

--- a/lib/src/components/NxDropdown/NxDropdown.tsx
+++ b/lib/src/components/NxDropdown/NxDropdown.tsx
@@ -15,6 +15,7 @@ import NxFontAwesomeIcon from '../NxFontAwesomeIcon/NxFontAwesomeIcon';
 import { wrapTooltipProps } from '../../util/tooltipUtils';
 import './NxDropdown.scss';
 import NxOverflowTooltip from '../NxTooltip/NxOverflowTooltip';
+import NxDropdownMenu from '../NxDropdownMenu/NxDropdownMenu';
 import useDropdownEvents from '../../util/useDropdownEvents';
 
 const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
@@ -33,7 +34,7 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
     ...attrs
   } = props;
 
-  const { onKeyDown, onToggleCollapse } =
+  const { onKeyDown, onToggleCollapse, menuRef, toggleRef, onMenuClosing } =
       useDropdownEvents(isOpen, disabled, externalOnToggleCollapse, onCloseClick, onCloseKeyDown, externalOnKeyDown);
 
   const buttonClasses = classnames('nx-dropdown__toggle', { disabled, open: isOpen });
@@ -50,7 +51,8 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
   ));
 
   const toggle = (
-    <NxButton type="button"
+    <NxButton ref={toggleRef}
+              type="button"
               variant={variant || 'tertiary'}
               className={buttonClasses}
               onClick={!disabled && onToggleCollapse || undefined}
@@ -64,12 +66,7 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
   return (
     <div className={classes} onKeyDown={onKeyDown} {...attrs}>
       { toggleTooltipProps ? <NxTooltip { ...toggleTooltipProps } >{toggle}</NxTooltip> : toggle }
-
-      { isOpen &&
-        <div className="nx-dropdown-menu">
-          {wrappedChildren}
-        </div>
-      }
+      { isOpen && <NxDropdownMenu ref={menuRef} onClosing={onMenuClosing}>{wrappedChildren}</NxDropdownMenu> }
     </div>
   );
 };

--- a/lib/src/components/NxDropdownMenu/NxDropdownMenu.scss
+++ b/lib/src/components/NxDropdownMenu/NxDropdownMenu.scss
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+@import '../../scss-shared/nx-dropdown-variables';
+@import '../../scss-shared/nx-container-helpers';
+
+.nx-dropdown-menu {
+  @include container-vertical();
+
+  background: var(--nx-swatch-white);
+  border-radius: var(--nx-border-radius);
+  box-shadow: 0 2px 12px 0 rgba(74, 77, 113, 0.2),
+              0 1px 2px 0 rgba(91, 95, 141, 0.2),
+              0 1px 1px 0 rgba(124, 128, 179, 0.2);
+  box-sizing: border-box;
+  display: block;
+  max-height: 328px;
+  margin: var(--nx-spacing-base) 0 0 0;
+  overflow-y: auto;
+  padding: var(--nx-spacing-base) 0;
+  position: absolute;
+  top: 100%;
+  width: $nx-dropdown-width;
+  z-index: 1;
+}

--- a/lib/src/components/NxDropdownMenu/NxDropdownMenu.tsx
+++ b/lib/src/components/NxDropdownMenu/NxDropdownMenu.tsx
@@ -10,6 +10,8 @@ import { Props } from './types';
 
 import './NxDropdownMenu.scss';
 
+export { Props };
+
 /**
  * This component is not currently intended for public export. It is a helper for NxDropdown and NxSegmentedButton
  * so they can reset focus when they close

--- a/lib/src/components/NxDropdownMenu/NxDropdownMenu.tsx
+++ b/lib/src/components/NxDropdownMenu/NxDropdownMenu.tsx
@@ -14,12 +14,12 @@ import './NxDropdownMenu.scss';
  * This component is not currently intended for public export. It is a helper for NxDropdown and NxSegmentedButton
  * so they can reset focus when they close
  */
+/* eslint-disable-next-line react/prop-types */
 const NxDropdownMenu = forwardRef<HTMLDivElement, Props>(function NxDropdownMenu({ children, onClosing }, ref) {
   // onClosing must execute when this element is being removed but BEFORE it actually gets removed from the DOM
   useLayoutEffect(() => onClosing, []);
 
   return <div ref={ref} className="nx-dropdown-menu">{children}</div>;
 });
-
 
 export default NxDropdownMenu;

--- a/lib/src/components/NxDropdownMenu/NxDropdownMenu.tsx
+++ b/lib/src/components/NxDropdownMenu/NxDropdownMenu.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { useLayoutEffect, forwardRef } from 'react';
+
+import { Props } from './types';
+
+import './NxDropdownMenu.scss';
+
+/**
+ * This component is not currently intended for public export. It is a helper for NxDropdown and NxSegmentedButton
+ * so they can reset focus when they close
+ */
+const NxDropdownMenu = forwardRef<HTMLDivElement, Props>(function NxDropdownMenu({ children, onClosing }, ref) {
+  // onClosing must execute when this element is being removed but BEFORE it actually gets removed from the DOM
+  useLayoutEffect(() => onClosing, []);
+
+  return <div ref={ref} className="nx-dropdown-menu">{children}</div>;
+});
+
+
+export default NxDropdownMenu;

--- a/lib/src/components/NxDropdownMenu/__tests__/NxDropdownMenu.test.tsx
+++ b/lib/src/components/NxDropdownMenu/__tests__/NxDropdownMenu.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { getShallowComponent } from '../../../__testutils__/enzymeUtils';
+
+import NxDropdownMenu, { Props } from '../NxDropdownMenu';
+
+describe('NxDropdownMenu', function() {
+  const minimalProps = { onClosing: () => {} },
+      getShallow = getShallowComponent<Props>(NxDropdownMenu, minimalProps);
+
+  it('renders a div with the nx-dropdown-menu class name', function() {
+    expect(getShallow()).toMatchSelector('div.nx-dropdown-menu');
+  });
+
+  it('renders its children into the div', function() {
+    const children = <div className="foo" />;
+
+    expect(getShallow({ children }).children()).toMatchSelector('div.foo');
+  });
+
+  // NOTE: this test seems to be of limited usefulness because different behavior is observed here vs in
+  // actual usage. In this test, using `useEffect` within the component apparently works. However in real
+  // React it does not as it calls onClosing too late, which is why useLayoutEffect must be used. This is
+  // one reason that we have a functional test for this behavior as well (in the NxModal functional tests)
+  it('calls onClosing when being removed, before it is actually removed from DOM', function() {
+    let attachedWhenOnClosing: boolean | undefined = undefined;
+
+    const container = document.createElement('div'),
+        onClosing = jest.fn(() => {
+          attachedWhenOnClosing = container.contains(component.getDOMNode());
+        });
+
+    function Fixture({ hasMenu }: { hasMenu: boolean }) {
+      return hasMenu ? <NxDropdownMenu onClosing={onClosing} /> : null;
+    }
+
+    const component = mount(<Fixture hasMenu={true} />, { attachTo: container });
+
+    expect(component).toContainMatchingElement('.nx-dropdown-menu');
+    expect(onClosing).not.toHaveBeenCalled();
+
+    component.setProps({ hasMenu: false });
+
+    expect(component).toBeEmptyRender();
+    expect(onClosing).toHaveBeenCalledTimes(1);
+    expect(attachedWhenOnClosing).toBe(true);
+  });
+});

--- a/lib/src/components/NxDropdownMenu/types.tsx
+++ b/lib/src/components/NxDropdownMenu/types.tsx
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import { ReactNode } from "react";
+
+export interface Props {
+  onClosing: () => void;
+  children?: ReactNode | null;
+}

--- a/lib/src/components/NxDropdownMenu/types.tsx
+++ b/lib/src/components/NxDropdownMenu/types.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import { ReactNode } from "react";
+import { ReactNode } from 'react';
 
 export interface Props {
   onClosing: () => void;

--- a/lib/src/components/NxModal/NxModal.scss
+++ b/lib/src/components/NxModal/NxModal.scss
@@ -75,6 +75,11 @@
 
   // prevent brief flash of scrollbar as tooltips disappear
   overflow: hidden;
+
+  &::backdrop {
+    // chrome tries to add its own subtle mask here which doubles up with our own
+    display: none;
+  }
 }
 
 .nx-modal-content {

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -29,6 +29,10 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
 
   function dialogKeydownListener(evt: KeyboardEvent) {
     if (evt.key === 'Escape' || evt.key === 'Esc') {
+      // prevent visibility of the keydown outside of the modal, so that global ESC listeners on the
+      // document don't pick it up
+      evt.stopPropagation();
+
       if (!hasNativeModalSupport && onCancel) {
         // emulate cancel-on-esc behavior in browsers which don't do it natively
         onCancel(new Event('cancel'));

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -58,6 +58,10 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
     if (hasNativeModalSupport) {
       el.showModal();
     }
+    else {
+      // without native support we don't trap focus in the modal, but we can at least start it off there
+      el.focus();
+    }
   }, []);
 
   // listen to the native HTMLDialogElement cancel event which supporting browsers fire when the modal is closed
@@ -91,8 +95,11 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
     <NxModalContext.Provider value={dialogRefState}>
       {/* Note: role="dialog" should be redundant but I think some screenreaders (ChromeVox) don't know
         * what a <dialog> is.  It makes a difference there.
+        *
+        * The tabindex is for the sake of browsers which don't support dialog. In those browsers we try to
+        * focus the dialog element itself when it opens which can't be done if it doesn't have a tab index
         */}
-      <dialog ref={dialogRef} role={role || 'dialog'} aria-modal="true" className="nx-modal-backdrop">
+      <dialog ref={dialogRef} role={role || 'dialog'} aria-modal="true" className="nx-modal-backdrop" tabIndex={-1}>
         <div className={modalClasses} {...attrs} />
       </dialog>
     </NxModalContext.Provider>

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -28,7 +28,7 @@ const NxModal: FunctionComponent<Props> = ({className, onClose, variant, role, .
       [dialogRefState, setDialogRefState] = useState<HTMLDialogElement | null>(null);
 
   useEffect(function() {
-    /* eslint-ignore @typescript-eslint/no-non-null-assertion */
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     const el = dialogRef.current!;
 
     setDialogRefState(el);

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -27,6 +27,18 @@ const NxModal: FunctionComponent<Props> = ({className, onClose, variant, role, .
       // value in order for it to be tracked.
       [dialogRefState, setDialogRefState] = useState<HTMLDialogElement | null>(null);
 
+  /**
+   * In browsers without native support for HTMLDialogElement cancel events, listen for keydown on the dialog
+   * and emulate it.
+   */
+  function documentKeydownListener(evt: KeyboardEvent) {
+    if (evt.key === 'Escape' || evt.key === 'Esc') {
+      if (onClose) {
+        onClose();
+      }
+    }
+  }
+
   useEffect(function() {
     /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
     const el = dialogRef.current!;
@@ -52,10 +64,16 @@ const NxModal: FunctionComponent<Props> = ({className, onClose, variant, role, .
   useEffect(function() {
     const dialog = dialogRef.current;
 
-    if (hasNativeModalSupport && dialog) {
-      dialog.addEventListener('cancel', onClose);
+    if (dialog) {
+      if (hasNativeModalSupport) {
+        dialog.addEventListener('cancel', onClose);
 
-      return () => { dialog.removeEventListener('cancel', onClose); };
+        return () => { dialog.removeEventListener('cancel', onClose); };
+      }
+      else {
+        dialog.addEventListener('keydown', documentKeydownListener);
+        return () => { dialog.removeEventListener('keydown', documentKeydownListener); };
+      }
     }
     else {
       return undefined;

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -40,7 +40,7 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
 
       if (!hasNativeModalSupport && onCancel && !evt.defaultPrevented) {
         // emulate cancel-on-esc behavior in browsers which don't do it natively
-        onCancel(new Event('cancel'));
+        onCancel(new Event('cancel', { cancelable: true }));
       }
     }
   }

--- a/lib/src/components/NxModal/__tests__/NxModal.test.tsx
+++ b/lib/src/components/NxModal/__tests__/NxModal.test.tsx
@@ -170,4 +170,33 @@ describe('NxModal', function() {
 
     expect(tooltip.prop('PopperProps')!.container).toBe(nxModal.getDOMNode());
   });
+
+  it('moves focus back to the previously focused element when closed', function() {
+    function Fixture({ modalOpen }: { modalOpen: boolean }) {
+      return (
+        <>
+          <button id="test-btn">Test</button>
+          { modalOpen && <NxModal onCancel={jest.fn()}><button id="cancel-btn">Close</button></NxModal> }
+        </>
+      );
+    }
+
+    const container = document.createElement('div');
+    document.body.append(container);
+
+    const component = mount(<Fixture modalOpen={false} />, { attachTo: container }),
+        externalBtn = component.find('#test-btn').getDOMNode() as HTMLElement;
+
+    externalBtn.focus();
+    expect(component).not.toContainMatchingElement(NxModal);
+    expect(document.activeElement).toBe(externalBtn);
+
+    component.setProps({ modalOpen: true });
+    expect(component).toContainMatchingElement(NxModal);
+    expect(document.activeElement).toBe(component.find(NxModal).getDOMNode());
+
+    component.setProps({ modalOpen: false });
+    expect(component).not.toContainMatchingElement(NxModal);
+    expect(document.activeElement).toBe(externalBtn);
+  });
 });

--- a/lib/src/components/NxModal/types.ts
+++ b/lib/src/components/NxModal/types.ts
@@ -4,20 +4,32 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import {HTMLAttributes, WeakValidationMap} from 'react';
+import {HTMLAttributes} from 'react';
 import * as PropTypes from 'prop-types';
 
-export type CloseHandler = () => void;
+export type CloseHandler = (evt: Event) => void;
 export const NX_MODAL_VARIANTS = ['wide', 'normal', 'narrow'] as const;
 export type NX_MODAL_VARIANT_TYPE = (typeof NX_MODAL_VARIANTS)[number];
 
-export type Props = HTMLAttributes<HTMLDivElement> & {
-  onClose: CloseHandler;
-  variant?: NX_MODAL_VARIANT_TYPE;
-};
+interface BaseProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: NX_MODAL_VARIANT_TYPE | null;
+}
 
-export const propTypes: WeakValidationMap<Props> = {
-  className: PropTypes.string,
-  onClose: PropTypes.func.isRequired,
+interface CurrentProps extends BaseProps {
+  onCancel: CloseHandler;
+  onClose?: never;
+}
+
+interface DeprecatedProps extends BaseProps {
+  onClose: CloseHandler;
+  onCancel?: never;
+}
+
+// Effectively, either onClose or onCancel must be specified
+export type Props = CurrentProps | DeprecatedProps;
+
+export const propTypes = {
+  onCancel: PropTypes.func,
+  onClose: PropTypes.func,
   variant: PropTypes.oneOf(NX_MODAL_VARIANTS)
-};
+} as PropTypes.ValidationMap<Props>;

--- a/lib/src/components/NxSegmentedButton/NxSegmentedButton.tsx
+++ b/lib/src/components/NxSegmentedButton/NxSegmentedButton.tsx
@@ -11,6 +11,7 @@ import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
 import NxFontAwesomeIcon from '../NxFontAwesomeIcon/NxFontAwesomeIcon';
 import NxButton from '../NxButton/NxButton';
 import NxOverflowTooltip from '../NxTooltip/NxOverflowTooltip';
+import NxDropdownMenu from '../NxDropdownMenu/NxDropdownMenu';
 
 import {Props, propTypes} from './types';
 
@@ -39,8 +40,9 @@ const NxSegmentedButton = forwardRef<HTMLDivElement, Props>(
           wrappedMenuItems = React.Children.map<ReactElement, ReactElement>(children, item => (
             <NxOverflowTooltip>{item}</NxOverflowTooltip>
           )),
-          { onKeyDown, onToggleCollapse } = useDropdownEvents(isOpen, disabled, externalOnToggleCollapse,
-              onCloseClick, onCloseKeyDown, externalOnKeyDown);
+          { onKeyDown, onToggleCollapse, menuRef, toggleRef, onMenuClosing } =
+              useDropdownEvents(isOpen, disabled, externalOnToggleCollapse, onCloseClick, onCloseKeyDown,
+                  externalOnKeyDown);
 
       return (
         <div ref={ref} className={classes} onKeyDown={onKeyDown} { ...attrs }>
@@ -50,17 +52,14 @@ const NxSegmentedButton = forwardRef<HTMLDivElement, Props>(
                     disabled={disabled || undefined}>
             {buttonContent}
           </NxButton>
-          <NxButton variant={variant}
+          <NxButton ref={toggleRef}
+                    variant={variant}
                     className="nx-segmented-btn__dropdown-btn"
                     onClick={onToggleCollapse}
                     disabled={disabled || undefined}>
             <NxFontAwesomeIcon icon={isOpen ? faCaretUp : faCaretDown} />
           </NxButton>
-          { isOpen &&
-            <div className="nx-dropdown-menu">
-              {wrappedMenuItems}
-            </div>
-          }
+          { isOpen && <NxDropdownMenu ref={menuRef} onClosing={onMenuClosing}>{wrappedMenuItems}</NxDropdownMenu> }
         </div>
       );
     }

--- a/lib/src/components/NxSegmentedButton/__tests__/NxSegmentedButton.test.tsx
+++ b/lib/src/components/NxSegmentedButton/__tests__/NxSegmentedButton.test.tsx
@@ -15,6 +15,7 @@ import NxButton from '../../NxButton/NxButton';
 import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
 import NxFontAwesomeIcon from '../../NxFontAwesomeIcon/NxFontAwesomeIcon';
 import NxOverflowTooltip from '../../NxTooltip/NxOverflowTooltip';
+import NxDropdownMenu from '../../NxDropdownMenu/NxDropdownMenu';
 
 describe('NxSegmentedButton', function() {
   let container: HTMLDivElement | null;
@@ -179,9 +180,9 @@ describe('NxSegmentedButton', function() {
     );
   });
 
-  it('renders an nx-dropdown-menu iff isOpen is set', function() {
-    expect(getShallow()).not.toContainMatchingElement('.nx-dropdown-menu');
-    expect(getShallow({ isOpen: true })).toContainMatchingElement('.nx-dropdown-menu');
+  it('renders an NxDropdownMenu iff isOpen is set', function() {
+    expect(getShallow()).not.toContainMatchingElement(NxDropdownMenu);
+    expect(getShallow({ isOpen: true })).toContainMatchingElement(NxDropdownMenu);
   });
 
   it('wraps each child in an NxOverflowTooltip and renders them within the nx-dropdown-menu', function() {
@@ -192,13 +193,13 @@ describe('NxSegmentedButton', function() {
     expect(closedComp).not.toContainMatchingElement('.foo');
     expect(closedComp).not.toContainMatchingElement('.bar');
 
-    expect(openComp.find('.nx-dropdown-menu')).toContainReact(
+    expect(openComp.find(NxDropdownMenu)).toContainReact(
       <NxOverflowTooltip>
         <span className="foo" />
       </NxOverflowTooltip>
     );
 
-    expect(openComp.find('.nx-dropdown-menu')).toContainReact(
+    expect(openComp.find(NxDropdownMenu)).toContainReact(
       <NxOverflowTooltip>
         <span className="bar" />
       </NxOverflowTooltip>
@@ -254,8 +255,20 @@ describe('NxSegmentedButton', function() {
     const onToggleOpen = jest.fn(),
         component = getShallow({ onToggleOpen, isOpen: true });
 
-    component.simulate('keyDown', { key: 'Escape' });
+    component.simulate('keyDown', { key: 'Escape', preventDefault: jest.fn() });
     expect(onToggleOpen).toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on Escape keydown', function() {
+    const component = getShallow({ onToggleOpen: jest.fn(), isOpen: true }),
+        escPreventDefault = jest.fn(),
+        otherPreventDefault = jest.fn();
+
+    component.simulate('keyDown', { key: 'Escape', preventDefault: escPreventDefault });
+    component.simulate('keyDown', { key: 'Q', preventDefault: otherPreventDefault });
+
+    expect(escPreventDefault).toHaveBeenCalled();
+    expect(otherPreventDefault).not.toHaveBeenCalled();
   });
 
   it('does not call onToggleOpen if ESC is pressed within the component when the dropdown is closed', function() {
@@ -331,5 +344,20 @@ describe('NxSegmentedButton', function() {
     });
     component!.update();
     expect(onToggleOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves focus to the dropdown toggle button if a menu item is focused when the dropdown is closed', function() {
+    const component = getMounted({
+          children: <button className="nx-dropdown-button">Foo</button>,
+          isOpen: true
+        }, { attachTo: container }),
+        menuBtn = component.find('button.nx-dropdown-button').getDOMNode() as HTMLElement,
+        toggleBtn = component.find('button.nx-segmented-btn__dropdown-btn').getDOMNode();
+
+    menuBtn.focus();
+    expect(document.activeElement).toBe(menuBtn);
+
+    component.setProps({ isOpen: false });
+    expect(document.activeElement).toBe(toggleBtn);
   });
 });

--- a/lib/src/scss-shared/_nx-dropdown-variables.scss
+++ b/lib/src/scss-shared/_nx-dropdown-variables.scss
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+$nx-dropdown-width: 250px;

--- a/lib/src/util/useDropdownEvents.ts
+++ b/lib/src/util/useDropdownEvents.ts
@@ -41,6 +41,10 @@ export default function useDropdownEvents(
 
       if (!event.defaultPrevented) {
         externalOnToggleCollapse();
+
+        // try to prevent the ESC from triggering multiple things, for instance closing a surrounding modal
+        // in addition to the dropdown
+        event.preventDefault();
       }
     }
 

--- a/lib/src/util/useDropdownEvents.ts
+++ b/lib/src/util/useDropdownEvents.ts
@@ -22,6 +22,10 @@ import { KeyboardEventHandler, useEffect, useRef } from 'react';
  * @return Object containing the following:
  * onKeyDown function to set on the dropdown to handle ESC keypresses within it
  * onToggleCollapse function to set as the click handler on the dropdown toggle
+ * menuRef A ref that should be attached to the NxDropdownMenu
+ * toggleRef A ref that should be attached to the dropdown toggle button
+ * onMenuClosing A callback that should be executed when the dropdown menu is closing but before it is removed
+ * from DOM. e.g. to be attached to NxDropdownMenu.onClosing.
  */
 export default function useDropdownEvents(
   isOpen: boolean,
@@ -31,7 +35,9 @@ export default function useDropdownEvents(
   externalOnCloseKeyDown?: KeyboardEventHandler | null,
   externalOnKeyDown?: KeyboardEventHandler
 ) {
-  const isToggling = useRef(false);
+  const isToggling = useRef(false),
+      menuRef = useRef<HTMLDivElement>(null),
+      toggleRef = useRef<HTMLButtonElement>(null);
 
   const onKeyDown: KeyboardEventHandler = event => {
     if (isOpen && !disabled && event.key === 'Escape' && externalOnToggleCollapse) {
@@ -102,5 +108,19 @@ export default function useDropdownEvents(
     }
   }, [disabled, isOpen]);
 
-  return { onKeyDown, onToggleCollapse };
+  // When the dropdown is closed while focus is within it, set focus back to the dropdown toggle. Otherwise
+  // it goes back to the <body> which is less helpful especially when within a modal
+  function onMenuClosing() {
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    const focusedEl = document.activeElement,
+        menuEl = menuRef.current,
+        toggleEl = toggleRef.current;
+
+    if (menuEl && menuEl.contains(focusedEl)) {
+      toggleEl!.focus();
+    }
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+  }
+
+  return { onKeyDown, onToggleCollapse, menuRef, toggleRef, onMenuClosing };
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-510

This deviates a bit from what the ticket was originally about.  I am against making `onClose` optional as it would be too easy for future modals to forget about it, missing that usability feature.  Instead I took another pass at making `NxModal` work in conjunction with other elements which can be closed with the ESC key.  Additionally this caused me to take a closer look at the focus behavior around the opening and closing of modals, which is a closely related issue.  The approach I came up with to make everything work as well as possible is as follows:

In browsers which have more-or-less full support for `<dialog>` elements (only Chromium-based browsers currently), the native `cancel` event on the modal is used as the signal to close the modal.  This leaves it up to the browser what standard ways of canceling the modal are made available to the user, but allowing them to press ESC is the typical one cited in the HTML standards.  In practice, what this means is that if an ESC keydown event is not cancelled while a modal is up, then after that even finishes bubbling a `cancel` event is fired on the modal itself.  Note that if we still reacted to the `keydown` instead of listening for `cancel`, that would (and *does*, on master) cause problems when multiple modals are present in that the inner modal would be removed programmatically in the `onClose` handler and the browser would then `cancel` the _outer_ modal, which can be seen by the fact that the outer modal's `open` attribute gets removed.  This puts things into an inconsistent state - the browser considers the outer modal to be closed, but our styles and JavaScript still have it presented and interactive.  In practical terms, what this meant was that when you ESC out of a inner modal, the focus trapping on the outer modal no longer works.  Listening for `cancel` instead as is done in this PR fixes that.

The `onClose` prop has been renamed to `onCancel` to more closely align with the meanings of "close" and "cancel" in relation to `<dialog>` elements.  `onClose` has been kept as a deprecated alias for `onCancel`.

In browsers which do not fully support `<dialog>`, the keydown listening is still done similarly to before.  However, to avoid complications with other elements, the listening is no longer done on the `document` but rather on the dialog backdrop.  A keydown which closes the modal here gets `stopPropagation` called on it so that it does not fire any other keydown listeners attached to the document.  Note that the modal focus-trapping does not work in these browsers, so we didn't have to worry about breaking it.  Also note however that with these changes ESC will not close a modal if the user has accidentally tabbed out of the modal.

`NxDropdown` and `NxSegmentedButton` have also been adjusted in this PR to play more nicely with modals and other ESC-closed elements.  The existing behavior for these elements has been that ESC can close them if they are focused when it is pressed.  This is still the case, but they have been adjusted so that the keydown which closes them gets canceled (that is, `preventDefault` is called on it) so that it does not close any other surrounding elements, such as a modal containing the dropdown.

In addition to all that, there were several changes to explicit focus management which needed to be made to prevent focus from defaulting back to the `<body>` and thus escaping modals:
* When a modal opens, it remembers which element had focus before and it resets focus back to that element when it closes.  According to the spec, this is supposed to be built-in behavior for `<dialog>`s but I didn't observe it even in browsers which otherwise support that element.
* When a modal is opened on browsers which don't support `<dialog>`, the `<dialog>` element itself is explicitly focused.  Without this, focus remained on the background page.  In browsers which do support `<dialog>`, the built-in behavior already was focusing the first focusable element within the modal.  That behavior remains.
* When a dropdown is closed and focus is on one of the dropdown menu items, focus gets moved to the dropdown toggle button.