### PR TITLE
Consolidate border variables RSC-614

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.4.7",
+  "version": "7.4.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -181,6 +181,9 @@ const CssVariablesPage = () => {
           <PropertyDocItem propertyVar="--nx-border-default">
             Standard border styles for higher-level elements.
           </PropertyDocItem>
+          <PropertyDocItem propertyVar="--nx-border-secondary">
+            Lighter border styles generally used inside components, or after a default border.
+          </PropertyDocItem>
           <PropertyDocItem propertyVar="--nx-border-subsection">
             Standard border styles for lower-level elements such as tile subsections.
           </PropertyDocItem>
@@ -210,6 +213,9 @@ const CssVariablesPage = () => {
           <NxTable.Body>
             <ColorDocRow colorVar="--nx-color-border">
               Color for standard higher-level borders
+            </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-border-secondary">
+              Color for lighter borders
             </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-subsection-border">
               Color for standard lower-level borders such as those of tile subsections

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -182,7 +182,12 @@ const CssVariablesPage = () => {
             Standard border styles for higher-level elements.
           </PropertyDocItem>
           <PropertyDocItem propertyVar="--nx-border-secondary">
-            Secondary border styles generally used inside components, or after a default border.
+            Secondary border styles generally used inside components or after a default border.
+          </PropertyDocItem>
+          <PropertyDocItem propertyVar="--nx-border-subsection">
+            <NxWarningAlert>
+              Deprecated. Standard border styles for lower-level elements such as tile subsections.
+            </NxWarningAlert>
           </PropertyDocItem>
           <PropertyDocItem propertyVar="--nx-box-shadow-focus">
             The standard box-shadow to apply to focused elements in addition to a border or outline.
@@ -213,6 +218,11 @@ const CssVariablesPage = () => {
             </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-border-secondary">
               Color for secondary borders
+            </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-border-subsection">
+              <NxWarningAlert>
+                Deprecated. Standard border styles for lower-level elements such as tile subsections.
+              </NxWarningAlert>
             </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-component-background">
               The background color of most RSC components including tiles and form fields. Note that many RSC

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -214,9 +214,6 @@ const CssVariablesPage = () => {
             <ColorDocRow colorVar="--nx-color-border-secondary">
               Color for lighter borders
             </ColorDocRow>
-            <ColorDocRow colorVar="--nx-color-subsection-border">
-              Color for standard lower-level borders such as those of tile subsections
-            </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-component-background">
               The background color of most RSC components including tiles and form fields. Note that many RSC
               components simply have transparent backgrounds. For those that have an actual color however, it is

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -221,7 +221,7 @@ const CssVariablesPage = () => {
             </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-border-subsection">
               <NxWarningAlert>
-                Deprecated. Standard border styles for lower-level elements such as tile subsections.
+                Deprecated. Standard border color for lower-level elements such as tile subsections.
               </NxWarningAlert>
             </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-component-background">

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -212,7 +212,7 @@ const CssVariablesPage = () => {
               Color for standard higher-level borders
             </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-border-secondary">
-              Color for lighter borders
+              Color for secondary borders
             </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-component-background">
               The background color of most RSC components including tiles and form fields. Note that many RSC

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -182,10 +182,7 @@ const CssVariablesPage = () => {
             Standard border styles for higher-level elements.
           </PropertyDocItem>
           <PropertyDocItem propertyVar="--nx-border-secondary">
-            Lighter border styles generally used inside components, or after a default border.
-          </PropertyDocItem>
-          <PropertyDocItem propertyVar="--nx-border-subsection">
-            Standard border styles for lower-level elements such as tile subsections.
+            Secondary border styles generally used inside components, or after a default border.
           </PropertyDocItem>
           <PropertyDocItem propertyVar="--nx-box-shadow-focus">
             The standard box-shadow to apply to focused elements in addition to a border or outline.

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.4.7",
+  "version": "7.4.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -7,7 +7,6 @@
 :root {
   --nx-color-border: var(--nx-swatch-indigo-90);
   --nx-color-border-secondary: var(--nx-swatch-indigo-95);
-  --nx-color-subsection-border: var(--nx-swatch-indigo-90);
 
   --nx-color-component-background: var(--nx-swatch-white);
 
@@ -42,4 +41,7 @@
 
   --nx-color-validation-valid: var(--nx-swatch-green-30);
   --nx-color-validation-invalid: var(--nx-swatch-red-45);
+
+  // Deprecated variables
+  --nx-color-subsection-border: var(--nx-color-border);
 }

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -6,7 +6,7 @@
  */
 :root {
   --nx-color-border: var(--nx-swatch-indigo-90);
-
+  --nx-color-border-secondary: var(--nx-swatch-indigo-95);
   --nx-color-subsection-border: var(--nx-swatch-indigo-90);
 
   --nx-color-component-background: var(--nx-swatch-white);

--- a/lib/src/base-styles/_nx-footer.scss
+++ b/lib/src/base-styles/_nx-footer.scss
@@ -7,7 +7,7 @@
 .nx-footer {
   @include container-vertical;
 
-  border-top: var(--nx-border-subsection);
+  border-top: var(--nx-border-default);
   margin-top: var(--nx-spacing-6x);
   padding-top: var(--nx-spacing-6x);
 

--- a/lib/src/base-styles/_nx-grid.scss
+++ b/lib/src/base-styles/_nx-grid.scss
@@ -13,7 +13,7 @@
 .nx-grid-col {
   @include container-vertical;
 
-  border-left: var(--nx-border-subsection);
+  border-left: var(--nx-border-default);
   box-sizing: border-box;
   flex: 1 0;
   overflow-x: hidden;
@@ -39,7 +39,7 @@
 
 .nx-grid-h-keyline {
   border: none;
-  border-top: var(--nx-border-subsection);
+  border-top: var(--nx-border-default);
   margin-top: var(--nx-spacing-6x);
   margin-bottom: var(--nx-spacing-6x);
 }

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -26,7 +26,7 @@
 
     align-items: first baseline;
     border: 1px solid transparent;
-    border-top-color: var(--nx-swatch-indigo-95);
+    border-top-color: var(--nx-color-border-secondary);
     box-sizing: border-box;
     display: grid;
     grid-template-columns: auto 1fr auto;
@@ -277,7 +277,7 @@
     display: flex;
   }
 
-  border-bottom: var(--nx-border-subsection);
+  border-bottom: var(--nx-border-default);
 }
 
 .nx-list__term {

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -23,7 +23,7 @@
       border-style: none;
 
       border-bottom-style: solid;
-      border-bottom-color: var(--nx-color-subsection-border);
+      border-bottom-color: var(--nx-color-border-secondary);
       border-top-style: solid;
 
       // we want the perceived padding to be the standard spacing size. As the top border is generally invisible,

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -127,7 +127,7 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
   margin-top: var(--nx-spacing-8x);
 
   &:first-of-type {
-    border-top: var(--nx-border-subsection);
+    border-top: var(--nx-border-default);
     margin-top: var(--nx-spacing-6x);
     padding-top: var(--nx-spacing-6x);
   }

--- a/lib/src/base-styles/_nx-variables.scss
+++ b/lib/src/base-styles/_nx-variables.scss
@@ -42,6 +42,7 @@
   --nx-border-radius: 6px;
 
   --nx-border-default: 1px solid var(--nx-color-border);
+  --nx-border-secondary: 1px solid var(--nx-color-border-secondary);
   --nx-border-subsection: 1px solid var(--nx-color-subsection-border);
 
   --nx-box-shadow-focus: 0 0 3px 1px var(--nx-color-interactive-shadow-focus);

--- a/lib/src/base-styles/_nx-variables.scss
+++ b/lib/src/base-styles/_nx-variables.scss
@@ -43,10 +43,12 @@
 
   --nx-border-default: 1px solid var(--nx-color-border);
   --nx-border-secondary: 1px solid var(--nx-color-border-secondary);
-  --nx-border-subsection: 1px solid var(--nx-color-subsection-border);
 
   --nx-box-shadow-focus: 0 0 3px 1px var(--nx-color-interactive-shadow-focus);
 
   // similar to above, but for use in drop-shadow filters rather than box-shadow properties
   --nx-drop-shadow-focus: 0 0 3px var(--nx-color-interactive-shadow-focus);
+
+  // Deprecated variables
+  --nx-border-subsection: 1px solid var(--nx-color-subsection-border);
 }

--- a/lib/src/components/NxNexusPageHeader/NxNexusPageHeader.scss
+++ b/lib/src/components/NxNexusPageHeader/NxNexusPageHeader.scss
@@ -106,6 +106,6 @@
 
   .nx-page-header__extra-content-divider {
     align-self: stretch;
-    border-left: var(--nx-border-subsection);
+    border-left: var(--nx-border-default);
   }
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-614

I decided to use ` --nx-color-border-secondary` as the variable color name and `--nx-border-secondary` as the border variable name.

I replaced the instances of subsection borders that I felt were not semantically correct.