### PR TITLE
Fix deprecated subsection color variable RSC-644

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -219,7 +219,7 @@ const CssVariablesPage = () => {
             <ColorDocRow colorVar="--nx-color-border-secondary">
               Color for secondary borders
             </ColorDocRow>
-            <ColorDocRow colorVar="--nx-color-border-subsection">
+            <ColorDocRow colorVar="--nx-color-subsection-border">
               <NxWarningAlert>
                 Deprecated. Standard border color for lower-level elements such as tile subsections.
               </NxWarningAlert>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-644

Two words were transposed in the deprecated subsection border colour variable, this PR fixes that, the swatch displays correctly now.