### PR TITLE
Improve NxToggle focus style RSC-602

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.3",
+  "version": "7.2.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.4",
+  "version": "7.2.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/visualtests/nxToggle.js
+++ b/gallery/visualtests/nxToggle.js
@@ -21,11 +21,15 @@ describe('NxToggle', function() {
     it('has a black border when hovered', hoverTest(selector));
 
     it('has a blue background and white indicator when clicked', async function() {
-      const targetElement = await browser.$(selector);
+      const blurSelector = `${selector} input`,
+          [targetElement, blurElement] = await Promise.all([browser.$(selector), browser.$(blurSelector)]);
 
       await targetElement.scrollIntoView({ block: 'center' });
       await targetElement.click();
       await targetElement.moveTo({ xOffset: -10, yOffset: -10 });
+      await browser.execute(function(el) {
+        el.blur();
+      }, blurElement);
 
       try {
         await browser.eyesRegionSnapshot(null, Target.region(targetElement));
@@ -36,7 +40,8 @@ describe('NxToggle', function() {
       }
     });
 
-    it('has a blue background, white indicator, and glow when clicked and focused', async function() {
+    it(`has a blue background, white indicator, light outer blue border and glow
+      when clicked and focused`, async function() {
       const focusSelector = `${selector} input`,
           [targetElement, focusElement] = await Promise.all([browser.$(selector), browser.$(focusSelector)]);
 
@@ -56,7 +61,8 @@ describe('NxToggle', function() {
       }
     });
 
-    it('dark border, blue background and white indicator when clicked, focused, and hovered', async function() {
+    it(`dark border, blue background and white indicator with light outer blue border
+      when clicked, focused, and hovered`, async function() {
       const focusSelector = `${selector} input`,
           [targetElement, focusElement] = await Promise.all([browser.$(selector), browser.$(focusSelector)]);
 
@@ -76,8 +82,8 @@ describe('NxToggle', function() {
       }
     });
 
-    it('has a light blue border and glow when focused', focusTest(selector));
-    it('has a dark border when focused and hovered', focusAndHoverTest(selector));
+    it('has a light blue outer border and glow when focused', focusTest(selector));
+    it('has a dark border and a light blue outer border when focused and hovered', focusAndHoverTest(selector));
   });
 
   describe('Attribute-Disabled NxToggle', function() {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.3",
+  "version": "7.2.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.4",
+  "version": "7.2.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxToggle/NxToggle.scss
+++ b/lib/src/components/NxToggle/NxToggle.scss
@@ -14,6 +14,7 @@
   margin: var(--nx-spacing-4x) 0;
   overflow-wrap: anywhere;
   max-width: var(--nx-width-form-element-wide);
+  position: relative;
 
   &.nx-toggle--disabled {
     &, &:hover {
@@ -31,11 +32,21 @@
 
   &:focus-within {
     .nx-toggle__control {
-      border-color: var(--nx-color-interactive-border-focus);
-      filter: drop-shadow(var(--nx-drop-shadow-focus));
-
       &:hover {
         border-color: var(--nx-swatch-grey-05);
+      }
+
+      &::after{
+        border: 1px solid var(--nx-color-interactive-border-focus);
+        border-radius: 16px;
+        box-shadow: var(--nx-box-shadow-focus);
+        content: '';
+        display: block;
+        height: 30px;
+        position:absolute;
+        left: -4px;
+        top: -4px;
+        width: 50px;
       }
     }
   }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-602

- Added focus styles on `NxToggle` that shows a light outer blue border when focused.
- Modified visual tests to align with new design spec.

Achieved by using an absolutely positioned `::after` pseudoelement that is visible on focus.