### PR TITLE
NxModal a11y label RSC-615

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxModal/NxModalAlertExample.tsx
+++ b/gallery/src/components/NxModal/NxModalAlertExample.tsx
@@ -16,7 +16,10 @@ export default function NxModalAlertExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Alert in content</NxButton>
       { showModal &&
-        <NxModal id="nx-modal-alert-example" role="alertdialog" onCancel={modalCloseHandler}>
+        <NxModal id="nx-modal-alert-example"
+                 role="alertdialog"
+                 onCancel={modalCloseHandler}
+                 aria-label="Example NxModal with NxAlert">
           <header className="nx-modal-header">
             <h2 className="nx-h2">Example NxModal with NxAlert</h2>
           </header>

--- a/gallery/src/components/NxModal/NxModalEscExample.tsx
+++ b/gallery/src/components/NxModal/NxModalEscExample.tsx
@@ -72,9 +72,9 @@ export default function NxModalStackedExample() {
         </NxModal>
       }
       {showModal2 &&
-        <NxModal id="nx-modal-esc-example-modal2" onCancel={modal2CancelHandler}>
+        <NxModal id="nx-modal-esc-example-modal2" onCancel={modal2CancelHandler} aria-labelledby="modal-esc-header2">
           <header className="nx-modal-header">
-            <h2 className="nx-h2">
+            <h2 className="nx-h2" id="modal-esc-header2">
               <NxFontAwesomeIcon icon={faAngry} />
               <span>NxModal stacked example</span>
             </h2>

--- a/gallery/src/components/NxModal/NxModalEscExample.tsx
+++ b/gallery/src/components/NxModal/NxModalEscExample.tsx
@@ -44,9 +44,9 @@ export default function NxModalStackedExample() {
         </div>
       }
       {showModal &&
-        <NxModal id="nx-modal-esc-example-modal" onCancel={modal1CancelHandler}>
+        <NxModal id="nx-modal-esc-example-modal" onCancel={modal1CancelHandler} aria-labelledby="modal-esc-header">
           <header className="nx-modal-header">
-            <h2 className="nx-h2">
+            <h2 className="nx-h2" id="modal-esc-header">
               <NxFontAwesomeIcon icon={faAngry} />
               <span>NxModal with a dropdown that opens another modal</span>
             </h2>

--- a/gallery/src/components/NxModal/NxModalExtraWideExample.tsx
+++ b/gallery/src/components/NxModal/NxModalExtraWideExample.tsx
@@ -16,8 +16,11 @@ export default function NxModalExtraWideExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open wide modal</NxButton>
       {showModal &&
-      <NxModal id="nx-modal-wide-example" variant="wide" onCancel={modalCloseHandler}>
-        <header className="nx-modal-header">
+      <NxModal id="nx-modal-wide-example"
+               variant="wide"
+               onCancel={modalCloseHandler}
+               aria-labelledby="modal-wide-header">
+        <header className="nx-modal-header" id="modal-wide-header">
           <h2 className="nx-h2">Vulnerability Information</h2>
         </header>
         <div className="nx-modal-content">

--- a/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
@@ -26,13 +26,15 @@ export default function NxModalFormErrorExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal with Form and Error Styling</NxButton>
       {showModal &&
-        <NxModal id="nx-modal-form-error-example" onCancel={modalCloseHandler}>
+        <NxModal id="nx-modal-form-error-example"
+                 onCancel={modalCloseHandler}
+                 aria-labelledby="modal-form-error-header">
           <NxForm className="nx-form"
                   onSubmit={modalCloseHandler}
                   onCancel={modalCloseHandler}
                   submitError={error}>
             <header className="nx-modal-header">
-              <h2 className="nx-h2">
+              <h2 className="nx-h2" id="modal-form-error-header">
                 <NxFontAwesomeIcon icon={faAngry} />
                 <span>Example NxModal header with form content and error styling</span>
               </h2>

--- a/gallery/src/components/NxModal/NxModalFormExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormExample.tsx
@@ -39,7 +39,7 @@ export default function NxModalFormExample() {
     <>
       <NxButton onClick={openModal}>Open Modal with Form</NxButton>
       {showModal &&
-        <NxModal id="nx-modal-form-example" onCancel={modalCloseHandler}>
+        <NxModal id="nx-modal-form-example" onCancel={modalCloseHandler} aria-labelledby="modal-form-header">
           <NxForm className="nx-form"
                   onSubmit={modalCloseHandler}
                   onCancel={modalCloseHandler}
@@ -52,7 +52,7 @@ export default function NxModalFormExample() {
                   doLoad={() => {}}
                   loading={loading}>
             <header className="nx-modal-header">
-              <h2 className="nx-h2">
+              <h2 className="nx-h2" id="modal-form-header">
                 <NxFontAwesomeIcon icon={faAngry} />
                 <span>NxModal header with form content</span>
               </h2>

--- a/gallery/src/components/NxModal/NxModalNarrowExample.tsx
+++ b/gallery/src/components/NxModal/NxModalNarrowExample.tsx
@@ -17,9 +17,12 @@ export default function NxModalSimpleExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal</NxButton>
       { showModal &&
-        <NxModal variant="narrow" id="nx-modal-narrow-example" onCancel={modalCloseHandler}>
+        <NxModal variant="narrow"
+                 id="nx-modal-narrow-example"
+                 onCancel={modalCloseHandler}
+                 aria-labelledby="modal-narrow-header">
           <header className="nx-modal-header">
-            <h2 className="nx-h2">
+            <h2 className="nx-h2" id="modal-narrow-header">
               <NxFontAwesomeIcon icon={faAngry} />
               <span>
                 Example NxModal header - this header is long to demonstrate the truncation that all modal headers

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -178,13 +178,23 @@ export default function NxModalPage() {
             </tr>
           </tbody>
         </table>
+        <NxInfoAlert>
+          Note: Placing content into the modal which exceeds its horizontal bounds is not supported. The resulting
+          layout is unspecified.
+        </NxInfoAlert>
         <h3>Accessibility</h3>
         <p className="nx-p">
-          Elements with the <code className="nx-code">dialog</code> roles are supposed to have a label specified by the
-          {' '}<code className="nx-code">aria-label</code> or <code className="nx-code">aria-labelledby</code>
-          attributes. Typically the label would be the same as the modal header text and so
-          {' '}<code className="nx-code">aria-labelledby</code> is the DRYer atribute, but either can work.
+          Elements with the <code className="nx-code">dialog</code> role are supposed to have a label specified by the
+          {' '}<code className="nx-code">aria-labelledby</code> or <code className="nx-code">aria-label</code>
+          {' '}attribute. Because the value of <code className="nx-code">aria-labelledby</code> or
+          {' '}<code className="nx-code">aria-label</code> is typically the same as the modal header text
+          {' '}<code className="nx-code">aria-labelledby</code> is the DRYer attribute.
         </p>
+        <NxWarningAlert>
+          Note: While the use of <code className="nx-code">aria-labelledby</code>
+          {' '}(or <code className="nx-code">aria-label</code>) is not required by the component it should be
+          considered mandatory in order to comply with accessibility guidelines.
+        </NxWarningAlert>
         <table className="nx-table nx-table--gallery-props">
           <thead>
             <tr className="nx-table-row nx-table-row--header">
@@ -194,26 +204,22 @@ export default function NxModalPage() {
           </thead>
           <tbody>
             <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">aria-label</code></td>
-              <td className="nx-cell">
-                When the <code className="nx-code">aria-label</code> attribute is used the text is added directly to the
-                attribute.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
               <td className="nx-cell"><code className="nx-code">aria-labelledby</code></td>
               <td className="nx-cell">
                 When the <code className="nx-code">aria-labelledby</code> attribute is used an ID is applied to the
-                HTML element that will be providing the label information (typically the modal title), the ID is
-                referened by <code className="nx-code">aria-labelledby</code>.
+                HTML element that will be providing the label information (typically the modal title H3), the ID is
+                referenced by <code className="nx-code">aria-labelledby</code>. See examples below.
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell"><code className="nx-code">aria-label</code></td>
+              <td className="nx-cell">
+                When the <code className="nx-code">aria-label</code> attribute is used the text is added directly to the
+                attribute. See the NxModal Example with NxAlert example below.
               </td>
             </tr>
           </tbody>
         </table>
-        <NxInfoAlert>
-          Note: Placing content into the modal which exceeds its horizontal bounds is not supported. The resulting
-          layout is unspecified.
-        </NxInfoAlert>
       </GalleryDescriptionTile>
 
       <GalleryExampleTile title="Simple NxModal Example"

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -178,6 +178,38 @@ export default function NxModalPage() {
             </tr>
           </tbody>
         </table>
+        <h3>Accessibility</h3>
+        <p className="nx-p">
+          Elements with the <code className="nx-code">dialog</code> roles are supposed to have a label specified by the
+          {' '}<code className="nx-code">aria-label</code> or <code className="nx-code">aria-labelledby</code>
+          attributes. Typically the label would be the same as the modal header text and so
+          {' '}<code className="nx-code">aria-labelledby</code> is the DRYer atribute, but either can work.
+        </p>
+        <table className="nx-table nx-table--gallery-props">
+          <thead>
+            <tr className="nx-table-row nx-table-row--header">
+              <th className="nx-cell nx-cell--header">Attribute</th>
+              <th className="nx-cell nx-cell--header">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="nx-table-row">
+              <td className="nx-cell"><code className="nx-code">aria-label</code></td>
+              <td className="nx-cell">
+                When the <code className="nx-code">aria-label</code> attribute is used the text is added directly to the
+                attribute.
+              </td>
+            </tr>
+            <tr className="nx-table-row">
+              <td className="nx-cell"><code className="nx-code">aria-labelledby</code></td>
+              <td className="nx-cell">
+                When the <code className="nx-code">aria-labelledby</code> attribute is used an ID is applied to the
+                HTML element that will be providing the label information (typically the modal title), the ID is
+                referened by <code className="nx-code">aria-labelledby</code>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
         <NxInfoAlert>
           Note: Placing content into the modal which exceeds its horizontal bounds is not supported. The resulting
           layout is unspecified.
@@ -191,6 +223,7 @@ export default function NxModalPage() {
         A basic example of an <code className="nx-code">NxModal</code>. Click the button to open the modal. Note that
         this modal has sufficient content to induce scrolling (on most monitors). You will see in other examples that
         when modals have smaller contents, the scrollbar does not appear and the modal content area shrinks to fit.
+        This example uses <code className="nx-code">aria-labelledby</code>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal Example with NxAlert"
@@ -201,6 +234,7 @@ export default function NxModalPage() {
         in this scenario is <NxCode>alertdialog</NxCode>.  Note that this is actually the only role you'd ever want to
         explicitly add to an <NxCode>NxModal</NxCode>. In non-alert cases, <NxCode>NxModal</NxCode> takes on the
         semantics of the <NxCode>dialog</NxCode> role as one would expect.
+        This example uses <code className="nx-code">aria-label</code>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal with stacked modal example"
@@ -209,6 +243,7 @@ export default function NxModalPage() {
                           codeExamples={NxModalStackedSourceCode}>
         <code className="nx-code">NxModal</code> also supports stacked or nested modals. A second modal can be
         generated from inside of an <code className="nx-code">NxModal</code>.
+        This example uses <code className="nx-code">aria-labelledby</code>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal example with other ESC-controller elements"
@@ -220,6 +255,7 @@ export default function NxModalPage() {
         component all working together such that pressing ESC only closes one of them at a time. Note
         that <NxCode>NxDropdown</NxCode> is designed so that pressing ESC when it is open only closes it if it is
         focused.
+        This example uses <code className="nx-code">aria-labelledby</code>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal Example with form"
@@ -227,6 +263,7 @@ export default function NxModalPage() {
                           liveExample={NxModalFormExample}
                           codeExamples={NxModalFormSourceCode}>
         <code className="nx-code">NxModal</code> also supports inclusion and styling of form elements.
+        This example uses <code className="nx-code">aria-labelledby</code>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal Example with form and error styling"
@@ -235,7 +272,8 @@ export default function NxModalPage() {
                           codeExamples={NxModalFormErrorSourceCode}>
         This <code className="nx-code">NxModal</code> also contains a form, but additionally demonstrates the typical
         way that an error upon the submission of said form would be handled: with
-        an <code className="nx-code">NxErrorAlert</code> in the footer
+        an <code className="nx-code">NxErrorAlert</code> in the footer.
+        This example uses <code className="nx-code">aria-labelledby</code>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Wide NxModal Example"
@@ -244,6 +282,7 @@ export default function NxModalPage() {
                           codeExamples={NxModalExtraWideSourceCode}>
         A demonstration of the <code className="nx-code">wide</code> styles
         for <code className="nx-code">NxModal</code>.
+        This example uses <code className="nx-code">aria-labelledby</code>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Narrow NxModal Example"
@@ -252,6 +291,7 @@ export default function NxModalPage() {
                           codeExamples={NxModalNarrowSourceCode}>
         A demonstration of the <code className="nx-code">narrow</code> styles
         for <code className="nx-code">NxModal</code>.
+        This example uses <code className="nx-code">aria-labelledby</code>.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -184,11 +184,12 @@ export default function NxModalPage() {
         </NxInfoAlert>
         <h3>Accessibility</h3>
         <p className="nx-p">
-          Elements with the <code className="nx-code">dialog</code> role are supposed to have a label specified by the
-          {' '}<code className="nx-code">aria-labelledby</code> or <code className="nx-code">aria-label</code>
-          {' '}attribute. Because the value of <code className="nx-code">aria-labelledby</code> or
-          {' '}<code className="nx-code">aria-label</code> is typically the same as the modal header text
-          {' '}<code className="nx-code">aria-labelledby</code> is the DRYer attribute.
+          <code className="nx-code">NxModal</code> uses the <code className="nx-code">dialog</code> role and needs
+          to have a label specified by the <code className="nx-code">aria-labelledby</code> or
+          {' '}<code className="nx-code">aria-label</code> attribute. Because the value
+          of <code className="nx-code">aria-labelledby</code> or <code className="nx-code">aria-label</code> is
+          typically the same as the modal header text <code className="nx-code">aria-labelledby</code> is the DRYer
+          attribute.
         </p>
         <NxWarningAlert>
           Note: While the use of <code className="nx-code">aria-labelledby</code>

--- a/gallery/src/components/NxModal/NxModalSimpleExample.tsx
+++ b/gallery/src/components/NxModal/NxModalSimpleExample.tsx
@@ -17,9 +17,9 @@ export default function NxModalSimpleExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open Modal</NxButton>
       { showModal &&
-        <NxModal id="nx-modal-simple-example" onCancel={modalCloseHandler}>
+        <NxModal id="nx-modal-simple-example" onCancel={modalCloseHandler} aria-labelledby="modal-header-text">
           <header className="nx-modal-header">
-            <h2 className="nx-h2">
+            <h2 className="nx-h2" id="modal-header-text">
               <NxFontAwesomeIcon icon={faAngry} />
               <span>Example NxModal header</span>
             </h2>

--- a/gallery/src/components/NxModal/NxModalStackedExample.tsx
+++ b/gallery/src/components/NxModal/NxModalStackedExample.tsx
@@ -43,9 +43,9 @@ export default function NxModalStackedExample() {
         </NxModal>
       }
       {showModal2 &&
-        <NxModal id="nx-modal-stacked-example2" onCancel={modal2CloseHandler}>
+        <NxModal id="nx-modal-stacked-example2" onCancel={modal2CloseHandler} aria-labelledby="modal-stacked-header2">
           <header className="nx-modal-header">
-            <h2 className="nx-h2">
+            <h2 className="nx-h2" id="modal-stacked-header2">
               <NxFontAwesomeIcon icon={faAngry} />
               <span>NxModal stacked example</span>
             </h2>

--- a/gallery/src/components/NxModal/NxModalStackedExample.tsx
+++ b/gallery/src/components/NxModal/NxModalStackedExample.tsx
@@ -19,9 +19,9 @@ export default function NxModalStackedExample() {
     <>
       <NxButton onClick={() => setShowModal(true)}>Open modal with stacked example</NxButton>
       {showModal &&
-        <NxModal id="nx-modal-stacked-example" onCancel={modal1CloseHandler}>
+        <NxModal id="nx-modal-stacked-example" onCancel={modal1CloseHandler} aria-labelledby="modal-stacked-header">
           <header className="nx-modal-header">
-            <h2 className="nx-h2">
+            <h2 className="nx-h2" id="modal-stacked-header">
               <NxFontAwesomeIcon icon={faAngry} />
               <span>NxModal with a stacked modal</span>
             </h2>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -104,7 +104,7 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
     }
   }, [onCancel]);
 
-  const ariaLabelAttrNames = ['aria-label', 'aria-labelledby'],
+  const ariaLabelAttrNames = ['aria-label', 'aria-labelledby'] as const,
       ariaLabels = pick(ariaLabelAttrNames, attrs),
       attrsWithoutLabels = omit(ariaLabelAttrNames, attrs);
 

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -124,8 +124,8 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
               className="nx-modal-backdrop"
               tabIndex={-1}
               onKeyDown={dialogKeydownListener}
-              aria-labelledby={ariaLabels}>
-        <div className={modalClasses} {...attrs} />
+              {...ariaLabels}>
+        <div className={modalClasses} {...attrsWithoutLabels}/>
       </dialog>
     </NxModalContext.Provider>
   );

--- a/lib/src/components/NxModal/NxModal.tsx
+++ b/lib/src/components/NxModal/NxModal.tsx
@@ -6,6 +6,7 @@
  */
 import React, {FunctionComponent, KeyboardEvent, useEffect, useRef, useState} from 'react';
 import classnames from 'classnames';
+import { pick, omit } from 'ramda';
 
 import {Props, propTypes} from './types';
 
@@ -103,6 +104,10 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
     }
   }, [onCancel]);
 
+  const ariaLabelAttrNames = ['aria-label', 'aria-labelledby'],
+      ariaLabels = pick(ariaLabelAttrNames, attrs),
+      attrsWithoutLabels = omit(ariaLabelAttrNames, attrs);
+
   return (
     // Provide the dialog element to descendants so that tooltips can attach to it instead of the body,
     // which is necessary so that they end up in the top layer rather than behind the modal
@@ -118,7 +123,8 @@ const NxModal: FunctionComponent<Props> = ({ className, onClose, onCancel = onCl
               aria-modal="true"
               className="nx-modal-backdrop"
               tabIndex={-1}
-              onKeyDown={dialogKeydownListener}>
+              onKeyDown={dialogKeydownListener}
+              aria-labelledby={ariaLabels}>
         <div className={modalClasses} {...attrs} />
       </dialog>
     </NxModalContext.Provider>


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-615

I could not see any way that we could automatically link the modal header to the `aria-labelledy` attribute so I left it as a manual step. I documented both `aria-labelledby` and `aria-label` making it clear that `aria-labelledby` is preferred.

I modified the examples of `NxModal` to use `aria-labelledby` except one which demonstrates `aria-label`.

I did not make the use of either mandatory because that would be a breaking change and I didn't think that it was worth making this a breaking change right now. Then next time we make a major release we can revisit this decision.