### PR TITLE
Improve tooltip screen reading - RSC-423

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.8.2",
+  "version": "7.8.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.8.2",
+  "version": "7.8.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxForm/NxForm.tsx
+++ b/lib/src/components/NxForm/NxForm.tsx
@@ -11,7 +11,6 @@ import classnames from 'classnames';
 import NxLoadWrapper from '../NxLoadWrapper/NxLoadWrapper';
 import NxLoadError from '../NxLoadError/NxLoadError';
 import NxButton from '../NxButton/NxButton';
-import NxTooltip from '../NxTooltip/NxTooltip';
 import NxSubmitMask from '../NxSubmitMask/NxSubmitMask';
 
 import { Props, propTypes } from './types';
@@ -53,40 +52,46 @@ const NxForm = forwardRef<HTMLFormElement, Props>(
         }
       }
 
-      const renderForm = () => (
-        <form ref={ref} className={formClasses} onSubmit={onSubmit} { ...formAttrs }>
-          { getChildren() }
-          <footer className="nx-footer">
-            { submitError &&
-              <NxLoadError titleMessage={submitErrorTitleMessage || 'An error occurred saving data.'}
-                           error={submitError}
-                           retryHandler={onSubmitProp} />
-            }
+      const renderForm = () => {
+        const submitValidationError = getFirstValidationError(validationErrors) || '',
+            submitAriaLabel = submitValidationError ? `Submit disabled: ${submitValidationError}` : undefined;
 
-            <div className="nx-btn-bar">
-              { additionalFooterBtns }
-              { onCancel &&
-                <NxButton type="button" onClick={onCancel} className="nx-form__cancel-btn">
-                  Cancel
-                </NxButton>
+        return (
+          <form ref={ref} className={formClasses} onSubmit={onSubmit} { ...formAttrs }>
+            { getChildren() }
+            <footer className="nx-footer">
+              { submitError &&
+                <NxLoadError titleMessage={submitErrorTitleMessage || 'An error occurred saving data.'}
+                             error={submitError}
+                             retryHandler={onSubmitProp} />
               }
-              { !submitError &&
-                <NxTooltip title={getFirstValidationError(validationErrors) || ''}>
-                  <NxButton variant="primary" className={submitBtnClasses || 'nx-form__submit-btn'}>
+
+              <div className="nx-btn-bar">
+                { additionalFooterBtns }
+                { onCancel &&
+                  <NxButton type="button" onClick={onCancel} className="nx-form__cancel-btn">
+                    Cancel
+                  </NxButton>
+                }
+                { !submitError &&
+                  <NxButton variant="primary"
+                            className={submitBtnClasses || 'nx-form__submit-btn'}
+                            title={submitValidationError}
+                            aria-label={submitAriaLabel}>
                     {submitBtnText || 'Submit'}
                   </NxButton>
-                </NxTooltip>
-              }
-            </div>
+                }
+              </div>
 
-          </footer>
-          { submitMaskState != null &&
-            <NxSubmitMask success={submitMaskState}
-                          message={submitMaskMessage}
-                          successMessage={submitMaskSuccessMessage} />
-          }
-        </form>
-      );
+            </footer>
+            { submitMaskState != null &&
+              <NxSubmitMask success={submitMaskState}
+                            message={submitMaskMessage}
+                            successMessage={submitMaskSuccessMessage} />
+            }
+          </form>
+        );
+      };
 
       return doLoad ? (
         <NxLoadWrapper loading={loading} error={loadError} retryHandler={doLoad}>

--- a/lib/src/components/NxForm/__tests__/NxForm.test.tsx
+++ b/lib/src/components/NxForm/__tests__/NxForm.test.tsx
@@ -10,7 +10,6 @@ import { ShallowWrapper, mount, shallow } from 'enzyme';
 import { getShallowComponent } from '../../../__testutils__/enzymeUtils';
 import NxForm, { Props } from '../NxForm';
 import NxButton from '../../NxButton/NxButton';
-import NxTooltip from '../../NxTooltip/NxTooltip';
 import NxLoadError from '../../NxLoadError/NxLoadError';
 import NxSubmitMask from '../../NxSubmitMask/NxSubmitMask';
 import NxLoadWrapper from '../../NxLoadWrapper/NxLoadWrapper';
@@ -145,18 +144,27 @@ describe('NxForm', function() {
         expect(submitBtn).toHaveText('Save');
       });
 
-      it('wraps the submit button in an NxTooltip with the first validation message if present', function() {
+      it('sets a title one the submit button with the first validation message if present', function() {
         const validComponent = getShallow(),
             invalidComponent = getShallow({ validationErrors: ['Broken', 'Foobarred'] }),
-            validComponentTooltip = validComponent.find('.nx-footer .nx-btn-bar').find(NxTooltip),
-            invalidComponentTooltip = invalidComponent.find('.nx-footer .nx-btn-bar').find(NxTooltip);
-
-        expect(validComponentTooltip).toContainMatchingElement(NxButton);
-        expect(invalidComponentTooltip).toContainMatchingElement(NxButton);
+            validComponentTooltip = validComponent.find('.nx-form__submit-btn'),
+            invalidComponentTooltip = invalidComponent.find('.nx-form__submit-btn');
 
         expect(validComponentTooltip).toHaveProp('title', '');
         expect(invalidComponentTooltip).toHaveProp('title', 'Broken');
       });
+
+      it('sets an aria-label on the submit button indicating why it is disabled when there are validation errors',
+          function() {
+            const validComponent = getShallow(),
+                invalidComponent = getShallow({ validationErrors: ['Broken', 'Foobarred'] }),
+                validComponentTooltip = validComponent.find('.nx-form__submit-btn'),
+                invalidComponentTooltip = invalidComponent.find('.nx-form__submit-btn');
+
+            expect(validComponentTooltip).toHaveProp('aria-label', undefined);
+            expect(invalidComponentTooltip).toHaveProp('title', 'Submit disabled: Broken');
+          }
+      );
 
       it('does not render the submit button is there is a submitError', function() {
         const submitBtn = getShallow({ submitError: 'bad' })

--- a/lib/src/components/NxForm/__tests__/NxForm.test.tsx
+++ b/lib/src/components/NxForm/__tests__/NxForm.test.tsx
@@ -162,7 +162,7 @@ describe('NxForm', function() {
                 invalidComponentTooltip = invalidComponent.find('.nx-form__submit-btn');
 
             expect(validComponentTooltip).toHaveProp('aria-label', undefined);
-            expect(invalidComponentTooltip).toHaveProp('title', 'Submit disabled: Broken');
+            expect(invalidComponentTooltip).toHaveProp('aria-label', 'Submit disabled: Broken');
           }
       );
 

--- a/lib/src/components/NxTable/NxTableCell.tsx
+++ b/lib/src/components/NxTable/NxTableCell.tsx
@@ -84,7 +84,7 @@ const NxTableCell = function NxTableCell(props: NxTableCellProps) {
 
   const cellSortingContents = (
     <NxTooltip title={ariaLabel}>
-      <button type="button" className="nx-cell__sort-btn">
+      <button aria-label={ariaLabel} type="button" className="nx-cell__sort-btn">
         {ensureElement(children)}
         <span className="nx-cell__sort-icons fa-layers">{maskedSort}</span>
       </button>

--- a/lib/src/components/NxTable/__tests__/NxTableCell.test.tsx
+++ b/lib/src/components/NxTable/__tests__/NxTableCell.test.tsx
@@ -131,6 +131,17 @@ describe('NxTableCell', function () {
             .toHaveProp('title', 'foo descending');
       });
 
+      it('adds an aria-label to the button matching the tooltip', function() {
+        expect(getMountedHeaderComponent({ isSortable: true, children: 'foo' }).find('button'))
+            .toHaveProp('aria-label', 'foo unsorted');
+
+        expect(getMountedHeaderComponent({ isSortable: true, children: 'foo', sortDir: 'asc' }).find('button'))
+            .toHaveProp('aria-label', 'foo ascending');
+
+        expect(getMountedHeaderComponent({ isSortable: true, children: 'foo', sortDir: 'desc' }).find('button'))
+            .toHaveProp('aria-label', 'foo descending');
+      });
+
       it('wraps the cell contents in a button within the tooltip with the nx-cell__sort-btn class', function() {
         const tooltip = getMountedHeaderComponent({ isSortable: true, children: 'foo' }).children(),
             button = tooltip.find('button');

--- a/lib/src/components/NxTooltip/NxTooltip.tsx
+++ b/lib/src/components/NxTooltip/NxTooltip.tsx
@@ -7,7 +7,6 @@
 import React, { FunctionComponent, useContext } from 'react';
 import classnames from 'classnames';
 import Tooltip, { TooltipProps } from '@material-ui/core/Tooltip';
-import { textContent } from '../../util/childUtil';
 
 import { NxModalContext } from '../NxModal/NxModal';
 import { Props, propTypes, TooltipPlacement } from './types';
@@ -47,7 +46,6 @@ function fixOptional(props: Omit<Props, 'title'>): Omit<TooltipProps, 'title'> {
 const NxTooltip: FunctionComponent<Props> =
     function NxTooltip({ className, title, ...otherProps }) {
       const tooltipClassName = classnames('nx-tooltip', className);
-      const ariaLabel = textContent(title);
       const parentModal = useContext(NxModalContext);
 
       // For some reason buttons with string tooltips get removed and re-added in the DOM as the tooltip appears
@@ -56,8 +54,7 @@ const NxTooltip: FunctionComponent<Props> =
       // sure that it always is
       const tooltipTitle = (typeof title === 'string' && title.length) ? <>{title}</> : (title || '');
 
-      return <Tooltip aria-label={ariaLabel}
-                      { ...fixOptional(otherProps) }
+      return <Tooltip { ...fixOptional(otherProps) }
                       title={tooltipTitle}
                       classes={{ tooltip: tooltipClassName }}
                       PopperProps={{ container: parentModal }} />;

--- a/lib/src/components/NxTooltip/__tests__/NxTooltip.test.tsx
+++ b/lib/src/components/NxTooltip/__tests__/NxTooltip.test.tsx
@@ -24,7 +24,6 @@ describe('NxTooltip', function() {
 
     expect(component).toMatchSelector(Tooltip);
     expect(component).toHaveProp('children', minimalProps.children);
-    expect(component).toHaveProp('aria-label', minimalProps.title);
     expect(component).toHaveProp('open', false);
     expect(component).toHaveProp('onOpen', onOpen);
     expect(component).toHaveProp('onClose', onClose);
@@ -44,7 +43,6 @@ describe('NxTooltip', function() {
     expect(component).toHaveProp('onOpen', undefined);
     expect(component).toHaveProp('onClose', undefined);
     expect(component).toHaveProp('title', '');
-    expect(component).toHaveProp('aria-label', '');
   });
 
   it('wraps the title in a JSX fragment if it is a non-empty string', function() {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-423

Before this PR, tabbing to an element with a tooltip would cause the screenreader to read only the tooltip text and not the actual text content of the element.  This was due to some extra code that was added to NxTooltip to improve the way table sort headers were read.  However. we have found that it actually works better without that, reading both the text content and the tooltip - in Voiceover.  ChromeVox unfortunately doesn't read the tooltip.

Note that this is how it is with tooltips that appear on focus/hover.  Tooltips that are already open when the screenreader gets to them behave in the opposite manner - ChromeVox reads them but VoiceOver does not.

I addition to resetting that behavior, I have added more explicit aria labels to certain elements (sortable table headers and form submit buttons) to ensure that they get read in a useful manner