### PR TITLE
.nx-spinner spacing in tiles RSC-650

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -23,6 +23,10 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
   border-radius: var(--nx-border-radius);
   margin: var(--nx-spacing-2x) 0 var(--nx-spacing-4x) 0;
   padding: var(--nx-tile-spacing);
+
+  > .nx-footer, > .nx-form > .nx-footer {
+    margin-top: var(--nx-spacing-8x);
+  }
 }
 
 // Tile headers

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -30,8 +30,9 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
     margin: var(--nx-spacing-8x) var(--nx-tile-padding) 0 var(--nx-tile-padding);
   }
 
-  // When a tile contains an NxForm that is in an error state, an nx-alert gets rendered as the tile's immediate child
-  > .nx-alert {
+  // When a tile contains an NxForm that is in an error or loading state, an nx-alert (error state) or
+  // nx-loading-spinner (loading state) are rendered as the tile's immediate child
+  > .nx-alert, > .nx-loading-spinner {
     margin-left: var(--nx-tile-padding);
     margin-right: var(--nx-tile-padding);
   }

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -16,26 +16,13 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
 .nx-tile {
   @include container-vertical;
 
-  // the "padding" around the inside edge of the nx-tile, which must be implemented using padding/margin
-  // on children since nx-tile-content--accordion-container is supposed to go all the way to the edges
-  --nx-tile-padding: var(--nx-spacing-6x);
+  // the "padding" around the inside edge of the nx-tile
+  --nx-tile-spacing: var(--nx-spacing-6x);
 
   background-color: var(--nx-color-component-background);
   border-radius: var(--nx-border-radius);
   margin: var(--nx-spacing-2x) 0 var(--nx-spacing-4x) 0;
-  padding: var(--nx-tile-padding) 0;
-
-  > .nx-footer, > .nx-form > .nx-footer {
-    // use margin for sides so the top border ends in the right places
-    margin: var(--nx-spacing-8x) var(--nx-tile-padding) 0 var(--nx-tile-padding);
-  }
-
-  // When a tile contains an NxForm that is in an error or loading state, an nx-alert (error state) or
-  // nx-loading-spinner (loading state) are rendered as the tile's immediate child
-  > .nx-alert, > .nx-loading-spinner {
-    margin-left: var(--nx-tile-padding);
-    margin-right: var(--nx-tile-padding);
-  }
+  padding: var(--nx-tile-spacing);
 }
 
 // Tile headers
@@ -46,7 +33,6 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
   row-gap: var(--nx-spacing-2x);
   grid-template-columns: auto 1fr auto;
   min-height: $nx-tile-header-height;
-  padding: 0 var(--nx-tile-padding) 0 var(--nx-tile-padding);
 
   + .nx-tile-content {
     padding-top: var(--nx-spacing-4x);
@@ -107,18 +93,16 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
 
 .nx-tile-content {
   @include container-vertical;
-
-  padding: 0 var(--nx-tile-padding) 0 var(--nx-tile-padding);
 }
 
 .nx-tile-content--accordion-container {
   background-color: var(--nx-swatch-indigo-95);
-  margin-top: var(--nx-spacing-4x);
+  margin: var(--nx-spacing-4x) calc(0px - var(--nx-tile-spacing)) 0 calc(0px - var(--nx-tile-spacing));
   padding: var(--nx-spacing-4x);
 
   &:last-child {
     padding-bottom: var(--nx-spacing-4x);
-    margin-bottom: calc(0px - var(--nx-tile-padding));
+    margin-bottom: calc(0px - var(--nx-tile-spacing));
   }
 }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-650

Because an `NxForm` can be in an error or loading state and both states have the same spacing issue it made sense to use the same styles for both.