### PR TITLE
Hide radio and checkbox inputs RSC-613

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.3",
+  "version": "7.2.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.3",
+  "version": "7.2.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -109,6 +109,7 @@ svg.nx-radio-checkbox__control {
   // in FF, the checkboxes don't respect the width: 0 and we need this in order to hide them
   // Fix discovered via the title of https://bugzilla.mozilla.org/show_bug.cgi?id=605985
   -moz-appearance: none;
+  -webkit-appearance: none;
 
   &:focus {
     // less-nice IE11 focus style because IE11 doesn't support :focus-within

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -104,7 +104,6 @@ svg.nx-radio-checkbox__control {
 
 .nx-radio-checkbox__input {
   margin: 0;
-  width: 0;
 
   // in FF, the checkboxes don't respect the width: 0 and we need this in order to hide them
   // Fix discovered via the title of https://bugzilla.mozilla.org/show_bug.cgi?id=605985

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -104,9 +104,6 @@ svg.nx-radio-checkbox__control {
 
 .nx-radio-checkbox__input {
   margin: 0;
-
-  // in FF, the checkboxes don't respect the width: 0 and we need this in order to hide them
-  // Fix discovered via the title of https://bugzilla.mozilla.org/show_bug.cgi?id=605985
   -moz-appearance: none;
   -webkit-appearance: none;
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-613

Fixed by adding `-webkit-appearance: none;` that hides the input element on webkit based browsers.