### PR TITLE
Add SCSS variables for focus borders RSC-620

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.2.6",
+  "version": "7.2.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.2.6",
+  "version": "7.2.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-@import '../../scss-shared/_nx-focus-border-helpers';
+@import '../../scss-shared/nx-focus-border-helpers';
 
 $nx-checkbox__box-height: 16px;
 $nx-checkbox__box-width: 16px;

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -8,7 +8,6 @@
 
 $nx-checkbox__box-height: 16px;
 $nx-checkbox__box-width: 16px;
-$nx-checkbox-focus-border-offset: 6px;
 
 .nx-checkbox__box {
   border-radius: 2px;
@@ -37,7 +36,7 @@ $nx-checkbox-focus-border-offset: 6px;
 
 .nx-checkbox:focus-within {
   &::after{
-    @include nx-radio-checkbox-focus-border($nx-checkbox__box-height, $nx-checkbox__box-width, $nx-checkbox-focus-border-offset);
+    @include nx-radio-checkbox-focus-border($nx-checkbox__box-height, $nx-checkbox__box-width);
     border-radius: 4px;
   }
 }

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -6,15 +6,15 @@
  */
 @import '../../scss-shared/nx-focus-border-helpers';
 
-$nx-checkbox__box-height: 16px;
-$nx-checkbox__box-width: 16px;
+$nx-checkbox-height: 16px;
+$nx-checkbox-width: 16px;
 
 .nx-checkbox__box {
   border-radius: 2px;
   box-sizing: border-box;
-  height: $nx-checkbox__box-height;
+  height: $nx-checkbox-height;
   position: relative;
-  width: $nx-checkbox__box-width;
+  width: $nx-checkbox-width;
 
   .fa-check {
     color: var(--nx-swatch-white);
@@ -36,7 +36,7 @@ $nx-checkbox__box-width: 16px;
 
 .nx-checkbox:focus-within {
   &::after{
-    @include nx-radio-checkbox-focus-border($nx-checkbox__box-height, $nx-checkbox__box-width);
+    @include nx-radio-checkbox-focus-border($nx-checkbox-height, $nx-checkbox-width);
     border-radius: 4px;
   }
 }

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -4,13 +4,18 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
+@import '../../scss-shared/_nx-focus-border-helpers';
+
+$nx-checkbox__box-height: 16px;
+$nx-checkbox__box-width: 16px;
+$nx-checkbox-focus-border-offset: 6px;
 
 .nx-checkbox__box {
   border-radius: 2px;
   box-sizing: border-box;
-  height: 16px;
+  height: $nx-checkbox__box-height;
   position: relative;
-  width: 16px;
+  width: $nx-checkbox__box-width;
 
   .fa-check {
     color: var(--nx-swatch-white);
@@ -32,9 +37,7 @@
 
 .nx-checkbox:focus-within {
   &::after{
+    @include nx-radio-checkbox-focus-border($nx-checkbox__box-height, $nx-checkbox__box-width, $nx-checkbox-focus-border-offset);
     border-radius: 4px;
-    height: 22px;
-    left: -4px;
-    width: 22px;
   }
 }

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -4,14 +4,14 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
- @import '../../scss-shared/nx-focus-border-helpers';
+@import '../../scss-shared/nx-focus-border-helpers';
 
-$nx-radio__circle-height: 16px;
-$nx-radio__circle-width: 16px;
+$nx-radio-height: 16px;
+$nx-radio-width: 16px;
 
 .nx-radio__circle {
-  height: $nx-radio__circle-height;
-  width: $nx-radio__circle-width;
+  height: $nx-radio-height;
+  width: $nx-radio-width;
 }
 
 .nx-radio__inner-circle {
@@ -38,7 +38,7 @@ $nx-radio__circle-width: 16px;
 
 .nx-radio:focus-within {
   &::after{
-    @include nx-radio-checkbox-focus-border($nx-radio__circle-height, $nx-radio__circle-width);
+    @include nx-radio-checkbox-focus-border($nx-radio-height, $nx-radio-width);
     border-radius: 12px;
   }
 }

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -4,10 +4,15 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
+ @import '../../scss-shared/_nx-focus-border-helpers';
+
+$nx-radio__circle-height: 16px;
+$nx-radio__circle-width: 16px;
+$nx-radio-focus-border-offset: 6px;
 
 .nx-radio__circle {
-  height: 24px;
-  width: 16px;
+  height: $nx-radio__circle-height;
+  width: $nx-radio__circle-width;
 }
 
 .nx-radio__inner-circle {
@@ -34,9 +39,7 @@
 
 .nx-radio:focus-within {
   &::after{
+    @include nx-radio-checkbox-focus-border($nx-radio__circle-height, $nx-radio__circle-width, $nx-radio-focus-border-offset);
     border-radius: 12px;
-    height: 22px;
-    left: -4px;
-    width: 22px;
   }
 }

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
- @import '../../scss-shared/_nx-focus-border-helpers';
+ @import '../../scss-shared/nx-focus-border-helpers';
 
 $nx-radio__circle-height: 16px;
 $nx-radio__circle-width: 16px;

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -8,7 +8,6 @@
 
 $nx-radio__circle-height: 16px;
 $nx-radio__circle-width: 16px;
-$nx-radio-focus-border-offset: 6px;
 
 .nx-radio__circle {
   height: $nx-radio__circle-height;
@@ -39,7 +38,7 @@ $nx-radio-focus-border-offset: 6px;
 
 .nx-radio:focus-within {
   &::after{
-    @include nx-radio-checkbox-focus-border($nx-radio__circle-height, $nx-radio__circle-width, $nx-radio-focus-border-offset);
+    @include nx-radio-checkbox-focus-border($nx-radio__circle-height, $nx-radio__circle-width);
     border-radius: 12px;
   }
 }

--- a/lib/src/components/NxToggle/NxToggle.scss
+++ b/lib/src/components/NxToggle/NxToggle.scss
@@ -9,7 +9,6 @@
 
 $nx-toggle__control-height: 24px;
 $nx-toggle__control-width: 44px;
-$nx-toggle-focus-border-offset: 6px;
 
 .nx-toggle {
   column-gap: 16px;
@@ -42,7 +41,7 @@ $nx-toggle-focus-border-offset: 6px;
       }
 
       &::after{
-        @include nx-toggle-focus-border($nx-toggle__control-height, $nx-toggle__control-width, $nx-toggle-focus-border-offset);
+        @include nx-toggle-focus-border($nx-toggle__control-height, $nx-toggle__control-width);
         border: 1px solid var(--nx-color-interactive-border-focus);
         border-radius: 16px;
         box-shadow: var(--nx-box-shadow-focus);

--- a/lib/src/components/NxToggle/NxToggle.scss
+++ b/lib/src/components/NxToggle/NxToggle.scss
@@ -7,8 +7,8 @@
 @import '../../scss-shared/nx-text-helpers';
 @import '../../scss-shared/nx-focus-border-helpers';
 
-$nx-toggle__control-height: 24px;
-$nx-toggle__control-width: 44px;
+$nx-toggle-height: 24px;
+$nx-toggle-width: 44px;
 
 .nx-toggle {
   column-gap: 16px;
@@ -41,7 +41,7 @@ $nx-toggle__control-width: 44px;
       }
 
       &::after{
-        @include nx-toggle-focus-border($nx-toggle__control-height, $nx-toggle__control-width);
+        @include nx-toggle-focus-border($nx-toggle-height, $nx-toggle-width);
         border: 1px solid var(--nx-color-interactive-border-focus);
         border-radius: 16px;
         box-shadow: var(--nx-box-shadow-focus);
@@ -92,9 +92,9 @@ $nx-toggle__control-width: 44px;
   box-sizing: border-box;
   display: flex;
   grid-area: toggle;
-  height: $nx-toggle__control-height;
+  height: $nx-toggle-height;
   padding: calc(var(--nx-spacing-base) - 1px);
-  width: $nx-toggle__control-width;
+  width: $nx-toggle-width;
 }
 
 .nx-toggle__indicator {

--- a/lib/src/components/NxToggle/NxToggle.scss
+++ b/lib/src/components/NxToggle/NxToggle.scss
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 @import '../../scss-shared/nx-text-helpers';
-@import '../../scss-shared/_nx-focus-border-helpers';
+@import '../../scss-shared/nx-focus-border-helpers';
 
 $nx-toggle__control-height: 24px;
 $nx-toggle__control-width: 44px;

--- a/lib/src/components/NxToggle/NxToggle.scss
+++ b/lib/src/components/NxToggle/NxToggle.scss
@@ -5,6 +5,11 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 @import '../../scss-shared/nx-text-helpers';
+@import '../../scss-shared/_nx-focus-border-helpers';
+
+$nx-toggle__control-height: 24px;
+$nx-toggle__control-width: 44px;
+$nx-toggle-focus-border-offset: 6px;
 
 .nx-toggle {
   column-gap: 16px;
@@ -37,16 +42,13 @@
       }
 
       &::after{
+        @include nx-toggle-focus-border($nx-toggle__control-height, $nx-toggle__control-width, $nx-toggle-focus-border-offset);
         border: 1px solid var(--nx-color-interactive-border-focus);
         border-radius: 16px;
         box-shadow: var(--nx-box-shadow-focus);
         content: '';
         display: block;
-        height: 30px;
-        position:absolute;
-        left: -4px;
-        top: -4px;
-        width: 50px;
+        position: absolute;
       }
     }
   }
@@ -91,9 +93,9 @@
   box-sizing: border-box;
   display: flex;
   grid-area: toggle;
-  height: 24px;
+  height: $nx-toggle__control-height;
   padding: calc(var(--nx-spacing-base) - 1px);
-  width: 44px;
+  width: $nx-toggle__control-width;
 }
 
 .nx-toggle__indicator {

--- a/lib/src/components/NxToggle/NxToggle.scss
+++ b/lib/src/components/NxToggle/NxToggle.scss
@@ -41,13 +41,16 @@ $nx-toggle-width: 44px;
       }
 
       &::after{
-        @include nx-toggle-focus-border($nx-toggle-height, $nx-toggle-width);
         border: 1px solid var(--nx-color-interactive-border-focus);
         border-radius: 16px;
         box-shadow: var(--nx-box-shadow-focus);
         content: '';
         display: block;
+        height: calc(#{$nx-toggle-height} + 6px);
         position: absolute;
+        left: -4px;
+        top: -4px;
+        width: calc(#{$nx-toggle-width} + 6px);
       }
     }
   }

--- a/lib/src/scss-shared/_nx-focus-border-helpers.scss
+++ b/lib/src/scss-shared/_nx-focus-border-helpers.scss
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+
+// For dynamically calculating focus border styles
+// based on height, width and focus border offset
+// Calculations based on a 1px border
+
+// NxRadio and NxCheckbox require the left property for correct positioning of focus border
+@mixin nx-radio-checkbox-focus-border($height, $width, $offset) {
+    height: calc(#{$height} + #{$offset});
+    left: calc(-1px - #{$offset}/2);
+    width: calc(#{$width} + #{$offset});
+}
+
+// NxToggle requires an additional top property for correct positioning of focus border
+@mixin nx-toggle-focus-border($height, $width, $offset) {
+    @include nx-radio-checkbox-focus-border($height, $width, $offset);
+    top: calc(-1px - #{$offset}/2);
+}

--- a/lib/src/scss-shared/_nx-focus-border-helpers.scss
+++ b/lib/src/scss-shared/_nx-focus-border-helpers.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-present Sonatype, Inc.
+ * Copyright (c) 2019-present Sonatype, Inc.
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.

--- a/lib/src/scss-shared/_nx-focus-border-helpers.scss
+++ b/lib/src/scss-shared/_nx-focus-border-helpers.scss
@@ -15,9 +15,3 @@
     left: -4px;
     width: calc(#{$width} + 6px);
 }
-
-// NxToggle requires an additional top property for correct positioning of focus border
-@mixin nx-toggle-focus-border($height, $width) {
-    @include nx-radio-checkbox-focus-border($height, $width);
-    top: -4px;
-}

--- a/lib/src/scss-shared/_nx-focus-border-helpers.scss
+++ b/lib/src/scss-shared/_nx-focus-border-helpers.scss
@@ -5,19 +5,19 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 
-// For dynamically calculating focus border styles
-// based on height, width and focus border offset
-// Calculations based on a 1px border
+// For dynamically calculating focus border styles based on height and width
+// Border size is 1px border and 6px here represents total space in each axis
+// between border and control elements. Values are based on RSC design spec.
 
 // NxRadio and NxCheckbox require the left property for correct positioning of focus border
-@mixin nx-radio-checkbox-focus-border($height, $width, $offset) {
-    height: calc(#{$height} + #{$offset});
-    left: calc(-1px - #{$offset}/2);
-    width: calc(#{$width} + #{$offset});
+@mixin nx-radio-checkbox-focus-border($height, $width) {
+    height: calc(#{$height} + 6px);
+    left: -4px;
+    width: calc(#{$width} + 6px);
 }
 
 // NxToggle requires an additional top property for correct positioning of focus border
-@mixin nx-toggle-focus-border($height, $width, $offset) {
-    @include nx-radio-checkbox-focus-border($height, $width, $offset);
-    top: calc(-1px - #{$offset}/2);
+@mixin nx-toggle-focus-border($height, $width) {
+    @include nx-radio-checkbox-focus-border($height, $width);
+    top: -4px;
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-620

- The focus border style's `width`, `height` and absolute positioning values (`left`, `top`) were previously hardcoded. 
- New implementation makes use of dynamic calculations to correctly position the focus borders on `NxToggle`, `NxRadio` and `NxCheckbox`.
- All calculations are based on a `1px` border width of the focus border.
- Introduced `mixins` to reuse calculation logic.