### PR TITLE
Pin selenium version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
 
 def seleniumHubDockerImage = 'docker-all.repo.sonatype.com/selenium/hub'
 def seleniumDockerImage = 'docker-all.repo.sonatype.com/selenium/node-chrome'
-def seleniumDockerVersion = '4.0.0'
+def seleniumDockerVersion = '3.141.59-20210713'
 def numSeleniumContainers = 10;
 
 dockerizedBuildPipeline(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@
 
 def seleniumHubDockerImage = 'docker-all.repo.sonatype.com/selenium/hub'
 def seleniumDockerImage = 'docker-all.repo.sonatype.com/selenium/node-chrome'
-def seleniumDockerVersion = '3.141.59-20210713'
+def seleniumDockerVersion = '4.0.0-rc-1-prerelease-20210618'
 def numSeleniumContainers = 10;
 
 dockerizedBuildPipeline(

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The latest updates to the 4.0.0 tag seem to be breaking the build (https://jenkins.ci.sonatype.dev/job/uxui/job/sonatype-react-shared-components/job/master/548/)

This change pins the version of selenium to the previous release, which seems to resolve the issue(https://jenkins.ci.sonatype.dev/job/uxui/job/sonatype-react-shared-components/job/seleniumVersion/4/).

Selenium releases are documented at:
https://github.com/SeleniumHQ/docker-selenium/releases