### PR TITLE
nx-tile__sub-header should be an h3 RSC-628

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.6.1",
+  "version": "7.7.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.5.5",
+  "version": "7.6.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import NxTilesExamples from './NxTilesExamples';
+import { NxCode } from '@sonatype/react-shared-components';
 
 const NxTilePage = () =>
   <>
@@ -47,19 +48,35 @@ const NxTilePage = () =>
             <td className="nx-cell">Used for tile titles, it has title and optional sub-title elements.</td>
           </tr>
           <tr className="nx-table-row">
+            <td className="nx-cell"><code className="nx-code">.nx-tile-header__headings</code></td>
+            <td className="nx-cell"><code className="nx-code">NxTile.Headings</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
+            <td className="nx-cell">
+              If there is a sub-title then the <NxCode>h2.nx-tile-header__title</NxCode> &amp;
+              {' '}<NxCode>h3.nx-tile-header__subtitle</NxCode> should both be wrapped in a containing
+              {' '}<code className="nx-code">&lt;hgroup&gt;</code> with this class. If there
+              is only an <code className="nx-code">.nx-tile-header__title</code> then this element and its class are
+              optional.
+            </td>
+          </tr>
+          <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-tile-header__title</code></td>
             <td className="nx-cell"><code className="nx-code">NxTile.HeaderTitle</code></td>
             <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
             <td className="nx-cell">
               Used for the main title inside an <code className="nx-code">.nx-tile-header</code>.
+              In the event there's a <code className="nx-code">.nx-tile-header__subtitle</code> this should be
+              used inside a <code className="nx-code">.nx-tile-header__headings</code> (see above).
             </td>
           </tr>
           <tr className="nx-table-row">
             <td className="nx-cell"><code className="nx-code">.nx-tile-header__subtitle</code></td>
             <td className="nx-cell"><code className="nx-code">NxTile.HeaderSubtitle</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
+            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header__headings</code></td>
             <td className="nx-cell">
-              Used for the subtitle inside an <code className="nx-code">.nx-tile-header</code>.
+              If there is sub-title text it should be wrapped in a containing
+              {' '}<code className="nx-code">&lt;H3&gt;</code> with this class. It should be used inside of
+              a <code className="nx-code">.nx-tile-header__headings</code> (see above).
             </td>
           </tr>
           <tr className="nx-table-row">

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -89,7 +89,7 @@ const NxTilePage = () =>
             </td>
           </tr>
           <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-content--accordion-container</code></td>
+            <td className="nx-cell"><code className="nx-code">.nx-tile-content--<br/>accordion-container</code></td>
             <td className="nx-cell"/>
             <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile-content</code></td>
             <td className="nx-cell">

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -7,132 +7,133 @@
 import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+import { NxCode, NxTable, NxP } from '@sonatype/react-shared-components';
+
 import NxTilesExamples from './NxTilesExamples';
-import { NxCode } from '@sonatype/react-shared-components';
 
 const NxTilePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">The base building block of our pages.</p>
-      <p className="nx-p">
-        There are three default classes that can be used within an <code className="nx-code">.nx-tile</code>.
-        It can also be paired with <code className="nx-code">.nx-alert</code> to create tiles with alert coloring.
-      </p>
-      <p className="nx-p">They're all showcased in the table below:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Convenience Component</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile</code></td>
-            <td className="nx-cell">Top-Level</td>
-            <td className="nx-cell">The parent tile class.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile__actions</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.HeaderActions</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">Used for actions (buttons or dropdowns) that appear in a tile header.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.Header</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">Used for tile titles, it has title and optional sub-title elements.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-header__headings</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.Headings</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell">
+      <NxP>The base building block of our pages.</NxP>
+      <NxP>
+        There are three default classes that can be used within an <NxCode>.nx-tile</NxCode>.
+        It can also be paired with <NxCode>.nx-alert</NxCode> to create tiles with alert coloring.
+      </NxP>
+      <NxP>They're all showcased in the table below:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Convenience Component</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top-Level</NxTable.Cell>
+            <NxTable.Cell>The parent tile class.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile__actions</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.HeaderActions</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>Used for actions (buttons or dropdowns) that appear in a tile header.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-header</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.Header</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>Used for tile titles, it has title and optional sub-title elements.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-header__headings</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.Headings</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile-header</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               If there is a sub-title then the <NxCode>h2.nx-tile-header__title</NxCode> &amp;
               {' '}<NxCode>h3.nx-tile-header__subtitle</NxCode> should both be wrapped in a containing
-              {' '}<code className="nx-code">&lt;hgroup&gt;</code> with this class. If there
-              is only an <code className="nx-code">.nx-tile-header__title</code> then this element and its class are
+              {' '}<NxCode>&lt;hgroup&gt;</NxCode> with this class. If there
+              is only an <NxCode>.nx-tile-header__title</NxCode> then this element and its class are
               optional.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-header__title</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.HeaderTitle</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell">
-              Used for the main title inside an <code className="nx-code">.nx-tile-header</code>.
-              In the event there's a <code className="nx-code">.nx-tile-header__subtitle</code> this should be
-              used inside a <code className="nx-code">.nx-tile-header__headings</code> (see above).
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-header__subtitle</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.HeaderSubtitle</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header__headings</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-header__title</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.HeaderTitle</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile-header</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Used for the main title inside an <NxCode>.nx-tile-header</NxCode>.
+              In the event there's a <NxCode>.nx-tile-header__subtitle</NxCode> this should be
+              used inside a <NxCode>.nx-tile-header__headings</NxCode> (see above).
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-header__subtitle</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.HeaderSubtitle</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile-header__headings</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               If there is sub-title text it should be wrapped in a containing
-              {' '}<code className="nx-code">&lt;H3&gt;</code> with this class. It should be used inside of
-              a <code className="nx-code">.nx-tile-header__headings</code> (see above).
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-content</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.Content</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
+              {' '}<NxCode>&lt;H3&gt;</NxCode> with this class. It should be used inside of
+              a <NxCode>.nx-tile-header__headings</NxCode> (see above).
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-content</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.Content</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used for the tile content. It is possible to have multiple of these in a row, particularly when one
               is an accordion container (see below).
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-content--<br/>accordion-container</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile-content</code></td>
-            <td className="nx-cell">
-              Creates a container for displaying one or more <code className="nx-code">NxAccordion</code>s
-              within an <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-footer</code></td>
-            <td className="nx-cell"><code className="nx-code">NxFooter</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-content--<br/>accordion-container</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile-content</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Creates a container for displaying one or more <NxCode>NxAccordion</NxCode>s
+              within an <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-footer</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxFooter</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used for footer contents (buttons for example). This class is not
-              called <code className="nx-code">nx-tile-footer</code> because it is used across a number of different
+              called <NxCode>nx-tile-footer</NxCode> because it is used across a number of different
               containers (e.g. forms and modals in addition to tiles) which have identical footer styles.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-alert</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
-              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-alert--info</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
-              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-alert--error</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
-              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-alert</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Class for providing alert colorings to <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-alert--info</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Class for providing alert colorings to <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-alert--error</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Class for providing alert colorings to <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <NxTilesExamples />

--- a/gallery/src/styles/NxTile/NxTileWithActionsExample.html
+++ b/gallery/src/styles/NxTile/NxTileWithActionsExample.html
@@ -8,12 +8,14 @@
 -->
 <section class="nx-tile" aria-label="Example of nx-tile with actions">
   <header class="nx-tile-header">
-    <div class="nx-tile-header__title">
-      <h2 class="nx-h2">
-        NX Tile with Actions - and this line is meant to wrap so that we can test truncation
-      </h2>
-    </div>
-    <div class="nx-tile-header__subtitle">The Subtitle</div>
+    <hgroup>
+      <div class="nx-tile-header__title">
+        <h2 class="nx-h2">
+          NX Tile with Actions - and this line is meant to wrap so that we can test truncation
+        </h2>
+      </div>
+      <h3 class="nx-tile-header__subtitle">The Subtitle</h3>
+    </hgroup>
     <div class="nx-tile__actions">
       <button class="nx-btn nx-btn--tertiary">Action 1</button>
       <button class="nx-btn nx-btn--tertiary">Action 2</button>

--- a/gallery/src/styles/NxTile/NxTileWithActionsExample.html
+++ b/gallery/src/styles/NxTile/NxTileWithActionsExample.html
@@ -8,7 +8,7 @@
 -->
 <section class="nx-tile" aria-label="Example of nx-tile with actions">
   <header class="nx-tile-header">
-    <hgroup>
+    <hgroup class="nx-page-title__headings">
       <div class="nx-tile-header__title">
         <h2 class="nx-h2">
           NX Tile with Actions - and this line is meant to wrap so that we can test truncation

--- a/gallery/src/styles/NxTile/NxTileWithSubtitleExample.html
+++ b/gallery/src/styles/NxTile/NxTileWithSubtitleExample.html
@@ -8,13 +8,15 @@
 -->
 <section class="nx-tile" aria-label="Example of nx-tile with subtitle">
   <header class="nx-tile-header">
-    <div class="nx-tile-header__title">
-      <h2 class="nx-h2">nx-tile with subtitle</h2>
-    </div>
-    <div class="nx-tile-header__subtitle">
-      The Subtitle - which wraps - sentient Chiba footage apophenia papier-mache Tokyo pre-skyscraper drone carbon
-      bomb range-rover
-    </div>
+    <hgroup>
+      <div class="nx-tile-header__title">
+        <h2 class="nx-h2">nx-tile with subtitle</h2>
+      </div>
+      <h3 class="nx-tile-header__subtitle">
+        The Subtitle - which wraps - sentient Chiba footage apophenia papier-mache Tokyo pre-skyscraper drone carbon
+        bomb range-rover
+      </h3>
+    </hgroup>
   </header>
   <div class="nx-tile-content">
     Math-savant boy soul-delay saturation point fetishism marketing tower plastic

--- a/gallery/src/styles/NxTile/NxTileWithSubtitleExample.html
+++ b/gallery/src/styles/NxTile/NxTileWithSubtitleExample.html
@@ -8,7 +8,7 @@
 -->
 <section class="nx-tile" aria-label="Example of nx-tile with subtitle">
   <header class="nx-tile-header">
-    <hgroup>
+    <hgroup class="nx-page-title__headings">
       <div class="nx-tile-header__title">
         <h2 class="nx-h2">nx-tile with subtitle</h2>
       </div>

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.5.5",
+  "version": "7.6.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.6.1",
+  "version": "7.7.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -39,6 +39,10 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
 
 // Tile headers
 
+.nx-tile-header__headings {
+  display: contents;
+}
+
 .nx-tile-header {
   align-items: center;
   display: grid;

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -80,6 +80,7 @@ $nx-tile-header-height-actions: 43px; // Height with sub-title and/or right acti
 
   color: var(--nx-color-text-dark);
   font-size: var(--nx-font-size-heading-3);
+  margin: 0;
   max-width: var(--nx-width-text-wrapping);
 }
 

--- a/lib/src/components/SimpleComponents.tsx
+++ b/lib/src/components/SimpleComponents.tsx
@@ -26,8 +26,9 @@ export const NxH4 = withClass('h4', 'nx-h4');
 
 export const NxTile = Object.assign(withClass('section', 'nx-tile'), {
   Header: withClass('header', 'nx-tile-header'),
+  Headings: withClass('hgroup', 'nx-tile-headings'),
   HeaderTitle: withClass('div', 'nx-tile-header__title'),
-  HeaderSubtitle: withClass('div', 'nx-tile-header__subtitle'),
+  HeaderSubtitle: withClass('h3', 'nx-tile-header__subtitle'),
   HeaderActions: withClass('div', 'nx-tile__actions'),
   Content: withClass('div', 'nx-tile-content'),
   Subsection: withClass('section', 'nx-tile-subsection'),

--- a/lib/src/components/SimpleComponents.tsx
+++ b/lib/src/components/SimpleComponents.tsx
@@ -26,7 +26,7 @@ export const NxH4 = withClass('h4', 'nx-h4');
 
 export const NxTile = Object.assign(withClass('section', 'nx-tile'), {
   Header: withClass('header', 'nx-tile-header'),
-  Headings: withClass('hgroup', 'nx-tile-headings'),
+  Headings: withClass('hgroup', 'nx-tile-header__headings'),
   HeaderTitle: withClass('div', 'nx-tile-header__title'),
   HeaderSubtitle: withClass('h3', 'nx-tile-header__subtitle'),
   HeaderActions: withClass('div', 'nx-tile__actions'),

--- a/lib/src/components/__tests__/SimpleComponents.test.tsx
+++ b/lib/src/components/__tests__/SimpleComponents.test.tsx
@@ -135,9 +135,15 @@ describe('NxTile.HeaderTitle', function() {
   });
 });
 
+describe('NxTile.Headings', function() {
+  it('makes a <hgroup> tag with an nx-tile-header__headings class', function() {
+    expect(shallow(<NxTile.Headings/>)).toMatchSelector('div.nx-tile-header__headings');
+  });
+});
+
 describe('NxTile.HeaderSubtitle', function() {
-  it('makes a <div> tag with an nx-tile-header__subtitle class', function() {
-    expect(shallow(<NxTile.HeaderSubtitle/>)).toMatchSelector('div.nx-tile-header__subtitle');
+  it('makes a <h3> tag with an nx-tile-header__subtitle class', function() {
+    expect(shallow(<NxTile.HeaderSubtitle/>)).toMatchSelector('h3.nx-tile-header__subtitle');
   });
 });
 

--- a/lib/src/components/__tests__/SimpleComponents.test.tsx
+++ b/lib/src/components/__tests__/SimpleComponents.test.tsx
@@ -137,7 +137,7 @@ describe('NxTile.HeaderTitle', function() {
 
 describe('NxTile.Headings', function() {
   it('makes a <hgroup> tag with an nx-tile-header__headings class', function() {
-    expect(shallow(<NxTile.Headings/>)).toMatchSelector('div.nx-tile-header__headings');
+    expect(shallow(<NxTile.Headings/>)).toMatchSelector('hgroup.nx-tile-header__headings');
   });
 });
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-628

Changes to documentation and examples. Added an `hgroup` with a class and convenience component.