### PR TITLE
Fix NxTreeViewMultiSelect focus states RSC-629

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.3.4",
+  "version": "7.4.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.3.4",
+  "version": "7.4.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -32,10 +32,7 @@
   }
 
   &:focus-within {
-    // For radios, .nx-radio-checkbox__control is added to an <svg>
-    // Since <svg> does not support pseudoelements, it is instead added to
-    // an additional <span> with the class nx-radio__focus
-    .nx-radio-checkbox__control, .nx-radio__focus {
+    .nx-checkbox__box, .nx-radio__focus {
       position: relative;
       &::after {
         border: 1px solid var(--nx-color-interactive-border-focus);

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -32,12 +32,18 @@
   }
 
   &:focus-within {
-    &::after {
-      border: 1px solid var(--nx-color-interactive-border-focus);
-      box-shadow: var(--nx-box-shadow-focus);
-      content: '';
-      display: block;
-      position: absolute;
+    // For radios, .nx-radio-checkbox__control is added to an <svg>
+    // Since <svg> does not support pseudoelements, it is instead added to
+    // an additional <span> with the class nx-radio__focus
+    .nx-radio-checkbox__control, .nx-radio__focus {
+      position: relative;
+      &::after {
+        border: 1px solid var(--nx-color-interactive-border-focus);
+        box-shadow: var(--nx-box-shadow-focus);
+        content: '';
+        display: block;
+        position: absolute;
+      }
     }
 
     &:hover {

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -16,6 +16,14 @@ $nx-checkbox-width: 16px;
   position: relative;
   width: $nx-checkbox-width;
 
+  // Pseudoelemtn style is for the focus border
+  &::after{
+    @include nx-radio-checkbox-focus-border($nx-checkbox-height, $nx-checkbox-width);
+    left: -5px;
+    top: -5px;
+    border-radius: 4px;
+  }
+
   .fa-check {
     color: var(--nx-swatch-white);
     font-size: var(--nx-font-size-s);
@@ -31,12 +39,5 @@ $nx-checkbox-width: 16px;
     .fa-check {
       color: var(--nx-color-text-disabled);
     }
-  }
-}
-
-.nx-checkbox:focus-within {
-  &::after{
-    @include nx-radio-checkbox-focus-border($nx-checkbox-height, $nx-checkbox-width);
-    border-radius: 4px;
   }
 }

--- a/lib/src/components/NxCheckbox/NxCheckbox.scss
+++ b/lib/src/components/NxCheckbox/NxCheckbox.scss
@@ -16,12 +16,13 @@ $nx-checkbox-width: 16px;
   position: relative;
   width: $nx-checkbox-width;
 
-  // Pseudoelemtn style is for the focus border
+  // Pseudo-element style is for the focus border
   &::after{
     @include nx-radio-checkbox-focus-border($nx-checkbox-height, $nx-checkbox-width);
+
+    border-radius: 4px;
     left: -5px;
     top: -5px;
-    border-radius: 4px;
   }
 
   .fa-check {

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -36,12 +36,13 @@ $nx-radio-width: 16px;
   }
 }
 
-// Pseudoelement style is for the focus border
+// Pseudo-element style is for the focus border
 .nx-radio__focus {
   &::after{
     @include nx-radio-checkbox-focus-border($nx-radio-height, $nx-radio-width);
+
+    border-radius: 12px;
     left: -28px;
     top: -12px;
-    border-radius: 12px;
   }
 }

--- a/lib/src/components/NxRadio/NxRadio.scss
+++ b/lib/src/components/NxRadio/NxRadio.scss
@@ -36,9 +36,12 @@ $nx-radio-width: 16px;
   }
 }
 
-.nx-radio:focus-within {
+// Pseudoelement style is for the focus border
+.nx-radio__focus {
   &::after{
     @include nx-radio-checkbox-focus-border($nx-radio-height, $nx-radio-width);
+    left: -28px;
+    top: -12px;
     border-radius: 12px;
   }
 }

--- a/lib/src/components/NxRadio/NxRadio.tsx
+++ b/lib/src/components/NxRadio/NxRadio.tsx
@@ -47,6 +47,7 @@ const NxRadio = forwardRef<HTMLLabelElement, Props>(
             { isChecked && <circle r="6" strokeWidth="4" className="nx-radio__inner-circle"/> }
             <circle r="7.5" strokeWidth="1" className="nx-radio__outer-circle"/>
           </svg>
+          <span className="nx-radio__focus"></span>
           { content &&
             (overflowTooltip !== false ? <NxOverflowTooltip>{content}</NxOverflowTooltip> : content)
           }

--- a/lib/src/scss-shared/_nx-focus-border-helpers.scss
+++ b/lib/src/scss-shared/_nx-focus-border-helpers.scss
@@ -9,9 +9,8 @@
 // Border size is 1px border and 6px here represents total space in each axis
 // between border and control elements. Values are based on RSC design spec.
 
-// NxRadio and NxCheckbox require the left property for correct positioning of focus border
+// NxRadio and NxCheckbox require the left and top property for correct positioning of focus border
 @mixin nx-radio-checkbox-focus-border($height, $width) {
     height: calc(#{$height} + 6px);
-    left: -4px;
     width: calc(#{$width} + 6px);
 }

--- a/lib/src/scss-shared/_nx-focus-border-helpers.scss
+++ b/lib/src/scss-shared/_nx-focus-border-helpers.scss
@@ -9,7 +9,8 @@
 // Border size is 1px border and 6px here represents total space in each axis
 // between border and control elements. Values are based on RSC design spec.
 
-// NxRadio and NxCheckbox require the left and top property for correct positioning of focus border
+// For correct positioning of focus borders, NxRadio and NxCheckbox additionally require
+// the left and top properties (currently specified in their respective .scss files)
 @mixin nx-radio-checkbox-focus-border($height, $width) {
     height: calc(#{$height} + 6px);
     width: calc(#{$width} + 6px);


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-629

This PR fixes the incorrectly positioned focus states for `NxTreeViewMultiSelect`

- Previously, the `::after` pseudoelement was added to the `<label>`. If the label had some padding (which is what the `NxTreeViewMultiSelect` labels have), the alignment of the focus border is misaligned.
- This fix adds the `::after` pseudoelement to a `<span>` which doesn't change based on the label padding.
- I had to add a `<span>` on `NxRadio`, because initially the `::after` was being added to an `<svg>`. Since `<svg>` does not support generated content like `::after`, I had to create a `<span>` for the `::after `element to show