### PR TITLE
Changes from Lighthouse audit RSC-426

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.4.3",
+  "version": "7.4.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/index.html
+++ b/gallery/src/index.html
@@ -7,7 +7,7 @@
 
 -->
 <!DOCTYPE html>
-<html class="nx-html nx-html--page-scrolling">
+<html class="nx-html nx-html--page-scrolling" lang="en">
   <head>
     <meta charset="utf-8">
     <title>Sonatype shared component gallery</title>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.4.3",
+  "version": "7.4.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -76,7 +76,7 @@
   background-color: var(--nx-swatch-grey-95);
   border: 1px solid var(--nx-swatch-grey-90);
   border-radius: var(--nx-border-radius);
-  color: var(--nx-swatch-red-45);
+  color: var(--nx-swatch-red-40);
   padding: 1px 4px;
   white-space: nowrap;
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-426

Two changes were required:
1. added 'lang' attribute to the `<html>` tag
2. increased the contrast of the `.nx-code` styles