### PR TITLE
iDay standardize doc tables

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.7.1",
+  "version": "7.7.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxInfoAlert, NxCode, NxTextLink, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxAccordionSimpleExample from './NxAccordionExample';

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxInfoAlert, NxCode, NxTextLink }
+import { NxTable, NxInfoAlert, NxCode, NxTextLink, NxP, NxH3 }
   from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
@@ -21,133 +21,131 @@ const NxAccordionSimpleCode = require('./NxAccordionExample?raw'),
 const NxAccordionPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         NxAccordion renders a panel with an always-visible header and a collapsible/expandable body section.
-        This is analogous to the HTML 5 <code className="nx-code">&lt;details&gt;</code> element (which is is
-        implemented on top of). There are two related components: <code className="nx-code">NxAccordion</code> itself,
-        and <code className="nx-code">NxAccordion.Header</code> which represents the header content. All other
-        children of <code className="nx-code">NxAccordion</code> aside from
-        the <code className="nx-code">Header</code> are rendered in the collapsible section.
+        This is analogous to the HTML 5 <NxCode>&lt;details&gt;</NxCode> element (which is is
+        implemented on top of). There are two related components: <NxCode>NxAccordion</NxCode> itself,
+        and <NxCode>NxAccordion.Header</NxCode> which represents the header content. All other
+        children of <NxCode>NxAccordion</NxCode> aside from
+        the <NxCode>Header</NxCode> are rendered in the collapsible section.
 
         Note that this component is stateless – its open state must be tracked externally.
-        See <code className="nx-code">NxStatefulAccordion</code> for a version which tracks its own open state.
-      </p>
+        See <NxCode>NxStatefulAccordion</NxCode> for a version which tracks its own open state.
+      </NxP>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">NxAccordion</h3>
+          <NxH3>NxAccordion</NxH3>
         </header>
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Name</NxTableCell>
-              <NxTableCell>Type</NxTableCell>
-              <NxTableCell>Required</NxTableCell>
-              <NxTableCell>Description</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell>onToggle</NxTableCell>
-              <NxTableCell>(() =&gt; void)</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Name</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Description</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>onToggle</NxTable.Cell>
+              <NxTable.Cell>(() =&gt; void)</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 A function which gets called when the accordion collapse/expand state is toggled.
 
                 <NxInfoAlert>
                   Deprecated behavior: the onToggle callback does actually get passed a value; it gets the
                   presumed new value of the open state. However with the introduction of
-                  the <a className="nx-text-link" href="#/pages/useToggle">useToggle</a> hook, that is of minimal
+                  the <NxTextLink href="#/pages/useToggle">useToggle</NxTextLink> hook, that is of minimal
                   value, so for the sake of API consistency the intent going forward is to treat this as a
                   parameterless callback.
                 </NxInfoAlert>
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>open</NxTableCell>
-              <NxTableCell>boolean</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>open</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell>
                 Whether or not the accordion should be rendered "open" with its full content visible, as
                 opposed to collapsed.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>HTML <NxCode>&lt;details&gt;</NxCode> Attributes</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;details&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/details">
                   HTML details Attributes
                 </NxTextLink>
-              </NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 NxAccordion supports any html attribute that's normally supported by the
                 {' '}<NxCode>&lt;details&gt;</NxCode> element
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </section>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">NxAccordion.Header</h3>
+          <NxH3>NxAccordion.Header</NxH3>
         </header>
-        <p className="nx-p">
-          <code className="nx-code">NxAccordion.Header</code> can receive standard
-          HTML <code className="nx-code">&lt;summary&gt;</code> attributes.
-        </p>
+        <NxP>
+          <NxCode>NxAccordion.Header</NxCode> can receive standard
+          HTML <NxCode>&lt;summary&gt;</NxCode> attributes.
+        </NxP>
       </section>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">Helper Classes</h3>
+          <NxH3>Helper Classes</NxH3>
         </header>
-        <p className="nx-p">The following CSS classes are available for use on child elements.</p>
+        <NxP>The following CSS classes are available for use on child elements.</NxP>
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Name</NxTableCell>
-              <NxTableCell>Location</NxTableCell>
-              <NxTableCell>Description</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-accordion__header-title</code></NxTableCell>
-              <NxTableCell>First child of <code className="nx-code">NxAccordion.Header</code></NxTableCell>
-              <NxTableCell>
-                It is expected that the first child of <code className="nx-code">NxAccordion.Header</code> will
-                always be an <code className="nx-code">&lt;h2&gt;</code> with
-                the <code className="nx-code">.nx-accordion__header-title</code> class containing
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Name</NxTable.Cell>
+              <NxTable.Cell>Location</NxTable.Cell>
+              <NxTable.Cell>Description</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-accordion__header-title</NxCode></NxTable.Cell>
+              <NxTable.Cell>First child of <NxCode>NxAccordion.Header</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                It is expected that the first child of <NxCode>NxAccordion.Header</NxCode> will
+                always be an <NxCode>&lt;h2&gt;</NxCode> with
+                the <NxCode>.nx-accordion__header-title</NxCode> class containing
                 the text content of the always-visible section of the accordion. Note
-                that <code className="nx-code">NxAccordion</code> is a{' '}
-                <a rel="noreferrer"
-                   className="nx-text-link"
-                   href="https://html.spec.whatwg.org/multipage/sections.html#sectioning-root">
+                that <NxCode>NxAccordion</NxCode> is a{' '}
+                <NxTextLink external href="https://html.spec.whatwg.org/multipage/sections.html#sectioning-root">
                   sectioning root
-                </a>
+                </NxTextLink>
                 , so it does not matter whether this header is a lower-rank heading than that of its surrounding
                 section.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-btn-bar</code></NxTableCell>
-              <NxTableCell>Last child of <code className="nx-code">NxAccordion.Header</code></NxTableCell>
-              <NxTableCell>
-                <code className="nx-code">NxAccordion.Header</code> supports the inclusion of buttons on
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-btn-bar</NxCode></NxTable.Cell>
+              <NxTable.Cell>Last child of <NxCode>NxAccordion.Header</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                <NxCode>NxAccordion.Header</NxCode> supports the inclusion of buttons on
                 its right-hand side. This is accomplished by adding
-                an <code className="nx-code">.nx-btn-bar</code> after
-                the <code className="nx-code">.nx-accordion__header-title</code>.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-h3</code></NxTableCell>
-              <NxTableCell>Subheader within accordion body</NxTableCell>
-              <NxTableCell>
+                an <NxCode>.nx-btn-bar</NxCode> after
+                the <NxCode>.nx-accordion__header-title</NxCode>.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-h3</NxCode></NxTable.Cell>
+              <NxTable.Cell>Subheader within accordion body</NxTable.Cell>
+              <NxTable.Cell>
                 The contents of the accordion body may include subheaders which should
-                be <code className="nx-code">&lt;h3&gt;</code> elements with
-                the <code className="nx-code">.nx-h3</code> class.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+                be <NxCode>&lt;h3&gt;</NxCode> elements with
+                the <NxCode>.nx-h3</NxCode> class.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </section>
     </GalleryDescriptionTile>
@@ -156,7 +154,7 @@ const NxAccordionPage = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxAccordionSimpleExample}
                         codeExamples={NxAccordionSimpleCode}>
-      A simple example of an <code className="nx-code">NxAccordion</code>.
+      A simple example of an <NxCode>NxAccordion</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Example with optional elements"
@@ -164,7 +162,7 @@ const NxAccordionPage = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxAccordionComplexExample}
                         codeExamples={NxAccordionComplexCode}>
-      A more complex <code className="nx-code">NxAccordion</code> including header buttons and a subheader.
+      A more complex <NxCode>NxAccordion</NxCode> including header buttons and a subheader.
       This example also demonstrates that clicks on the header and buttons are handled correctly. Clicking a header
       button does not cause the accordion to toggle, but clicking anywhere else on the header does, even including
       places that have their own click handlers (e.g. the accordion title in this example). This example also
@@ -178,7 +176,7 @@ const NxAccordionPage = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxAccordionTertiaryButtonExample}
                         codeExamples={NxAccordionTertiaryButtonCode}>
-      An <code className="nx-code">NxAccordion</code> which contains a tertiary button in the header. Note that the
+      An <NxCode>NxAccordion</NxCode> which contains a tertiary button in the header. Note that the
       height of this button causes the height of the entire header to grow slightly.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -5,10 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxInfoAlert, NxCode, NxTextLink, NxP, NxH3 }
-  from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxInfoAlert, NxCode, NxTextLink, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
 
 import NxAccordionSimpleExample from './NxAccordionExample';
 import NxAccordionComplexExample from './NxAccordionComplexExample';
@@ -32,10 +31,10 @@ const NxAccordionPage = () =>
         Note that this component is stateless – its open state must be tracked externally.
         See <NxCode>NxStatefulAccordion</NxCode> for a version which tracks its own open state.
       </NxP>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>NxAccordion</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxTable>
           <NxTable.Head>
             <NxTable.Row>
@@ -86,20 +85,20 @@ const NxAccordionPage = () =>
             </NxTable.Row>
           </NxTable.Body>
         </NxTable>
-      </section>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      </NxTile.Subsection>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>NxAccordion.Header</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxP>
           <NxCode>NxAccordion.Header</NxCode> can receive standard
           HTML <NxCode>&lt;summary&gt;</NxCode> attributes.
         </NxP>
-      </section>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      </NxTile.Subsection>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>Helper Classes</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxP>The following CSS classes are available for use on child elements.</NxP>
         <NxTable>
           <NxTable.Head>
@@ -147,7 +146,7 @@ const NxAccordionPage = () =>
             </NxTable.Row>
           </NxTable.Body>
         </NxTable>
-      </section>
+      </NxTile.Subsection>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxInfoAlert, NxCode, NxTextLink, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxAccordionSimpleExample from './NxAccordionExample';
 import NxAccordionComplexExample from './NxAccordionComplexExample';

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 
 import NxAlertExample from './NxAlertExample';

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxCode, NxP, NxH3 } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
 
 import NxAlertExample from './NxAlertExample';
 import NxErrorAlertExample from './NxErrorAlertExample';
@@ -87,10 +88,10 @@ const NxAlertPage = () =>
         Accepts any prop that is valid on a div as well as the <NxCode>onClose</NxCode> prop
         described above.
       </NxP>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>Accessibility Considerations</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxP>
           Different types of alerts use
           different <a target="_blank" rel="noreferrer" href="https://www.w3.org/WAI/PF/aria/roles">ARIA roles</a>.{' '}
@@ -103,7 +104,7 @@ const NxAlertPage = () =>
           the <NxCode>status</NxCode> or <NxCode>alert</NxCode> role.
           The roles which are provided by default may be overridden by the caller.
         </NxP>
-      </section>
+      </NxTile.Subsection>
     </GalleryTile>
 
     <GalleryExampleTile title="Success Alert Example"

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -5,8 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxCode, NxP }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxH3 } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 
 import NxAlertExample from './NxAlertExample';
@@ -28,38 +27,38 @@ const NxAlertPage = () =>
       <NxP>Handy for DIY alert variations</NxP>
       <NxP>Accepts any prop that is valid on a div as well as the following:</NxP>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>icon</NxTableCell>
-            <NxTableCell>FontAwesome's Icons</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>icon</NxTable.Cell>
+            <NxTable.Cell>FontAwesome's Icons</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               A FontAwesome icon to use in the alert message
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>iconLabel</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>iconLabel</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Brief descriptive text to apply to the icon using
               the <NxCode>aria-label</NxCode> attribute. Optional for backwards compatibility, but
               strongly recommended.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>onClose</NxTableCell>
-            <NxTableCell>Function</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onClose</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A handler that dismisses the alert when called. If this prop is present, a close button will be rendered
               at the right-hand side of the alert. When that button is clicked, this callback will be fired. Note that
               while this callback (and button) are optional, our UX patterns call for almost all alerts to be
@@ -68,9 +67,9 @@ const NxAlertPage = () =>
               A "Retry" button would be an example of such an alternative mechanism. Conversely, in the
               case where such an alternative mechanism is present, the <NxCode>onClose</NxCode>
               callback <em>should not</em> be provided.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 
@@ -90,7 +89,7 @@ const NxAlertPage = () =>
       </NxP>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">Accessibility Considerations</h3>
+          <NxH3>Accessibility Considerations</NxH3>
         </header>
         <NxP>
           Different types of alerts use

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -5,7 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
+import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxCode, NxP }
+  from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 
 import NxAlertExample from './NxAlertExample';
@@ -23,54 +24,54 @@ const nxErrorAlertExampleCode = require('./NxErrorAlertExample?raw'),
 const NxAlertPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Generic alert.</p>
-      <p className="nx-p">Handy for DIY alert variations</p>
-      <p className="nx-p">Accepts any prop that is valid on a div as well as the following:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">icon</td>
-            <td className="nx-cell">FontAwesome's Icons</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+      <NxP>Generic alert.</NxP>
+      <NxP>Handy for DIY alert variations</NxP>
+      <NxP>Accepts any prop that is valid on a div as well as the following:</NxP>
+      <NxTable>
+        <NxTableHead>
+          <NxTableRow>
+            <NxTableCell>Prop</NxTableCell>
+            <NxTableCell>Type</NxTableCell>
+            <NxTableCell>Required</NxTableCell>
+            <NxTableCell>Details</NxTableCell>
+          </NxTableRow>
+        </NxTableHead>
+        <NxTableBody>
+          <NxTableRow>
+            <NxTableCell>icon</NxTableCell>
+            <NxTableCell>FontAwesome's Icons</NxTableCell>
+            <NxTableCell>Yes</NxTableCell>
+            <NxTableCell>
               A FontAwesome icon to use in the alert message
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">iconLabel</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTableCell>
+          </NxTableRow>
+          <NxTableRow>
+            <NxTableCell>iconLabel</NxTableCell>
+            <NxTableCell>string</NxTableCell>
+            <NxTableCell>No</NxTableCell>
+            <NxTableCell>
               Brief descriptive text to apply to the icon using
-              the <code className="nx-code">aria-label</code> attribute. Optional for backwards compatibility, but
+              the <NxCode>aria-label</NxCode> attribute. Optional for backwards compatibility, but
               strongly recommended.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onClose</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTableCell>
+          </NxTableRow>
+          <NxTableRow>
+            <NxTableCell>onClose</NxTableCell>
+            <NxTableCell>Function</NxTableCell>
+            <NxTableCell>No</NxTableCell>
+            <NxTableCell>
               A handler that dismisses the alert when called. If this prop is present, a close button will be rendered
               at the right-hand side of the alert. When that button is clicked, this callback will be fired. Note that
               while this callback (and button) are optional, our UX patterns call for almost all alerts to be
-              dismissable in some way. Therefore, an <code className="nx-code">onClose</code> callback should
+              dismissable in some way. Therefore, an <NxCode>onClose</NxCode> callback should
               be provided, unless some other mechanism for closing the alert is provided within the alert children.
               A "Retry" button would be an example of such an alternative mechanism. Conversely, in the
-              case where such an alternative mechanism is present, the <code className="nx-code">onClose</code>
+              case where such an alternative mechanism is present, the <NxCode>onClose</NxCode>
               callback <em>should not</em> be provided.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTableCell>
+          </NxTableRow>
+        </NxTableBody>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Alert Example"
@@ -81,28 +82,28 @@ const NxAlertPage = () =>
     </GalleryExampleTile>
 
     <GalleryTile title="NxErrorAlert, etc.">
-      <p className="nx-p">Standard sonatype alerts.</p>
-      <p className="nx-p">They come in four variations: Error, Info, Warning, and Success.</p>
-      <p className="nx-p">
-        Accepts any prop that is valid on a div as well as the <code className="nx-code">onClose</code> prop
+      <NxP>Standard sonatype alerts.</NxP>
+      <NxP>They come in four variations: Error, Info, Warning, and Success.</NxP>
+      <NxP>
+        Accepts any prop that is valid on a div as well as the <NxCode>onClose</NxCode> prop
         described above.
-      </p>
+      </NxP>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
           <h3 className="nx-h3">Accessibility Considerations</h3>
         </header>
-        <p className="nx-p">
+        <NxP>
           Different types of alerts use
           different <a target="_blank" rel="noreferrer" href="https://www.w3.org/WAI/PF/aria/roles">ARIA roles</a>.{' '}
-          <code className="nx-code">NxErrorAlert</code> uses <code className="nx-code">alert</code>.{' '}
-          <code className="nx-code">NxSuccessAlert</code> uses <code className="nx-code">status</code>.{' '}
-          <code className="nx-code">NxInfoAlert</code> uses no special role by default, though
-          the <code className="nx-code">status</code> role may be appropriate in some use cases.{' '}
-          Finally, <code className="nx-code">NxWarningAlert</code> also has no default role, but
+          <NxCode>NxErrorAlert</NxCode> uses <NxCode>alert</NxCode>.{' '}
+          <NxCode>NxSuccessAlert</NxCode> uses <NxCode>status</NxCode>.{' '}
+          <NxCode>NxInfoAlert</NxCode> uses no special role by default, though
+          the <NxCode>status</NxCode> role may be appropriate in some use cases.{' '}
+          Finally, <NxCode>NxWarningAlert</NxCode> also has no default role, but
           when used in dynamic circumstances, should typically be given either
-          the <code className="nx-code">status</code> or <code className="nx-code">alert</code> role.
+          the <NxCode>status</NxCode> or <NxCode>alert</NxCode> role.
           The roles which are provided by default may be overridden by the caller.
-        </p>
+        </NxP>
       </section>
     </GalleryTile>
 

--- a/gallery/src/components/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/components/NxAlert/NxAlertPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 
 import NxAlertExample from './NxAlertExample';
 import NxErrorAlertExample from './NxErrorAlertExample';

--- a/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
+++ b/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
@@ -5,8 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxCode, NxP }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxBackButtonSimpleExample from './NxBackButtonSimpleExample';
@@ -23,34 +22,34 @@ const NxBackButtonPage = () =>
       <NxP>A standard UI element for navigating back to a previous page</NxP>
       <NxP>Props:</NxP>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>targetPageTitle</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>The name of the page to navigate to</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>text</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>Optional custom text to override the back button's default text logic</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>href</NxTableCell>
-            <NxTableCell>URL</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>The URL to navigate to when the back button is clicked</NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>targetPageTitle</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>The name of the page to navigate to</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>text</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>Optional custom text to override the back button's default text logic</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>href</NxTable.Cell>
+            <NxTable.Cell>URL</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>The URL to navigate to when the back button is clicked</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 

--- a/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
+++ b/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxBackButtonSimpleExample from './NxBackButtonSimpleExample';

--- a/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
+++ b/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
@@ -5,7 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
+import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxCode, NxP }
+  from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxBackButtonSimpleExample from './NxBackButtonSimpleExample';
@@ -19,59 +20,59 @@ const textSourceCode = require('./NxBackButtonTextExample?raw');
 const NxBackButtonPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">A standard UI element for navigating back to a previous page</p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">targetPageTitle</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">The name of the page to navigate to</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">text</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">Optional custom text to override the back button's default text logic</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">href</td>
-            <td className="nx-cell">URL</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">The URL to navigate to when the back button is clicked</td>
-          </tr>
-        </tbody>
-      </table>
+      <NxP>A standard UI element for navigating back to a previous page</NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTableHead>
+          <NxTableRow>
+            <NxTableCell>Prop</NxTableCell>
+            <NxTableCell>Type</NxTableCell>
+            <NxTableCell>Required</NxTableCell>
+            <NxTableCell>Details</NxTableCell>
+          </NxTableRow>
+        </NxTableHead>
+        <NxTableBody>
+          <NxTableRow>
+            <NxTableCell>targetPageTitle</NxTableCell>
+            <NxTableCell>string</NxTableCell>
+            <NxTableCell>No</NxTableCell>
+            <NxTableCell>The name of the page to navigate to</NxTableCell>
+          </NxTableRow>
+          <NxTableRow>
+            <NxTableCell>text</NxTableCell>
+            <NxTableCell>string</NxTableCell>
+            <NxTableCell>No</NxTableCell>
+            <NxTableCell>Optional custom text to override the back button's default text logic</NxTableCell>
+          </NxTableRow>
+          <NxTableRow>
+            <NxTableCell>href</NxTableCell>
+            <NxTableCell>URL</NxTableCell>
+            <NxTableCell>Yes</NxTableCell>
+            <NxTableCell>The URL to navigate to when the back button is clicked</NxTableCell>
+          </NxTableRow>
+        </NxTableBody>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Back button with no title or text specified"
                         id="nx-back-button-simple-example"
                         liveExample={NxBackButtonSimpleExample}
                         codeExamples={simpleSourceCode}>
-      Basic <code className="nx-code">NxBackButton</code> example.
+      Basic <NxCode>NxBackButton</NxCode> example.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Back button with targetPageTitle specified"
                         id="nx-back-button-title-example"
                         liveExample={NxBackButtonTitleExample}
                         codeExamples={titleSourceCode}>
-      A demonstration of using the <code className="nx-code">targetPageTitle</code> to generate the text content.
+      A demonstration of using the <NxCode>targetPageTitle</NxCode> to generate the text content.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Back button with custom text specified"
                         id="nx-back-button-text-example"
                         liveExample={NxBackButtonTextExample}
                         codeExamples={textSourceCode}>
-      A demonstration of using completely custom text for the <code className="nx-code">NxBackButton</code>.
+      A demonstration of using completely custom text for the <NxCode>NxBackButton</NxCode>.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
+++ b/gallery/src/components/NxBackButton/NxBackButtonPage.tsx
@@ -5,6 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -7,7 +7,8 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxCode, NxP, NxTextLink }
+  from '@sonatype/react-shared-components';
 
 import NxBinaryDonutChartMinimalExample from './NxBinaryDonutChartMinimalExample';
 import NxBinaryDonutChartNoHoleExample from './NxBinaryDonutChartNoHoleExample';
@@ -20,71 +21,71 @@ const nxBinaryDonutChartLargeHoleExample = require('./NxBinaryDonutChartLargeHol
 const NxBinaryDonutChartPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxBinaryDonutChart</code> represents a binary donut chart.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">percent</td>
-            <td className="nx-cell">number</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+      <NxP>
+        <NxCode>NxBinaryDonutChart</NxCode> represents a binary donut chart.
+      </NxP>
+      <NxTable>
+        <NxTableHead>
+          <NxTableRow>
+            <NxTableCell>Prop</NxTableCell>
+            <NxTableCell>Type</NxTableCell>
+            <NxTableCell>Required</NxTableCell>
+            <NxTableCell>Details</NxTableCell>
+          </NxTableRow>
+        </NxTableHead>
+        <NxTableBody>
+          <NxTableRow>
+            <NxTableCell>percent</NxTableCell>
+            <NxTableCell>number</NxTableCell>
+            <NxTableCell>Yes</NxTableCell>
+            <NxTableCell>
               Percentage which this donut represents. E.g. when 0 the donut is empty, and as it increases towards 100
               the amount of the donut which is filled in increases.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">innerRadiusPercent</td>
-            <td className="nx-cell">number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTableCell>
+          </NxTableRow>
+          <NxTableRow>
+            <NxTableCell>innerRadiusPercent</NxTableCell>
+            <NxTableCell>number</NxTableCell>
+            <NxTableCell>No</NxTableCell>
+            <NxTableCell>
               The size of the hole in the donut, as a percentage of the donut's overall size.  The default value is 50.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">aria-label</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTableCell>
+          </NxTableRow>
+          <NxTableRow>
+            <NxTableCell>aria-label</NxTableCell>
+            <NxTableCell>string</NxTableCell>
+            <NxTableCell>No</NxTableCell>
+            <NxTableCell>
               If the chart is not accompanied by visible text content that contains the same information that the chart
-              conveys, then the chart should have an <code className="nx-code">aria-label</code> attribute giving it
+              conveys, then the chart should have an <NxCode>aria-label</NxCode> attribute giving it
               an accessible name which adequately describes its information for non-visual users. If the chart is
               accompanied by a text description however, such a label would be redundant and the chart is considered
               a presentational element.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">SVG <code className="nx-code">&lt;svg&gt;</code> Attributes</td>
-            <td className="nx-cell">
+            </NxTableCell>
+          </NxTableRow>
+          <NxTableRow>
+            <NxTableCell>SVG <NxCode>&lt;svg&gt;</NxCode> Attributes</NxTableCell>
+            <NxTableCell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/SVG/Element/svg">
                 SVG Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTableCell>
+            <NxTableCell>No</NxTableCell>
+            <NxTableCell>
               NxBinaryDonutChart supports any SVG attribute that's normally supported
-              by <code className="nx-code">&lt;svg&gt;</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              by <NxCode>&lt;svg&gt;</NxCode>.
+            </NxTableCell>
+          </NxTableRow>
+        </NxTableBody>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Minimal Examples"
                         id="nx-binary-donut-chart-minimal-examples"
                         codeExamples={nxBinaryDonutChartMinimalExampleCode}
                         liveExample={NxBinaryDonutChartMinimalExample}>
-      Minimal examples of <code className="nx-code">NxBinaryDonutChart</code>s with different values.
-      Some of these charts demonstrate the usage of <code className="nx-code">aria-label</code> to describe the
+      Minimal examples of <NxCode>NxBinaryDonutChart</NxCode>s with different values.
+      Some of these charts demonstrate the usage of <NxCode>aria-label</NxCode> to describe the
       chart contents.
     </GalleryExampleTile>
 
@@ -92,14 +93,14 @@ const NxBinaryDonutChartPage = () =>
                         id="nx-binary-donut-chart-no-hole-example"
                         codeExamples={nxBinaryDonutChartNoHoleExample}
                         liveExample={NxBinaryDonutChartNoHoleExample}>
-      An example of a <code className="nx-code">NxBinaryDonutChart</code> without a hole i.e. a pie chart.
+      An example of a <NxCode>NxBinaryDonutChart</NxCode> without a hole i.e. a pie chart.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Example with a Large Hole"
                         id="nx-binary-donut-chart-large-hole-example"
                         codeExamples={nxBinaryDonutChartLargeHoleExample}
                         liveExample={NxBinaryDonutChartLargeHoleExample}>
-      An example of a <code className="nx-code">NxBinaryDonutChart</code> with a large hole.
+      An example of a <NxCode>NxBinaryDonutChart</NxCode> with a large hole.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -7,8 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxCode, NxP, NxTextLink }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxBinaryDonutChartMinimalExample from './NxBinaryDonutChartMinimalExample';
 import NxBinaryDonutChartNoHoleExample from './NxBinaryDonutChartNoHoleExample';
@@ -25,58 +24,58 @@ const NxBinaryDonutChartPage = () =>
         <NxCode>NxBinaryDonutChart</NxCode> represents a binary donut chart.
       </NxP>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>percent</NxTableCell>
-            <NxTableCell>number</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>percent</NxTable.Cell>
+            <NxTable.Cell>number</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Percentage which this donut represents. E.g. when 0 the donut is empty, and as it increases towards 100
               the amount of the donut which is filled in increases.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>innerRadiusPercent</NxTableCell>
-            <NxTableCell>number</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>innerRadiusPercent</NxTable.Cell>
+            <NxTable.Cell>number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               The size of the hole in the donut, as a percentage of the donut's overall size.  The default value is 50.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>aria-label</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>aria-label</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If the chart is not accompanied by visible text content that contains the same information that the chart
               conveys, then the chart should have an <NxCode>aria-label</NxCode> attribute giving it
               an accessible name which adequately describes its information for non-visual users. If the chart is
               accompanied by a text description however, such a label would be redundant and the chart is considered
               a presentational element.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>SVG <NxCode>&lt;svg&gt;</NxCode> Attributes</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>SVG <NxCode>&lt;svg&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/SVG/Element/svg">
                 SVG Attributes
               </NxTextLink>
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               NxBinaryDonutChart supports any SVG attribute that's normally supported
               by <NxCode>&lt;svg&gt;</NxCode>.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxBinaryDonutChartMinimalExample from './NxBinaryDonutChartMinimalExample';

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxBinaryDonutChartMinimalExample from './NxBinaryDonutChartMinimalExample';
 import NxBinaryDonutChartNoHoleExample from './NxBinaryDonutChartNoHoleExample';

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxTextLink, NxP } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxButtonDefaultExample from './NxButtonDefaultExample';

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -28,11 +28,11 @@ export default function NxButtonPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          <code className="nx-code">NxButton</code> is a react wrapper around
-          HTML <code className="nx-code">&lt;button&gt;</code> elements using
-          the <code className="nx-code">.nx-btn</code> CSS class.
-        </p>
+        <NxP>
+          <NxCode>NxButton</NxCode> is a react wrapper around
+          HTML <NxCode>&lt;button&gt;</NxCode> elements using
+          the <NxCode>.nx-btn</NxCode> CSS class.
+        </NxP>
         <NxTable>
           <NxTableHead>
             <NxTableRow>
@@ -90,7 +90,7 @@ export default function NxButtonPage() {
                           id="nx-button-default-example"
                           liveExample={NxButtonDefaultExample}
                           codeExamples={NxButtonDefaultCode}>
-        An example of an <code className="nx-code">NxButton</code> using the default styling, also known as the
+        An example of an <NxCode>NxButton</NxCode> using the default styling, also known as the
         "secondary" styling, along with some other inline content and some disabled buttons. Disabling by class will
         add aria-disabled=true to the button.
       </GalleryExampleTile>
@@ -113,7 +113,7 @@ export default function NxButtonPage() {
                           id="nx-button-error-example"
                           liveExample={NxButtonErrorExample}
                           codeExamples={nxButtonErrorCode}>
-        An example using the "error" button styles. Commonly seen in <code className="nx-code">NxErrorAlert</code>s.
+        An example using the "error" button styles. Commonly seen in <NxCode>NxErrorAlert</NxCode>s.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Using icons in buttons"

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -14,8 +14,7 @@ import NxButtonTertiaryExample from './NxButtonTertiaryExample';
 import NxButtonErrorExample from './NxButtonErrorExample';
 import NxButtonIconExample from './NxButtonIconExample';
 import NxButtonIconOnlyExample from './NxButtonIconOnlyExample';
-import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody, NxCode, NxTextLink, NxP }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxTextLink, NxP } from '@sonatype/react-shared-components';
 
 const NxButtonDefaultCode = require('./NxButtonDefaultExample?raw'),
     nxButtonPrimaryCode = require('./NxButtonPrimaryExample?raw'),
@@ -34,50 +33,50 @@ export default function NxButtonPage() {
           the <NxCode>.nx-btn</NxCode> CSS class.
         </NxP>
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Prop</NxTableCell>
-              <NxTableCell>Type</NxTableCell>
-              <NxTableCell>Required</NxTableCell>
-              <NxTableCell>Default</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell>variant</NxTableCell>
-              <NxTableCell>'primary' | 'secondary' | 'tertiary' | 'icon-only' | 'error'</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>secondary</NxTableCell>
-              <NxTableCell>The variant of button. See examples of each variant below.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>title</NxTableCell>
-              <NxTableCell>string</NxTableCell>
-              <NxTableCell>Required on icon-only buttons</NxTableCell>
-              <NxTableCell>Empty</NxTableCell>
-              <NxTableCell>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Default</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>variant</NxTable.Cell>
+              <NxTable.Cell>'primary' | 'secondary' | 'tertiary' | 'icon-only' | 'error'</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>secondary</NxTable.Cell>
+              <NxTable.Cell>The variant of button. See examples of each variant below.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>title</NxTable.Cell>
+              <NxTable.Cell>string</NxTable.Cell>
+              <NxTable.Cell>Required on icon-only buttons</NxTable.Cell>
+              <NxTable.Cell>Empty</NxTable.Cell>
+              <NxTable.Cell>
                 A string to render as a tooltip and accessibility label for the button. This is generally not necessary
                 for buttons that include text content, but icon-only buttons should use this to make the button's
                 meaning clear in all contexts. Omitting this prop when using an icon-only button is deprecated and will
                 become unsupported in a future release.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>HTML <NxCode>&lt;button&gt;</NxCode> Attributes</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;button&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/button">
                   HTML button Attributes
                 </NxTextLink>
-              </NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 <NxCode>NxButton</NxCode> supports any html attribute that's normally supported by the
                 {' '}<NxCode>&lt;button&gt;</NxCode> element.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
         <NxP>
           <NxCode>NxButton</NxCode>s are often used within an <NxCode>NxButtonBar</NxCode> wrapper. See the

--- a/gallery/src/components/NxButton/NxButtonPage.tsx
+++ b/gallery/src/components/NxButton/NxButtonPage.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 
+import { NxTable, NxCode, NxTextLink, NxP } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxButtonDefaultExample from './NxButtonDefaultExample';
@@ -14,7 +15,6 @@ import NxButtonTertiaryExample from './NxButtonTertiaryExample';
 import NxButtonErrorExample from './NxButtonErrorExample';
 import NxButtonIconExample from './NxButtonIconExample';
 import NxButtonIconOnlyExample from './NxButtonIconOnlyExample';
-import { NxTable, NxCode, NxTextLink, NxP } from '@sonatype/react-shared-components';
 
 const NxButtonDefaultCode = require('./NxButtonDefaultExample?raw'),
     nxButtonPrimaryCode = require('./NxButtonPrimaryExample?raw'),

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxCheckboxExample from './NxCheckboxExample';
 import NxCheckboxNowrapExample from './NxCheckboxNowrapExample';
@@ -18,84 +18,84 @@ const nowrapExampleCode = require('./NxCheckboxNowrapExample?raw');
 const NxCheckboxPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Custom checkbox input.</p>
-      <p className="nx-p">Child VDOM will be used as a label following the checkbox button itself.</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">checkboxId</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">An id to identify the checkbox</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isChecked</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">Whether the checkbox should be rendered as checked or unchecked</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function (() =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A callback for when the checkbox is toggled</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      <NxP>Custom checkbox input.</NxP>
+      <NxP>Child VDOM will be used as a label following the checkbox button itself.</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>checkboxId</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>An id to identify the checkbox</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isChecked</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>Whether the checkbox should be rendered as checked or unchecked</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function (() =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A callback for when the checkbox is toggled</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the checkbox should be rendered as disabled or not.  When disabled, the onChange callback will
               not fire.  Defaults to false
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">overflowTooltip</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>overflowTooltip</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the checkbox label content should be wrapped in
-              an <code className="nx-code">NxOverflowTooltip</code>. Defaults to true. Set this to false when
-              the <code className="nx-code">NxCheckbox</code> is being wrapped in a tooltip externally, to prevent
+              an <NxCode>NxOverflowTooltip</NxCode>. Defaults to true. Set this to false when
+              the <NxCode>NxCheckbox</NxCode> is being wrapped in a tooltip externally, to prevent
               multiple overlapping tooltips from appearing.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">Virtual DOM</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>Virtual DOM</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               VDOM rendered as a label. Should be
               {' '}
               <NxTextLink external
                           href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content">
                 phrasing content
               </NxTextLink>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;label&gt;</code> Attributes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;label&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/label">
                 HTML label Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               NxCheckbox supports any html attribute that's normally supported by the
-              <code className="nx-code">label</code> element.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              <NxCode>label</NxCode> element.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxCheckboxExample from './NxCheckboxExample';

--- a/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
+++ b/gallery/src/components/NxCheckbox/NxCheckboxPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxCheckboxExample from './NxCheckboxExample';
 import NxCheckboxNowrapExample from './NxCheckboxNowrapExample';

--- a/gallery/src/components/NxCloseButton/NxCloseButtonPage.tsx
+++ b/gallery/src/components/NxCloseButton/NxCloseButtonPage.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import { NxCode, NxP } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import NxCloseButtonExample from './NxCloseButtonExample';
 
 const nxCloseButtonExampleCode = require('./NxCloseButtonExample?raw');

--- a/gallery/src/components/NxCloseButton/NxCloseButtonPage.tsx
+++ b/gallery/src/components/NxCloseButton/NxCloseButtonPage.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 
+import { NxCode, NxP } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import NxCloseButtonExample from './NxCloseButtonExample';
 
@@ -14,10 +15,10 @@ const nxCloseButtonExampleCode = require('./NxCloseButtonExample?raw');
 const NxCloseButtonPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxCloseButton</code> represents a standard "×" close button for use on modals,
-        alerts, etc. It supports all attributes supported by HTML <code className="nx-code">&lt;button&gt;</code>s.
-      </p>
+      <NxP>
+        <NxCode>NxCloseButton</NxCode> represents a standard "×" close button for use on modals,
+        alerts, etc. It supports all attributes supported by HTML <NxCode>&lt;button&gt;</NxCode>s.
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/components/NxCloseButton/NxCloseButtonPage.tsx
+++ b/gallery/src/components/NxCloseButton/NxCloseButtonPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxCloseButtonExample from './NxCloseButtonExample';

--- a/gallery/src/components/NxCodeSnippet/NxCodeSnippetPage.tsx
+++ b/gallery/src/components/NxCodeSnippet/NxCodeSnippetPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxCodeSnippetExample from './NxCodeSnippetExample';

--- a/gallery/src/components/NxCodeSnippet/NxCodeSnippetPage.tsx
+++ b/gallery/src/components/NxCodeSnippet/NxCodeSnippetPage.tsx
@@ -11,8 +11,7 @@ import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-componen
 import NxCodeSnippetExample from './NxCodeSnippetExample';
 import NxCodeSnippetComplexExample from './NxCodeSnippetComplexExample';
 
-import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody, NxTextLink }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 const nxCodeSnippetCode = require('./NxCodeSnippetExample?raw'),
     nxCodeSnippetComplexCode = require('./NxCodeSnippetComplexExample?raw');
@@ -21,88 +20,88 @@ export default function NxCodeSnippetPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          <code className="nx-code">NxCodeSnippet</code> creates a read-only text area containing the specified text
+        <NxP>
+          <NxCode>NxCodeSnippet</NxCode> creates a read-only text area containing the specified text
           content, along with a button enabling the user to easily copy that text content to the clipboard.
-        </p>
+        </NxP>
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Prop</NxTableCell>
-              <NxTableCell>Type</NxTableCell>
-              <NxTableCell>Required</NxTableCell>
-              <NxTableCell>Default</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell>label</NxTableCell>
-              <NxTableCell>string | ReactElement</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>The label for the text area's form group</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>sublabel</NxTableCell>
-              <NxTableCell>string | ReactElement</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>empty</NxTableCell>
-              <NxTableCell>JSX content to render as the sublabel for the text area's form group</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>content</NxTableCell>
-              <NxTableCell>string</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Default</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>label</NxTable.Cell>
+              <NxTable.Cell>string | ReactElement</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>The label for the text area's form group</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>sublabel</NxTable.Cell>
+              <NxTable.Cell>string | ReactElement</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>empty</NxTable.Cell>
+              <NxTable.Cell>JSX content to render as the sublabel for the text area's form group</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>content</NxTable.Cell>
+              <NxTable.Cell>string</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 The text content to display within the text area and for which to enable copying to the clipboard
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>onCopyUsingBtn</NxTableCell>
-              <NxTableCell>Function () =&gt; void</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onCopyUsingBtn</NxTable.Cell>
+              <NxTable.Cell>Function () =&gt; void</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 A callback which fires after the copy initiated by the Copy to Clipboard button completes.
                 Note that copies initiated in other ways (e.g. Ctrl-C) do not trigger this callback.
                 See also the{' '}
                 <NxTextLink external href="https://developer.mozilla.org/en-US/docs/Web/API/Element/copy_event">
                   native copy event
                 </NxTextLink>
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>inputProps</NxTableCell>
-              <NxTableCell>
-                Props for <code className="nx-code">NxTextInput</code> except
-                for <code className="nx-code">type</code>,{' '}
-                <code className="nx-code">value</code>,{' '}
-                <code className="nx-code">isPristine</code>,
-                and <code className="nx-code">readOnly</code>
-              </NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
-                Props to apply to the textarea within the <code className="nx-code">NxCodeSnippet</code>
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>inputProps</NxTable.Cell>
+              <NxTable.Cell>
+                Props for <NxCode>NxTextInput</NxCode> except
+                for <NxCode>type</NxCode>,{' '}
+                <NxCode>value</NxCode>,{' '}
+                <NxCode>isPristine</NxCode>,
+                and <NxCode>readOnly</NxCode>
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
+                Props to apply to the textarea within the <NxCode>NxCodeSnippet</NxCode>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                   HTML div Attributes
                 </NxTextLink>
-              </NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>N/A</NxTableCell>
-              <NxTableCell>
-                <code className="nx-code">NxCodeSnippet</code> supports any HTML attribute that's normally
-                supported by <code className="nx-code">&lt;div&gt;</code>.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>N/A</NxTable.Cell>
+              <NxTable.Cell>
+                <NxCode>NxCodeSnippet</NxCode> supports any HTML attribute that's normally
+                supported by <NxCode>&lt;div&gt;</NxCode>.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </GalleryDescriptionTile>
 
@@ -110,7 +109,7 @@ export default function NxCodeSnippetPage() {
                           id="nx-code-snippet-simple-example"
                           liveExample={NxCodeSnippetExample}
                           codeExamples={nxCodeSnippetCode}>
-        Two <code className="nx-code">NxCodeSnippet</code>s with minimal props: just some content which can be
+        Two <NxCode>NxCodeSnippet</NxCode>s with minimal props: just some content which can be
         copied to the clipboard.
       </GalleryExampleTile>
 
@@ -118,11 +117,10 @@ export default function NxCodeSnippetPage() {
                           id="nx-code-snippet-complex-example"
                           liveExample={NxCodeSnippetComplexExample}
                           codeExamples={nxCodeSnippetComplexCode}>
-        An <code className="nx-code">NxCodeSnippet</code> demonstrating optional
-        props: <code className="nx-code">sublabel</code>, <code className="nx-code">onCopyUsingBtn</code>,
-        and <code className="nx-code">inputProps</code>
+        An <NxCode>NxCodeSnippet</NxCode> demonstrating optional
+        props: <NxCode>sublabel</NxCode>, <NxCode>onCopyUsingBtn</NxCode>,
+        and <NxCode>inputProps</NxCode>
       </GalleryExampleTile>
     </>
   );
 }
-

--- a/gallery/src/components/NxCodeSnippet/NxCodeSnippetPage.tsx
+++ b/gallery/src/components/NxCodeSnippet/NxCodeSnippetPage.tsx
@@ -6,12 +6,11 @@
  */
 import React from 'react';
 
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxCodeSnippetExample from './NxCodeSnippetExample';
 import NxCodeSnippetComplexExample from './NxCodeSnippetComplexExample';
-
-import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 const nxCodeSnippetCode = require('./NxCodeSnippetExample?raw'),
     nxCodeSnippetComplexCode = require('./NxCodeSnippetComplexExample?raw');

--- a/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
+++ b/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
@@ -5,8 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody, NxTextLink }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import NxColorPickerExample from './NxColorPickerExample';
@@ -16,89 +15,91 @@ const NxColorPickerExampleCode = require('./NxColorPickerExample?raw');
 const NxColorPickerPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxColorPicker</code> allows the user to select from a set of nine colors. A typical
-        use case would be to select the color to be associated with a colored <code className="nx-code">NxTag</code>.
-      </p>
-      <p className="nx-p">
-        The colors available in <code className="nx-code">NxColorPicker</code> match those supported
-        by <code className="nx-code">NxTag</code>. The list of these colors is available programmatically via
-        RSC's <code className="nx-code">selectableColors</code> export. Additionally, a TypeScript type union
-        respresenting the color choices is available as <code className="nx-code">SelectableColor</code>.
-      </p>
+      <NxP>
+        <NxCode>NxColorPicker</NxCode> allows the user to select from a set of nine colors. A typical
+        use case would be to select the color to be associated with a colored <NxCode>NxTag</NxCode>.
+      </NxP>
+      <NxP>
+        The colors available in <NxCode>NxColorPicker</NxCode> match those supported
+        by <NxCode>NxTag</NxCode>. The list of these colors is available programmatically via
+        RSC's <NxCode>selectableColors</NxCode> export. Additionally, a TypeScript type union
+        respresenting the color choices is available as <NxCode>SelectableColor</NxCode>.
+      </NxP>
       <h3 className="nx-h3">Props</h3>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Default</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>label</NxTableCell>
-            <NxTableCell>string | ReactNode</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>JSX content to render as the label for the picker. Must not be null or undefined.</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>isRequired</NxTableCell>
-            <NxTableCell>boolean</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>false</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Default</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>label</NxTable.Cell>
+            <NxTable.Cell>string | ReactNode</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
+              JSX content to render as the label for the picker. Must not be null or undefined.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isRequired</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>false</NxTable.Cell>
+            <NxTable.Cell>
               Sets whether the optional flag should be displayed next to the picker label – the flag is present
-              by default and setting <code className="nx-code">isRequired</code> to true removes the flag.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>value</NxTableCell>
-            <NxTableCell>
+              by default and setting <NxCode>isRequired</NxCode> to true removes the flag.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>value</NxTable.Cell>
+            <NxTable.Cell>
               SelectableColor
               ('light-blue' | 'purple' | 'pink' | 'blue' | 'red' | 'green' | 'orange' | 'yellow' | 'lime')
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell></NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell></NxTable.Cell>
+            <NxTable.Cell>
               The currently selected color, or null or undefined if no color is currently selected.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>onChange</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>
               Function
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell></NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell></NxTable.Cell>
+            <NxTable.Cell>
               A callback function to execute whenever the user updates their selection. Receives the name of the
               selected color as an argument.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>HTML <code className="nx-code">&lt;fieldset&gt;</code> Attributes</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;fieldset&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/fieldset">
                 HTML fieldset Attributes
               </NxTextLink>
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell></NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell></NxTable.Cell>
+            <NxTable.Cell>
               NxColorPicker supports any html attribute that's normally supported by
-              {' '}<code className="nx-code">&lt;fieldset&gt;</code> elements.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+              {' '}<NxCode>&lt;fieldset&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Example" liveExample={NxColorPickerExample} codeExamples={NxColorPickerExampleCode}>
-      An example of an <code className="nx-code">NxColorPicker</code>
+      An example of an <NxCode>NxColorPicker</NxCode>
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
+++ b/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
@@ -5,9 +5,10 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+
 import NxColorPickerExample from './NxColorPickerExample';
 
 const NxColorPickerExampleCode = require('./NxColorPickerExample?raw');

--- a/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
+++ b/gallery/src/components/NxColorPicker/NxColorPickerPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxColorPickerExample from './NxColorPickerExample';

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -5,8 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody, NxTextLink, NxCode, NxWarningAlert }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxCode, NxWarningAlert, NxH3, NxP } from '@sonatype/react-shared-components';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
@@ -29,36 +28,36 @@ const nxDropdownNavigationExampleCode = require('./NxDropdownNavigationExample?r
 const NxDropdownPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         A dropdown menu component. Note that this is for menus of nagivation links or
         action-triggering buttons.  It is <em>not</em> a form select field. By default the dropdown can display
         a maximum of 10 items before it scrolls the contents of the dropdown menu.
-      </p>
+      </NxP>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">Props:</h3>
+          <NxH3>Props:</NxH3>
         </header>
-        <table className="nx-table nx-table--gallery-props">
-          <thead>
-            <tr className="nx-table-row">
-              <th className="nx-cell nx-cell--header">Prop</th>
-              <th className="nx-cell nx-cell--header">Type</th>
-              <th className="nx-cell nx-cell--header">Required</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell">label</td>
-              <td className="nx-cell">string | VDOM</td>
-              <td className="nx-cell">Yes</td>
-              <td className="nx-cell">Content to render in the dropdown's button</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">children</td>
-              <td className="nx-cell">ReactElement | ReactElement[]</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>label</NxTable.Cell>
+              <NxTable.Cell>string | VDOM</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell>Content to render in the dropdown's button</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>children</NxTable.Cell>
+              <NxTable.Cell>ReactElement | ReactElement[]</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 The items to render within the dropdown list, including all <NxCode>.nx-dropdown-button</NxCode>s and
                 {' '}<NxCode>.nx-dropdown-link</NxCode>s.
                 <NxWarningAlert>
@@ -67,171 +66,171 @@ const NxDropdownPage = () =>
                   wrapping logic to work. These children may not be wrapped in other intermediate react components,
                   fragments, or even nested arrays.
                 </NxWarningAlert>
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">isOpen</td>
-              <td className="nx-cell">boolean</td>
-              <td className="nx-cell">Yes</td>
-              <td className="nx-cell">Value to control the toggling of the dropdown.</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">variant</td>
-              <td className="nx-cell">"primary" | "secondary" | "tertiary"</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>isOpen</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell>Value to control the toggling of the dropdown.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>variant</NxTable.Cell>
+              <NxTable.Cell>"primary" | "secondary" | "tertiary"</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 What type of button to render for the dropdown.
-                Defaults to <code className="nx-code">"tertiary"</code>
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">className</td>
-              <td className="nx-cell">string</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">Extra classes to apply to the component</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">disabled</td>
-              <td className="nx-cell">boolean</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+                Defaults to <NxCode>"tertiary"</NxCode>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>className</NxTable.Cell>
+              <NxTable.Cell>string</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>Extra classes to apply to the component</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>disabled</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 Controls if the component should be rendered as disabled.
-                Defaults to <code className="nx-code">false</code>
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onToggleCollapse</td>
-              <td className="nx-cell">function</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+                Defaults to <NxCode>false</NxCode>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onToggleCollapse</NxTable.Cell>
+              <NxTable.Cell>function</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 A function to execute whenever the dropdown is toggled. This toggling occurs when the dropdown button
                 is clicked and also, if the dropdown is currently open, whenever a click occurs anywhere on the
                 screen and any time the ESC key is pressed while focus is within the dropdown.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">toggleTooltip</td>
-              <td className="nx-cell">string | NxTooltip Props</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>toggleTooltip</NxTable.Cell>
+              <NxTable.Cell>string | NxTooltip Props</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 If present, describes a tooltip to be placed on the dropdowns' toggle element. There are two ways
                 to specify the tooltip: the simpler way is to simply specify the tooltip text as a string. If control
                 of more complex tooltip options is desired, an object can be passed which will serve as the props for
                 NxTooltip
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onCloseClick</td>
-              <td className="nx-cell">Function (MouseEvent =&lt; void)</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onCloseClick</NxTable.Cell>
+              <NxTable.Cell>Function (MouseEvent =&lt; void)</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 A callback function to execute when a click is detected anywhere on the document which would by
                 default close this dropdown (i.e. any click while the dropdown is open). This callback is dispatched
                 before the dropdown is closed and is provided with a proxy of the <em>native</em> MouseEvent object.
-                Calling <code className="nx-code">preventDefault</code> on this MouseEvent will cause the dropdown
+                Calling <NxCode>preventDefault</NxCode> on this MouseEvent will cause the dropdown
                 not to close. Note however that the event is proxied in such a way that
-                calling <code className="nx-code">preventDefault</code> <em>will not</em> have any other
-                effects – that is, the true native MouseEvent's <code className="nx-code">defaultPrevented</code> flag
+                calling <NxCode>preventDefault</NxCode> <em>will not</em> have any other
+                effects – that is, the true native MouseEvent's <NxCode>defaultPrevented</NxCode> flag
                 will be untouched, and only the logic within the dropdown will be affected.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onCloseKeyDown</td>
-              <td className="nx-cell">Function (KeyboardEvent =&lt; void)</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onCloseKeyDown</NxTable.Cell>
+              <NxTable.Cell>Function (KeyboardEvent =&lt; void)</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 A callback function to execute when a key press is detected which would by
                 default close this dropdown (i.e. an ESC keypress occurring within the dropdown while it is open).
                 This callback is dispatched before the dropdown is closed and is provided with the React KeyboardEvent
-                object.  Calling <code className="nx-code">preventDefault</code> on this event object will cause the
+                object.  Calling <NxCode>preventDefault</NxCode> on this event object will cause the
                 dropdown not to close.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/element/div">
                   HTML div Attributes
                 </NxTextLink>
-              </td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 NxDropdown supports any html attribute that's normally supported by
-                {' '}<code className="nx-code">&lt;div&gt;</code> elements.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                {' '}<NxCode>&lt;div&gt;</NxCode> elements.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
       </section>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">Auxiliary Components</h3>
+          <NxH3>Auxiliary Components</NxH3>
         </header>
-        <p className="nx-p">
-          An auxiliary component called <code className="nx-code">NxDropdownDivider</code> is available
+        <NxP>
+          An auxiliary component called <NxCode>NxDropdownDivider</NxCode> is available
           to be used as separator between child elements.
-        </p>
+        </NxP>
       </section>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">Dropdown Menu Content Classes</h3>
+          <NxH3>Dropdown Menu Content Classes</NxH3>
         </header>
-        <p className="nx-p">
+        <NxP>
           The following CSS classes are provided which must be used for the contents of the dropdown menu.
-        </p>
+        </NxP>
         <NxTable className="nx-table--gallery-props">
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Class</NxTableCell>
-              <NxTableCell>Location</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-dropdown-button</code></NxTableCell>
-              <NxTableCell>
-                <code className="nx-code">&lt;a&gt;</code> and <code className="nx-code">&lt;button&gt;</code> elements
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Class</NxTable.Cell>
+              <NxTable.Cell>Location</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-dropdown-button</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                <NxCode>&lt;a&gt;</NxCode> and <NxCode>&lt;button&gt;</NxCode> elements
                 within the dropdown menu
-              </NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+              <NxTable.Cell>
                 Styles the buttons and links as clickable rows within the menu
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-dropdown-link</code></NxTableCell>
-              <NxTableCell>
-                <code className="nx-code">&lt;a&gt;</code> elements within the dropdown menu
-              </NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-dropdown-link</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                <NxCode>&lt;a&gt;</NxCode> elements within the dropdown menu
+              </NxTable.Cell>
+              <NxTable.Cell>
                 Applies typical blue styling to links within the menu
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-dropdown-right-button</code></NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-dropdown-right-button</NxCode></NxTable.Cell>
+              <NxTable.Cell>
                 An additional icon-only button which can appear on the right side of a menu row
-              </NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+              <NxTable.Cell>
                 Sometimes it is desirable to add a icon-only button to a menu row which performs an action distinct
                 from clicking on the row itself - for instance, a trashcan button which deletes the row. For this
                 scenario, the icon button, a preceding sibling of the main row button, must include this class and{' '}
-                <code className="nx-code">nx-dropdown-button-content</code> must be used in conjunction.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-dropdown-button-content</code></NxTableCell>
-              <NxTableCell>
+                <NxCode>nx-dropdown-button-content</NxCode> must be used in conjunction.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-dropdown-button-content</NxCode></NxTable.Cell>
+              <NxTable.Cell>
                 Wrapper around text content of menu rows
-                when <code className="nx-code">nx-dropdown-right-button</code> is in use.
-              </NxTableCell>
-              <NxTableCell>
+                when <NxCode>nx-dropdown-right-button</NxCode> is in use.
+              </NxTable.Cell>
+              <NxTable.Cell>
                 This wrapper is necessary around the text content of
-                any <code className="nx-code">nx-dropdown-button</code> which is in a menu containing
-                any <code className="nx-code">.nx-dropdown-right-button</code>s.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+                any <NxCode>nx-dropdown-button</NxCode> which is in a menu containing
+                any <NxCode>.nx-dropdown-right-button</NxCode>s.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </section>
     </GalleryDescriptionTile>
@@ -239,9 +238,9 @@ const NxDropdownPage = () =>
     <GalleryExampleTile title="Navigation Example"
                         liveExample={NxDropdownNavigationExample}
                         codeExamples={nxDropdownNavigationExampleCode}>
-      An example of an <code className="nx-code">NxDropdown</code> as it might be used to implement a navigation list.
-      Note that the menu can contain either <code className="nx-code">&lt;a&gt;</code> or
-      {' '}<code className="nx-code">&lt;button&gt;</code> elements; this example contains both.
+      An example of an <NxCode>NxDropdown</NxCode> as it might be used to implement a navigation list.
+      Note that the menu can contain either <NxCode>&lt;a&gt;</NxCode> or
+      {' '}<NxCode>&lt;button&gt;</NxCode> elements; this example contains both.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Scrolling Example"
@@ -279,20 +278,20 @@ const NxDropdownPage = () =>
       This example demonstrates a dropdown where some of the dropdown menu rows have an additional icon-only button
       at their right end.  Clicking the row itself still behaves as normal, while clicking the icon button performs
       some other action related to the row, such as deleting the item the row represents. There are a few caveats to
-      using these styles: note that this example uses <code className="nx-code">&lt;a&gt;</code> elements for all
-      menu items – unfortunately <code className="nx-code">&lt;button&gt;</code> elements get some special behaviors
+      using these styles: note that this example uses <NxCode>&lt;a&gt;</NxCode> elements for all
+      menu items – unfortunately <NxCode>&lt;button&gt;</NxCode> elements get some special behaviors
       from the browser that prevent them from working with the styling here. Additionally, note that
-      the <code className="nx-code">nx-dropdown-button-content</code> is present on all menu items, even those that
+      the <NxCode>nx-dropdown-button-content</NxCode> is present on all menu items, even those that
       do not have icon buttons, in order to get consistent menu item heights.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Example with disabled close handlers"
                         liveExample={NxDropdownCloseHandlerExample}
                         codeExamples={nxDropdownCloseHandlerExampleCode}>
-      This example demonstrates the usage of the <code className="nx-code">onCloseClick</code>{' '}
-      and <code className="nx-code">onCloseKeyDown</code> props. These props can be used to disable the
+      This example demonstrates the usage of the <NxCode>onCloseClick</NxCode>{' '}
+      and <NxCode>onCloseKeyDown</NxCode> props. These props can be used to disable the
       close-on-click and close-on-ESC behaviors that the dropdown has by default, by
-      calling <code className="nx-code">preventDefault()</code> on the event. This example demonstrates both props
+      calling <NxCode>preventDefault()</NxCode> on the event. This example demonstrates both props
       simultaneously, but either can be used independently if desired.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTextLink, NxCode, NxWarningAlert, NxH3, NxP } from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxCode, NxWarningAlert, NxH3, NxP, NxTile } from '@sonatype/react-shared-components';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
@@ -33,10 +33,10 @@ const NxDropdownPage = () =>
         action-triggering buttons.  It is <em>not</em> a form select field. By default the dropdown can display
         a maximum of 10 items before it scrolls the contents of the dropdown menu.
       </NxP>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>Props:</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxTable>
           <NxTable.Head>
             <NxTable.Row>
@@ -161,24 +161,26 @@ const NxDropdownPage = () =>
             </NxTable.Row>
           </NxTable.Body>
         </NxTable>
-      </section>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      </NxTile.Subsection>
+
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>Auxiliary Components</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxP>
           An auxiliary component called <NxCode>NxDropdownDivider</NxCode> is available
           to be used as separator between child elements.
         </NxP>
-      </section>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      </NxTile.Subsection>
+
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>Dropdown Menu Content Classes</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxP>
           The following CSS classes are provided which must be used for the contents of the dropdown menu.
         </NxP>
-        <NxTable className="nx-table--gallery-props">
+        <NxTable>
           <NxTable.Head>
             <NxTable.Row>
               <NxTable.Cell>Class</NxTable.Cell>
@@ -232,7 +234,7 @@ const NxDropdownPage = () =>
             </NxTable.Row>
           </NxTable.Body>
         </NxTable>
-      </section>
+      </NxTile.Subsection>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Navigation Example"

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxTextLink, NxCode, NxWarningAlert, NxH3, NxP, NxTile } from '@sonatype/react-shared-components';
 
+import { NxTable, NxTextLink, NxCode, NxWarningAlert, NxH3, NxP, NxTile } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxDropdownNavigationExample from './NxDropdownNavigationExample';

--- a/gallery/src/components/NxDropdown/NxDropdownPage.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxCode, NxWarningAlert, NxH3, NxP, NxTile } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxDropdownNavigationExample from './NxDropdownNavigationExample';

--- a/gallery/src/components/NxFieldset/NxFieldsetPage.tsx
+++ b/gallery/src/components/NxFieldset/NxFieldsetPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFieldsetExample from './NxFieldsetExample';

--- a/gallery/src/components/NxFieldset/NxFieldsetPage.tsx
+++ b/gallery/src/components/NxFieldset/NxFieldsetPage.tsx
@@ -6,8 +6,7 @@
  */
 import React from 'react';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTableHead, NxTableRow, NxTableCell, NxTable, NxTableBody, NxTextLink }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxFieldsetExample from './NxFieldsetExample';
 import NxFieldsetRequiredExample from './NxFieldsetRequiredExample';
@@ -22,101 +21,103 @@ const nxFieldsetExampleCode = require('./NxFieldsetExample?raw'),
 const NxFieldsetPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        An <code className="nx-code">NxFieldset</code> is a wrapper around a collection of checkboxes, radios, or
+      <NxP>
+        An <NxCode>NxFieldset</NxCode> is a wrapper around a collection of checkboxes, radios, or
         similar form elements which should be displayed to the user as a group with an overall label. When used
-        with <code className="nx-code">NxCheckbox</code> or <code className="nx-code">NxRadio</code>, all inputs
+        with <NxCode>NxCheckbox</NxCode> or <NxCode>NxRadio</NxCode>, all inputs
         contained within a single NxFieldset should represent different options/values of the same field.
-      </p>
-      <p className="nx-p">
-        Form fields which have their own individual label styled using <code className="nx-code">.nx-label</code>{' '}
-        (including those wrapped in <code className="nx-code">NxFormGroup</code>) should not be wrapped
-        in <code className="nx-code">NxFieldset</code> as the label styles between the two are intended to be identical
+      </NxP>
+      <NxP>
+        Form fields which have their own individual label styled using <NxCode>.nx-label</NxCode>{' '}
+        (including those wrapped in <NxCode>NxFormGroup</NxCode>) should not be wrapped
+        in <NxCode>NxFieldset</NxCode> as the label styles between the two are intended to be identical
         and not hierarchical.
-      </p>
+      </NxP>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Default</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>label</NxTableCell>
-            <NxTableCell>string | ReactNode</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>JSX content to render as the label for the group. Must not be null or undefined.</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>sublabel</NxTableCell>
-            <NxTableCell>string | ReactNode</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>empty</NxTableCell>
-            <NxTableCell>JSX content to render as the sublabel for the group.</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>isRequired</NxTableCell>
-            <NxTableCell>boolean</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>false</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Default</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>label</NxTable.Cell>
+            <NxTable.Cell>string | ReactNode</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
+              JSX content to render as the label for the group. Must not be null or undefined.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>sublabel</NxTable.Cell>
+            <NxTable.Cell>string | ReactNode</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>empty</NxTable.Cell>
+            <NxTable.Cell>JSX content to render as the sublabel for the group.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isRequired</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>false</NxTable.Cell>
+            <NxTable.Cell>
               Sets whether the input should display the optional flag – the flag is present by default and
-              setting <code className="nx-code">isRequired</code> to true removes the flag.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>children</NxTableCell>
-            <NxTableCell>ReactNode</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>
+              setting <NxCode>isRequired</NxCode> to true removes the flag.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>ReactNode</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
               The child form elements to render within the fieldset – often a series
-              of <code className="nx-code">NxRadio</code> or <code className="nx-code">NxCheckbox</code> components
+              of <NxCode>NxRadio</NxCode> or <NxCode>NxCheckbox</NxCode> components
               which represent different options for the same field.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>HTML <code className="nx-code">&lt;fieldset&gt;</code> Attributes</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;fieldset&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/fieldset">
                 HTML fieldset Attributes
               </NxTextLink>
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
               NxFieldset supports any HTML attribute that's normally supported
-              by <code className="nx-code">&lt;fieldset&gt;</code>.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+              by <NxCode>&lt;fieldset&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Basic Example"
                         liveExample={NxFieldsetExample}
                         codeExamples={nxFieldsetExampleCode}>
-      A basic example of an <code className="nx-code">NxFieldset</code> wrapping
-      some <code className="nx-code">NxCheckbox</code>s.
+      A basic example of an <NxCode>NxFieldset</NxCode> wrapping
+      some <NxCode>NxCheckbox</NxCode>s.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Required Example"
                         liveExample={NxFieldsetRequiredExample}
                         codeExamples={nxFieldsetRequiredExampleCode}>
-      An example of an <code className="nx-code">NxFieldset</code> wrapping
-      some <code className="nx-code">NxRadio</code>s which uses the isRequired flag to remove the "Optional"
+      An example of an <NxCode>NxFieldset</NxCode> wrapping
+      some <NxCode>NxRadio</NxCode>s which uses the isRequired flag to remove the "Optional"
       indicator.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Sublabel Example"
                         liveExample={NxFieldsetSublabelExample}
                         codeExamples={nxFieldsetSublabelExampleCode}>
-      An example of an <code className="nx-code">NxFieldset</code> which includes a sublabel.
+      An example of an <NxCode>NxFieldset</NxCode> which includes a sublabel.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Rich Label Content Example"

--- a/gallery/src/components/NxFieldset/NxFieldsetPage.tsx
+++ b/gallery/src/components/NxFieldset/NxFieldsetPage.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFieldsetExample from './NxFieldsetExample';
 import NxFieldsetRequiredExample from './NxFieldsetRequiredExample';

--- a/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
+++ b/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFilterInputFullExample from './NxFilterInputFullExample';

--- a/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
+++ b/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink, NxH3 } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFilterInputFullExample from './NxFilterInputFullExample';
 import NxFilterInputDisabledExample from './NxFilterInputDisabledExample';

--- a/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
+++ b/gallery/src/components/NxFilterInput/NxFilterInputPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink, NxH3 } from '@sonatype/react-shared-components';
 
 import NxFilterInputFullExample from './NxFilterInputFullExample';
 import NxFilterInputDisabledExample from './NxFilterInputDisabledExample';
@@ -22,71 +22,71 @@ const nxFilterInputFullExampleCode = require('./NxFilterInputFullExample?raw'),
 const NxFilterInputPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         An input to be used for filtering purposes
-      </p>
+      </NxP>
 
-      <h3>NxFilterInput Props</h3>
-      <p className="nx-p">
-        <code className="nx-code">NxFilterInput</code> receives a subset of the props that are valid on NxTextInput,
+      <NxH3>NxFilterInput Props</NxH3>
+      <NxP>
+        <NxCode>NxFilterInput</NxCode> receives a subset of the props that are valid on NxTextInput,
         as described below.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">value</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">The value rendered in the text input</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function ((string) =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>value</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>The value rendered in the text input</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function ((string) =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A callback for when the user changes the value of the text box (e.g. by typing a letter)
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onKeyPress</td>
-            <td className="nx-cell">Function ((string) =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              <p className="nx-p">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onKeyPress</NxTable.Cell>
+            <NxTable.Cell>Function ((string) =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 A callback for when the user presses a key that doesn't necessarily change the input value
                 (e.g. by hitting enter)
-              </p>
-              <p className="nx-p">
+              </NxP>
+              <NxP>
                 The value given to the callback will be that of the key name, as described in the spec
                 for{' '}
                 <NxTextLink external href="https://www.w3.org/TR/uievents-key/#named-key-attribute-values">
                   named keys
                 </NxTextLink>
-              </p>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;input&gt;</code> Attributes</td>
-            <td className="nx-cell">
+              </NxP>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;input&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/input">
                 Input Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               NxFilterInput supports any html attribute that's normally supported by HTML Inputs. The only notable
               exceptions are:
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
-                  <code className="nx-code">defaultValue</code> which is left out because it creates what's commonly
+                  <NxCode>defaultValue</NxCode> which is left out because it creates what's commonly
                   known as{' '}
                   <NxTextLink external href="https://reactjs.org/docs/uncontrolled-components.html">
                     uncontrolled inputs
@@ -97,10 +97,10 @@ const NxFilterInputPage = () =>
                   react propTypes.
                 </li>
               </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="NxFilterInput Example"
@@ -108,7 +108,7 @@ const NxFilterInputPage = () =>
                         className="nx-filter-input-examples"
                         liveExample={NxFilterInputFullExample}
                         codeExamples={nxFilterInputFullExampleCode}>
-      A simple <code className="nx-code">NxFilterInput</code>.
+      A simple <NxCode>NxFilterInput</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxFilterInput Disabled Example"
@@ -116,7 +116,7 @@ const NxFilterInputPage = () =>
                         className="nx-filter-input-examples"
                         liveExample={NxFilterInputDisabledExample}
                         codeExamples={nxFilterInputDisabledExampleCode}>
-      A disabled <code className="nx-code">NxFilterInput</code>.
+      A disabled <NxCode>NxFilterInput</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxFilterInput Datalist Example"
@@ -124,8 +124,8 @@ const NxFilterInputPage = () =>
                         className="nx-filter-input-examples"
                         liveExample={NxFilterInputDataListExample}
                         codeExamples={nxFilterInputDataListExampleCode}>
-      An example using a <code className="nx-code">datalist</code> with
-      <code className="nx-code">NxFilterInput</code>.
+      An example using a <NxCode>datalist</NxCode> with
+      <NxCode>NxFilterInput</NxCode>.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
+++ b/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxH3, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFontAwesomeIconExample from './NxFontAwesomeIconExample';
 

--- a/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
+++ b/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxH3, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFontAwesomeIconExample from './NxFontAwesomeIconExample';

--- a/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
+++ b/gallery/src/components/NxFontAwesomeIcon/NxFontAwesomeIconPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxH3, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxFontAwesomeIconExample from './NxFontAwesomeIconExample';
 
@@ -22,34 +23,36 @@ const NxFontAwesomeIconPage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          <code className="nx-code">NxFontAwesomeIcon</code> is a wrapper around
-          the <code className="nx-code">FontAwesomeIcon</code> component. It passes through its props
-          to <code className="nx-code">FontAwesomeIcon</code> and adds the <code className="nx-code">.nx-icon</code> CSS
+        <NxP>
+          <NxCode>NxFontAwesomeIcon</NxCode> is a wrapper around
+          the <NxCode>FontAwesomeIcon</NxCode> component. It passes through its props
+          to <NxCode>FontAwesomeIcon</NxCode> and adds the <NxCode>.nx-icon</NxCode> CSS
           class.
-        </p>
-        <p className="nx-p">
-          See the <code className="nx-code">FontAwesomeIcon</code>{' '}
-          <a href="https://github.com/FortAwesome/react-fontawesome#features" target="_blank">documentation</a>
+        </NxP>
+        <NxP>
+          See the <NxCode>FontAwesomeIcon</NxCode>{' '}
+          <NxTextLink href="https://github.com/FortAwesome/react-fontawesome#features" target="_blank">
+            documentation
+          </NxTextLink>
           {' '}for details on available props
-        </p>
-        <h3 className="nx-h3">Accessibility</h3>
-        <p className="nx-p">
-          <code className="nx-code">FontAwesomeIcon</code> has a <code className="nx-code">title</code> prop which
-          sets up a <code className="nx-code">&lt;title&gt;</code> element within the rendered SVG and configures it
+        </NxP>
+        <NxH3>Accessibility</NxH3>
+        <NxP>
+          <NxCode>FontAwesomeIcon</NxCode> has a <NxCode>title</NxCode> prop which
+          sets up a <NxCode>&lt;title&gt;</NxCode> element within the rendered SVG and configures it
           as the accessible name for the icon. Use this attribute when an icon itself needs to be read by a
           screenreader. Note however that this will also create a native tooltip with the title, which is not ideal
-          due to our preference for <code className="nx-code">NxTooltip</code>. This technique should therefore be
+          due to our preference for <NxCode>NxTooltip</NxCode>. This technique should therefore be
           used sparingly, and labels on parent elements should be preferred where appropriate. For instance,
           the accessible name for an icon-only button should be placed on the button itself, not on the icon.
-          See the <a href="#/pages/NxButton"><code className="nx-code">NxButton</code></a> page for an example.
-        </p>
-        <p className="nx-p">
+          See the <NxTextLink href="#/pages/NxButton"><NxCode>NxButton</NxCode></NxTextLink> page for an example.
+        </NxP>
+        <NxP>
           If you are in doubt about whether an icon should be made accessible consider whether the user could perform
           their given task, or understand an explanation if that icon was not there. Take care that adding an
-          {' '}<code className="nx-code">aria-label</code> does not cause repetition in text read by assistive
+          {' '}<NxCode>aria-label</NxCode> does not cause repetition in text read by assistive
           technologies.
-        </p>
+        </NxP>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="General Example"
                           codeExamples={codeExamples}

--- a/gallery/src/components/NxForm/NxFormPage.tsx
+++ b/gallery/src/components/NxForm/NxFormPage.tsx
@@ -7,8 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTableHead, NxTableRow, NxTableCell, NxTable, NxTableBody, NxWarningAlert, NxTextLink }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxWarningAlert, NxTextLink, NxP, NxCode, NxH3 } from '@sonatype/react-shared-components';
 
 import NxFormExample from './NxFormExample';
 import NxFormCustomizedExample from './NxFormCustomizedExample';
@@ -27,10 +26,10 @@ const customizedExampleCode = [
 const NxFormPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxForm</code> is an encapsulation of styles and typical behavior for
+      <NxP>
+        <NxCode>NxForm</NxCode> is an encapsulation of styles and typical behavior for
         a form within a Sonatype application. It helps manage the UI around the following behaviors.
-      </p>
+      </NxP>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">
           <span className="nx-list__text">Standard form footer with submit and cancel buttons</span>
@@ -51,229 +50,229 @@ const NxFormPage = () =>
         </li>
       </ul>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Default</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>loading</NxTableCell>
-            <NxTableCell>boolean</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>false</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Default</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>loading</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>false</NxTable.Cell>
+            <NxTable.Cell>
               Set to true to display a loading spinner in place of the form. Only has an effect when used in
-              conjunction with <code className="nx-code">doLoad</code>
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>doLoad</NxTableCell>
-            <NxTableCell>Function</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>noop</NxTableCell>
-            <NxTableCell>
+              conjunction with <NxCode>doLoad</NxCode>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>doLoad</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>noop</NxTable.Cell>
+            <NxTable.Cell>
               When this prop is defined, it indicates that some asynchronous, retryable data load must happen
               before the form can be displayed. The form is wrapped in an{' '}
               <NxTextLink href="#/pages/NxLoadWrapper">
-                <code className="nx-code">NxLoadWrapper</code>
+                <NxCode>NxLoadWrapper</NxCode>
               </NxTextLink>
               {' '}and this function is wired up to the retry button on the load error alert. Note that the
               initial load of the form data is expected to be triggered externally{' '}
-              – <code className="nx-code">NxForm</code> only calls this function in response to the Retry button.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>onSubmit</NxTableCell>
-            <NxTableCell>Function</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>
+              – <NxCode>NxForm</NxCode> only calls this function in response to the Retry button.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onSubmit</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
               The function to invoke in response to the form submission. Note that to prevent browser-native
               form submission semantics (e.g. page reload) the form
-              event's <code className="nx-code">preventDefault</code> method is called before this method is
+              event's <NxCode>preventDefault</NxCode> method is called before this method is
               dispatched. This function does not receive the form submit event as an argument, because it may
               also be called in response to a click on the Retry button in the form submission error alert.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>onCancel</NxTableCell>
-            <NxTableCell>Function</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>noop</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onCancel</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>noop</NxTable.Cell>
+            <NxTable.Cell>
               If this prop is defined, a Cancel button will be added to the form footer which triggers this function
               when clicked.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>loadError</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>undefined</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>loadError</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>undefined</NxTable.Cell>
+            <NxTable.Cell>
               If defined, the load wrapper's error alert will be displayed in place of the form, with this string
-              as its error message. Only has an effect if <code className="nx-code">doLoad</code> is also defined.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>submitError</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>undefined</NxTableCell>
-            <NxTableCell>
+              as its error message. Only has an effect if <NxCode>doLoad</NxCode> is also defined.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>submitError</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>undefined</NxTable.Cell>
+            <NxTable.Cell>
               If defined, an error alert will be rendered in the form footer showing the corresponding message,
-              along with a Retry button wired to the <code className="nx-code">onSubmit</code> handler.
+              along with a Retry button wired to the <NxCode>onSubmit</NxCode> handler.
               Additionally, the Submit button is hidden when this prop is defined.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>submitErrorTitleMessage</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>"An error occurred saving data."</NxTableCell>
-            <NxTableCell>
-              The <code className="nx-code">titleMessage</code> to set on
-              the <code className="nx-code">NxLoadError</code> which displays errors from form submission.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>validationErrors</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>undefined</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>submitErrorTitleMessage</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>"An error occurred saving data."</NxTable.Cell>
+            <NxTable.Cell>
+              The <NxCode>titleMessage</NxCode> to set on
+              the <NxCode>NxLoadError</NxCode> which displays errors from form submission.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>validationErrors</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>undefined</NxTable.Cell>
+            <NxTable.Cell>
               A form-wide validation error message which, when defined, is displayed as a tooltip on the Submit
               button. Additionally the submit button is disabled when present.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>submitBtnClasses</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>empty</NxTableCell>
-            <NxTableCell>Extra CSS classes to apply to the submit button</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>submitBtnText</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>Submit</NxTableCell>
-            <NxTableCell>The text content of the submit button</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>submitMaskState</NxTableCell>
-            <NxTableCell>boolean</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>null</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>submitBtnClasses</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>empty</NxTable.Cell>
+            <NxTable.Cell>Extra CSS classes to apply to the submit button</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>submitBtnText</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>Submit</NxTable.Cell>
+            <NxTable.Cell>The text content of the submit button</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>submitMaskState</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>null</NxTable.Cell>
+            <NxTable.Cell>
               If null, the submit mask is not shown. If false, the mask is shown in its "submitting" state. If
               true, the mask is shown in its "success" state.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>submitMaskMessage</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>Submitting…</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>submitMaskMessage</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>Submitting…</NxTable.Cell>
+            <NxTable.Cell>
               The message to display in the submit mask while the form submission is pending
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>submitMaskSuccessMessage</NxTableCell>
-            <NxTableCell>string</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>Success!</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>submitMaskSuccessMessage</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>Success!</NxTable.Cell>
+            <NxTable.Cell>
               The message to briefly display in the submit mask while the form submission has succeeded
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>additionalFooterBtns</NxTableCell>
-            <NxTableCell>JSX</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>empty</NxTableCell>
-            <NxTableCell>
-              <p className="nx-p">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>additionalFooterBtns</NxTable.Cell>
+            <NxTable.Cell>JSX</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>empty</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 Extra buttons to render in the form footer to the left of the Submit and Cancel buttons. These buttons
                 would typically use tertiary button styling.
-              </p>
+              </NxP>
               <NxWarningAlert>
-                Do not forget that <code className="nx-code">&lt;button&gt;</code> elements, including those
-                rendered by <code className="nx-code">NxButton</code>,
-                have <code className="nx-code">type="submit"</code> by default. Therefore, in order to avoid these
+                Do not forget that <NxCode>&lt;button&gt;</NxCode> elements, including those
+                rendered by <NxCode>NxButton</NxCode>,
+                have <NxCode>type="submit"</NxCode> by default. Therefore, in order to avoid these
                 additional buttons submitting the form, care must be taken to
-                add <code className="nx-code">type="button"</code> to each of them.
+                add <NxCode>type="button"</NxCode> to each of them.
               </NxWarningAlert>
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>children</NxTableCell>
-            <NxTableCell>JSX or (() =&gt; JSX)</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>JSX or (() =&gt; JSX)</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
               The form contents, excluding the footer which is provided by this component. Can be specified as a
               function in order to avoid rendering children before loading completes
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>HTML <code className="nx-code">&lt;form&gt;</code> Attributes</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;form&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/form">
                 HTML form Attributes
               </NxTextLink>
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
               NxForm supports any HTML attribute that's normally supported
-              by <code className="nx-code">&lt;form&gt;</code>.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+              by <NxCode>&lt;form&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">NxForm Submit and Cancel Button Classes</h3>
+          <NxH3>NxForm Submit and Cancel Button Classes</NxH3>
         </header>
-        <p className="nx-p">
+        <NxP>
           In order to differentiate them from other buttons that might be on the page the
-          <code className="nx-code">NxForm</code> cancel and submit buttons have custom classes.
-        </p>
+          <NxCode>NxForm</NxCode> cancel and submit buttons have custom classes.
+        </NxP>
         <NxTable className="nx-table--gallery-props">
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Class</NxTableCell>
-              <NxTableCell>Location</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-form__cancel-btn</code></NxTableCell>
-              <NxTableCell>
-                Applied to the default <code className="nx-code">NxForm</code> Cancel button.
-              </NxTableCell>
-              <NxTableCell>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Class</NxTable.Cell>
+              <NxTable.Cell>Location</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-form__cancel-btn</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                Applied to the default <NxCode>NxForm</NxCode> Cancel button.
+              </NxTable.Cell>
+              <NxTable.Cell>
                 A CSS class that can be used to identify the Cancel button on the page for testing or other purposes.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">nx-form__submit-btn</code></NxTableCell>
-              <NxTableCell>
-                Applied to the default <code className="nx-code">NxForm</code> Submit button.
-              </NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>nx-form__submit-btn</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                Applied to the default <NxCode>NxForm</NxCode> Submit button.
+              </NxTable.Cell>
+              <NxTable.Cell>
                 A CSS class that can be used to identify the Submit button on the page for testing or other purposes.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </section>
     </GalleryDescriptionTile>

--- a/gallery/src/components/NxForm/NxFormPage.tsx
+++ b/gallery/src/components/NxForm/NxFormPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxWarningAlert, NxTextLink, NxP, NxCode, NxH3, NxTile } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormExample from './NxFormExample';

--- a/gallery/src/components/NxForm/NxFormPage.tsx
+++ b/gallery/src/components/NxForm/NxFormPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxWarningAlert, NxTextLink, NxP, NxCode, NxH3, NxTile } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormExample from './NxFormExample';
 import NxFormCustomizedExample from './NxFormCustomizedExample';

--- a/gallery/src/components/NxForm/NxFormPage.tsx
+++ b/gallery/src/components/NxForm/NxFormPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTable, NxWarningAlert, NxTextLink, NxP, NxCode, NxH3 } from '@sonatype/react-shared-components';
+import { NxTable, NxWarningAlert, NxTextLink, NxP, NxCode, NxH3, NxTile } from '@sonatype/react-shared-components';
 
 import NxFormExample from './NxFormExample';
 import NxFormCustomizedExample from './NxFormCustomizedExample';
@@ -237,15 +237,15 @@ const NxFormPage = () =>
           </NxTable.Row>
         </NxTable.Body>
       </NxTable>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
           <NxH3>NxForm Submit and Cancel Button Classes</NxH3>
-        </header>
+        </NxTile.SubsectionHeader>
         <NxP>
           In order to differentiate them from other buttons that might be on the page the
           <NxCode>NxForm</NxCode> cancel and submit buttons have custom classes.
         </NxP>
-        <NxTable className="nx-table--gallery-props">
+        <NxTable>
           <NxTable.Head>
             <NxTable.Row>
               <NxTable.Cell>Class</NxTable.Cell>
@@ -274,7 +274,7 @@ const NxFormPage = () =>
             </NxTable.Row>
           </NxTable.Body>
         </NxTable>
-      </section>
+      </NxTile.Subsection>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Asynchronous Example"

--- a/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
+++ b/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
@@ -6,8 +6,7 @@
  */
 import React from 'react';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTable, NxTextLink, NxP, NxCode }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxFormGroupExample from './NxFormGroupExample';
 import NxFormGroupRequiredExample from './NxFormGroupRequiredExample';

--- a/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
+++ b/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTableHead, NxTableRow, NxTableCell, NxTable, NxTableBody, NxTextLink }
+import { NxTable, NxTextLink, NxP, NxCode }
   from '@sonatype/react-shared-components';
 
 import NxFormGroupExample from './NxFormGroupExample';
@@ -24,105 +24,107 @@ const nxFormGroupExampleCode = require('./NxFormGroupExample?raw'),
 const NxFormGroupPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        An <code className="nx-code">NxFormGroup</code> is a wrapper around a form field which provides the labels
-        and overall spacing. Most commonly, <code className="nx-code">NxFormGroup</code> wraps
-        an <code className="nx-code">NxTextInput</code>, but it may wrap other content such as
-        a <code className="nx-code">&lt;select&gt;</code>. It <em>should not</em> be used to wrap radio
+      <NxP>
+        An <NxCode>NxFormGroup</NxCode> is a wrapper around a form field which provides the labels
+        and overall spacing. Most commonly, <NxCode>NxFormGroup</NxCode> wraps
+        an <NxCode>NxTextInput</NxCode>, but it may wrap other content such as
+        a <NxCode>&lt;select&gt;</NxCode>. It <em>should not</em> be used to wrap radio
         and checkbox groups, as those are best encapsulated
-        in <code className="nx-code">&lt;fieldset&gt;</code> elements.
-      </p>
+        in <NxCode>&lt;fieldset&gt;</NxCode> elements.
+      </NxP>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Default</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>label</NxTableCell>
-            <NxTableCell>string | ReactNode</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>JSX content to render as the label for the group. Must not be null or undefined.</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>sublabel</NxTableCell>
-            <NxTableCell>string | ReactNode</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>empty</NxTableCell>
-            <NxTableCell>JSX content to render as the sublabel for the group.</NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>isRequired</NxTableCell>
-            <NxTableCell>boolean</NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>false</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Default</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>label</NxTable.Cell>
+            <NxTable.Cell>string | ReactNode</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
+              JSX content to render as the label for the group. Must not be null or undefined.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>sublabel</NxTable.Cell>
+            <NxTable.Cell>string | ReactNode</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>empty</NxTable.Cell>
+            <NxTable.Cell>JSX content to render as the sublabel for the group.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isRequired</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>false</NxTable.Cell>
+            <NxTable.Cell>
               Sets whether the input should display the optional flag – the flag is present by default and
-              setting <code className="nx-code">isRequired</code> to true removes the flag.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>children</NxTableCell>
-            <NxTableCell>A single ReactElement which can take an id as a prop</NxTableCell>
-            <NxTableCell>Yes</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>
+              setting <NxCode>isRequired</NxCode> to true removes the flag.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>A single ReactElement which can take an id as a prop</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
               The form element that this group wraps and labels. For accessibility reasons, it
-              must be able to receive <code className="nx-code">id</code> and{' '}
-              <code className="nx-code">aria-describedby</code> props which must ultimately get rendered onto the
+              must be able to receive <NxCode>id</NxCode> and{' '}
+              <NxCode>aria-describedby</NxCode> props which must ultimately get rendered onto the
               native input element. If these props are already present, their values
-              will be respected. Otherwise, the <code className="nx-code">NxFormGroup</code> will clone and
+              will be respected. Otherwise, the <NxCode>NxFormGroup</NxCode> will clone and
               augment the child JSX node with autogenerated values for the props.
-              If <code className="nx-code">aria-describedby</code> is provided, the autogenerated id of the sublabel
+              If <NxCode>aria-describedby</NxCode> is provided, the autogenerated id of the sublabel
               will be appended to the existing values.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                 HTML div Attributes
               </NxTextLink>
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>N/A</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>N/A</NxTable.Cell>
+            <NxTable.Cell>
               NxFormGroup supports any HTML attribute that's normally supported
-              by <code className="nx-code">&lt;div&gt;</code>.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+              by <NxCode>&lt;div&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Basic Example"
                         liveExample={NxFormGroupExample}
                         codeExamples={nxFormGroupExampleCode}>
-      A basic example of an <code className="nx-code">NxFormGroup</code> wrapping
-      an <code className="nx-code">NxTextInput</code>.
+      A basic example of an <NxCode>NxFormGroup</NxCode> wrapping
+      an <NxCode>NxTextInput</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Required Example"
                         liveExample={NxFormGroupRequiredExample}
                         codeExamples={nxFormGroupRequiredExampleCode}>
-      An example of an <code className="nx-code">NxFormGroup</code> wrapping
-      an <code className="nx-code">NxTextInput</code> which uses the isRequired flag to remove the "Optional"
+      An example of an <NxCode>NxFormGroup</NxCode> wrapping
+      an <NxCode>NxTextInput</NxCode> which uses the isRequired flag to remove the "Optional"
       indicator.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Sublabel Example"
                         liveExample={NxFormGroupSublabelExample}
                         codeExamples={nxFormGroupSublabelExampleCode}>
-      An example of an <code className="nx-code">NxFormGroup</code> which includes a sublabel. This example also
-      shows that <code className="nx-code">NxFormGroup</code> can wrap a
-      {' '}<code className="nx-code">&lt;select&gt;</code> in addition to
-      an <code className="nx-code">NxTextInput</code>.
+      An example of an <NxCode>NxFormGroup</NxCode> which includes a sublabel. This example also
+      shows that <NxCode>NxFormGroup</NxCode> can wrap a
+      {' '}<NxCode>&lt;select&gt;</NxCode> in addition to
+      an <NxCode>NxTextInput</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Rich Label Content Example"

--- a/gallery/src/components/NxFormSelect/NxFormSelectPage.tsx
+++ b/gallery/src/components/NxFormSelect/NxFormSelectPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxTable, NxP, NxTextLink, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormSelectExample from './NxFormSelectExample';

--- a/gallery/src/components/NxFormSelect/NxFormSelectPage.tsx
+++ b/gallery/src/components/NxFormSelect/NxFormSelectPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxCode, NxTable, NxP, NxTextLink, NxTile, NxH3 } from '@sonatype/react-shared-components';
 
+import { NxCode, NxTable, NxP, NxTextLink, NxTile, NxH3 } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormSelectExample from './NxFormSelectExample';

--- a/gallery/src/components/NxGlobalSidebar/NxGlobalSidebarPage.tsx
+++ b/gallery/src/components/NxGlobalSidebar/NxGlobalSidebarPage.tsx
@@ -47,7 +47,7 @@ export default function NxGlobalSidebarPage() {
         </NxP>
         <NxTile.Subsection>
           <NxTile.SubsectionHeader>
-            <h3 className="nx-h3"><NxCode>NxGlobalSidebar</NxCode> Props</h3>
+            <NxH3><NxCode>NxGlobalSidebar</NxCode> Props</NxH3>
           </NxTile.SubsectionHeader>
           <NxTable>
             <NxTable.Head>
@@ -110,7 +110,7 @@ export default function NxGlobalSidebarPage() {
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                     HTML div Attributes
@@ -118,8 +118,8 @@ export default function NxGlobalSidebarPage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxGlobalSidebar</code> supports any HTML attribute that's normally
-                  supported by <code className="nx-code">&lt;div&gt;</code>.
+                  <NxCode>NxGlobalSidebar</NxCode> supports any HTML attribute that's normally
+                  supported by <NxCode>&lt;div&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -127,7 +127,7 @@ export default function NxGlobalSidebarPage() {
         </NxTile.Subsection>
         <NxTile.Subsection>
           <NxTile.SubsectionHeader>
-            <h3 className="nx-h3"><NxCode>NxGlobalSidebarNavigation</NxCode> Props</h3>
+            <NxH3><NxCode>NxGlobalSidebarNavigation</NxCode> Props</NxH3>
           </NxTile.SubsectionHeader>
           <NxP>
             <NxCode>NxGlobalSidebarNavigation</NxCode> is a container for navigation links.
@@ -147,7 +147,7 @@ export default function NxGlobalSidebarPage() {
             </NxTable.Head>
             <NxTable.Body>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                     HTML div Attributes
@@ -155,8 +155,8 @@ export default function NxGlobalSidebarPage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxGlobalSidebar</code> supports any HTML attribute that's normally
-                  supported by <code className="nx-code">&lt;div&gt;</code>.
+                  <NxCode>NxGlobalSidebar</NxCode> supports any HTML attribute that's normally
+                  supported by <NxCode>&lt;div&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -164,7 +164,7 @@ export default function NxGlobalSidebarPage() {
         </NxTile.Subsection>
         <NxTile.Subsection>
           <NxTile.SubsectionHeader>
-            <h3 className="nx-h3"><NxCode>NxGlobalSidebarNavigationLink</NxCode> Props</h3>
+            <NxH3><NxCode>NxGlobalSidebarNavigationLink</NxCode> Props</NxH3>
           </NxTile.SubsectionHeader>
           <NxTable>
             <NxTable.Head>
@@ -203,7 +203,7 @@ export default function NxGlobalSidebarPage() {
                 <NxTable.Cell>URL</NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;a&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;a&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/a">
                     HTML a Attributes
@@ -211,8 +211,8 @@ export default function NxGlobalSidebarPage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxGlobalSidebarNavigationLink</code> supports any HTML attribute that's
-                  normally supported by <code className="nx-code">&lt;a&gt;</code>.
+                  <NxCode>NxGlobalSidebarNavigationLink</NxCode> supports any HTML attribute that's
+                  normally supported by <NxCode>&lt;a&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -261,9 +261,9 @@ export default function NxGlobalSidebarPage() {
         </NxTile.Header>
         <NxTile.Content>
           <NxP>
-            <a className="nx-text-link" href="#/NxGlobalSidebarExample">
+            <NxTextLink href="#/NxGlobalSidebarExample">
               Click here to navigate to the live example.
-            </a>
+            </NxTextLink>
           </NxP>
           <CodeExample content={NxGlobalSidebarExample} />
         </NxTile.Content>
@@ -280,9 +280,9 @@ export default function NxGlobalSidebarPage() {
             scrolling, and all footer options enabled.
           </NxP>
           <NxP>
-            <a className="nx-text-link" href="#/NxGlobalSidebarScrollingExample">
+            <NxTextLink href="#/NxGlobalSidebarScrollingExample">
               Click here to navigate to the live example.
-            </a>
+            </NxTextLink>
           </NxP>
           <CodeExample content={NxGlobalSidebarScrollingExample} />
         </NxTile.Content>

--- a/gallery/src/components/NxGlobalSidebarFooter/NxGlobalSidebarFooterPage.tsx
+++ b/gallery/src/components/NxGlobalSidebarFooter/NxGlobalSidebarFooterPage.tsx
@@ -82,7 +82,7 @@ export default function NxGlobalSidebarFooterPage() {
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                     HTML div Attributes
@@ -91,7 +91,7 @@ export default function NxGlobalSidebarFooterPage() {
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
                   NxGlobalSidebarFooter supports any HTML attribute that's normally supported
-                  by <code className="nx-code">&lt;div&gt;</code>.
+                  by <NxCode>&lt;div&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>

--- a/gallery/src/components/NxGlobalSidebarFooter/NxGlobalSidebarFooterPage.tsx
+++ b/gallery/src/components/NxGlobalSidebarFooter/NxGlobalSidebarFooterPage.tsx
@@ -5,9 +5,10 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+
 import CodeExample from '../../CodeExample';
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode, NxTable, NxTile, NxH2, NxH3, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 const NxGlobalSidebarFooterExample = require('./NxGlobalSidebarFooterExample.tsx?raw'),
     NxGlobalSidebarFooterMinimalExample = require('./NxGlobalSidebarFooterMinimalExample.tsx?raw');

--- a/gallery/src/components/NxGlobalSidebarFooter/NxGlobalSidebarFooterPage.tsx
+++ b/gallery/src/components/NxGlobalSidebarFooter/NxGlobalSidebarFooterPage.tsx
@@ -5,10 +5,11 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+import { NxP, NxCode, NxTable, NxTile, NxH2, NxH3, NxTextLink } from '@sonatype/react-shared-components';
+
+import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import CodeExample from '../../CodeExample';
-import { NxP, NxCode, NxTable, NxTile, NxH2, NxH3, NxTextLink } from '@sonatype/react-shared-components';
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 const NxGlobalSidebarFooterExample = require('./NxGlobalSidebarFooterExample.tsx?raw'),
     NxGlobalSidebarFooterMinimalExample = require('./NxGlobalSidebarFooterMinimalExample.tsx?raw');

--- a/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
+++ b/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxIndeterminatePaginationExample from './NxIndeterminatePaginationExample';

--- a/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
+++ b/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxIndeterminatePaginationExample from './NxIndeterminatePaginationExample';
 

--- a/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
+++ b/gallery/src/components/NxIndeterminatePagination/NxIndeterminatePaginationPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxIndeterminatePaginationExample from './NxIndeterminatePaginationExample';
 
@@ -16,53 +16,53 @@ const nxIndeterminatePaginationCode = require('./NxIndeterminatePaginationExampl
 const NxIndeterminatePaginationPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         A pagination control for use in cases where the current page number and total number of pages is indeterminate.
         This component simply allows the user to navigate to the next and previous pages.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">onPrevPageSelect</code></td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>onPrevPageSelect</NxCode></NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               The callback handler for when the previous page button is clicked. The mouse event is passed as
               an argument.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">onNextPageSelect</code></td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>onNextPageSelect</NxCode></NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               The callback handler for when the next page button is clicked. The mouse event is passed as
               an argument.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                 HTML div Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              <code className="nx-code">NxIndeterminatePagination</code> supports any HTML attribute that's normally
-              supported by <code className="nx-code">&lt;div&gt;</code> elements.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>NxIndeterminatePagination</NxCode> supports any HTML attribute that's normally
+              supported by <NxCode>&lt;div&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
 
     </GalleryDescriptionTile>
 
@@ -70,7 +70,7 @@ const NxIndeterminatePaginationPage = () =>
                         id="nx-indeterminate-pagination-example"
                         liveExample={NxIndeterminatePaginationExample}
                         codeExamples={nxIndeterminatePaginationCode}>
-      An <code className="nx-code">NxIndeterminatePagination</code> component.
+      An <NxCode>NxIndeterminatePagination</NxCode> component.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
+++ b/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxLoadErrorSimpleExample from './NxLoadErrorSimpleExample';

--- a/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
+++ b/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxLoadErrorSimpleExample from './NxLoadErrorSimpleExample';
 import NxLoadErrorNoCloseExample from './NxLoadErrorNoCloseExample';

--- a/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
+++ b/gallery/src/components/NxLoadError/NxLoadErrorPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxLoadErrorSimpleExample from './NxLoadErrorSimpleExample';
 import NxLoadErrorNoCloseExample from './NxLoadErrorNoCloseExample';
@@ -21,55 +22,55 @@ const retryLongMessageSourceCode = require('./NxLoadErrorRetryExample?raw');
 const NxLoadErrorPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Error message with optional Retry button</p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">error</td>
-            <td className="nx-cell">string | JSX</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      <NxP>Error message with optional Retry button</NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>error</NxTable.Cell>
+            <NxTable.Cell>string | JSX</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A message that represents an error that occurred.  If null or undefined, NxLoadError will not render
               anything
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">titleMessage</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>titleMessage</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A message to display before the error output. Defaults to 'An error occurred loading data.'
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">retryHandler</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>retryHandler</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If this is defined, a Retry button will be rendered which executes this function when clicked
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onClose</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onClose</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A handler that dismisses the alert when called.
-              See <a href="#/page/NxAlert"><code className="nx-code">NxAlert</code></a> for details. This never
-              be specified at the same time as <code className="nx-code">retryHandler</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              See <NxTextLink href="#/page/NxAlert"><NxCode>NxAlert</NxCode></NxTextLink> for details. This never
+              be specified at the same time as <NxCode>retryHandler</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Standard Example with Retry Button"
@@ -77,16 +78,16 @@ const NxLoadErrorPage = () =>
                         codeExamples={retrySourceCode}
                         liveExample={NxLoadErrorRetryExample}>
       In this example, the error is cleared on retry. Note that
-      the <code className="nx-code">NxLoadError</code> component
+      the <NxCode>NxLoadError</NxCode> component
       disappears when that happens. This is the most common usage
-      of <code className="nx-code">NxLoadError</code>.
+      of <NxCode>NxLoadError</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Example with Close Button"
                         codeExamples={simpleSourceCode}
                         liveExample={NxLoadErrorSimpleExample}>
-      This example demonstrates a basic <code className="nx-code">NxLoadError</code> for cases where a Retry action
-      does not make sense. In most cases, when an <code className="nx-code">NxLoadError</code> does
+      This example demonstrates a basic <NxCode>NxLoadError</NxCode> for cases where a Retry action
+      does not make sense. In most cases, when an <NxCode>NxLoadError</NxCode> does
       not have a Retry button, it should have a Close button. Additionally, this example demonstrates that the
       error message may be JSX as opposed to just a simple string
     </GalleryExampleTile>
@@ -94,11 +95,11 @@ const NxLoadErrorPage = () =>
     <GalleryExampleTile title="Example without Close Button"
                         codeExamples={noCloseSourceCode}
                         liveExample={NxLoadErrorNoCloseExample}>
-      This example demonstrates an <code className="nx-code">NxLoadError</code> which has neither a Retry button nor a
+      This example demonstrates an <NxCode>NxLoadError</NxCode> which has neither a Retry button nor a
       Close button. This arrangement should only be used for cases where both of the following are true:
       <ol>
         <li>
-          The <code className="nx-code">NxLoadError</code> is the only component within the main area of the page.
+          The <NxCode>NxLoadError</NxCode> is the only component within the main area of the page.
         </li>
         <li>
           Retrying the load would not help.

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxLoadWrapperErrorRetryExample from './NxLoadWrapperErrorRetryExample';

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxLoadWrapperErrorRetryExample from './NxLoadWrapperErrorRetryExample';
 import NxLoadWrapperLoadingExample from './NxLoadWrapperLoadingExample';

--- a/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
+++ b/gallery/src/components/NxLoadWrapper/NxLoadWrapperPage.tsx
@@ -5,9 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxLoadWrapperErrorRetryExample from './NxLoadWrapperErrorRetryExample';
 import NxLoadWrapperLoadingExample from './NxLoadWrapperLoadingExample';
@@ -20,53 +20,53 @@ const errorRetrySourceCode = require('./NxLoadWrapperErrorRetryExample?raw');
 const NxLoadWrapperPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         A component that will display either a loading spinner, an error message, or the specified child VDOM
-      </p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">error</td>
-            <td className="nx-cell">string | JSX</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>error</NxTable.Cell>
+            <NxTable.Cell>string | JSX</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A message that represents an error that occurred.  If defined, will be rendered via NxLoadError
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">loading</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>loading</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If true, and error is unset, a loading spinner will be rendered via NxLoadingSpinner
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">VDOM</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">VDOM to render if loading is false and error is not set</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">retryHandler</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
-              A Retry button will be rendered in the <code className="nx-code">NxLoadError</code> which
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>VDOM</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>VDOM to render if loading is false and error is not set</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>retryHandler</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
+              A Retry button will be rendered in the <NxCode>NxLoadError</NxCode> which
               executes this function when clicked.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
       <NxP>
         <NxCode>NxLoadWrapper</NxCode> is most often used inside of <NxCode>.nx-page-main</NxCode> or one of its
         descendants. However there are cases where it makes sense to use it at a higher level in order to control
@@ -79,24 +79,24 @@ const NxLoadWrapperPage = () =>
     <GalleryExampleTile title="Renders children when not loading or in error"
                         liveExample={NxLoadWrapperChildrenExample}
                         codeExamples={childrenSourceCode}>
-      An <code className="nx-code">NxLoadWrapper</code> in which
-      neither <code className="nx-code">loading</code> nor <code className="nx-code">error</code> are
+      An <NxCode>NxLoadWrapper</NxCode> in which
+      neither <NxCode>loading</NxCode> nor <NxCode>error</NxCode> are
       set. As a result, the children are rendered.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Loading"
                         liveExample={NxLoadWrapperLoadingExample}
                         codeExamples={loadingSourceCode}>
-      An <code className="nx-code">NxLoadWrapper</code> in which the <code className="nx-code">loading</code> flag is
+      An <NxCode>NxLoadWrapper</NxCode> in which the <NxCode>loading</NxCode> flag is
       set, and thus the loading spinner is visible.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Error with retry button"
                         liveExample={NxLoadWrapperErrorRetryExample}
                         codeExamples={errorRetrySourceCode}>
-      An <code className="nx-code">NxLoadWrapper</code> in which the <code className="nx-code">error</code> property
-      is set along with a <code className="nx-code">retryHandler</code>, and thus
-      an <code className="nx-code">NxErrorAlert</code> is rendered.
+      An <NxCode>NxLoadWrapper</NxCode> in which the <NxCode>error</NxCode> property
+      is set along with a <NxCode>retryHandler</NxCode>, and thus
+      an <NxCode>NxErrorAlert</NxCode> is rendered.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
+++ b/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
@@ -6,8 +6,9 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import NxLoadingSpinnerExample from './NxLoadingSpinnerExample';
 
 const sourceCode = require('./NxLoadingSpinnerExample?raw');

--- a/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
+++ b/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxLoadingSpinnerExample from './NxLoadingSpinnerExample';

--- a/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
+++ b/gallery/src/components/NxLoadingSpinner/NxLoadingSpinnerPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-
+import { NxP } from '@sonatype/react-shared-components';
 import NxLoadingSpinnerExample from './NxLoadingSpinnerExample';
 
 const sourceCode = require('./NxLoadingSpinnerExample?raw');
@@ -15,8 +15,8 @@ const sourceCode = require('./NxLoadingSpinnerExample?raw');
 const NxLoadingSpinnerPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Loading Spinner with caption</p>
-      <p className="nx-p">Props: none</p>
+      <NxP>Loading Spinner with caption</NxP>
+      <NxP>Props: none</NxP>
     </GalleryDescriptionTile>
     <GalleryExampleTile title="General Example"
                         codeExamples={sourceCode}

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -5,6 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+
 import {
   NxTable,
   NxInfoAlert,
@@ -14,8 +15,8 @@ import {
   NxWarningAlert,
   NxH3
 } from '@sonatype/react-shared-components';
-
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import NxModalSimpleExample from './NxModalSimpleExample';
 import NxModalAlertExample from './NxModalAlertExample';
 import NxModalFormExample from './NxModalFormExample';

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -5,7 +5,6 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import {
   NxTable,
   NxInfoAlert,
@@ -15,6 +14,7 @@ import {
   NxWarningAlert,
   NxH3
 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxModalSimpleExample from './NxModalSimpleExample';

--- a/gallery/src/components/NxModal/NxModalPage.tsx
+++ b/gallery/src/components/NxModal/NxModalPage.tsx
@@ -5,7 +5,15 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxCode, NxP, NxTextLink, NxWarningAlert } from '@sonatype/react-shared-components';
+import {
+  NxTable,
+  NxInfoAlert,
+  NxCode,
+  NxP,
+  NxTextLink,
+  NxWarningAlert,
+  NxH3
+} from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import NxModalSimpleExample from './NxModalSimpleExample';
@@ -31,38 +39,38 @@ export default function NxModalPage() {
     <>
       <GalleryDescriptionTile>
         <NxP>
-          <code className="nx-code">NxModal</code> is the preferred way to handle modals. It creates a foreground modal
+          <NxCode>NxModal</NxCode> is the preferred way to handle modals. It creates a foreground modal
           window along with a backdrop mask over the rest of the page.
         </NxP>
-        <h3>Props</h3>
-        <table className="nx-table">
-          <thead>
-            <tr className="nx-table-row">
-              <th className="nx-cell nx-cell--header">Prop</th>
-              <th className="nx-cell nx-cell--header">Type</th>
-              <th className="nx-cell nx-cell--header">Required</th>
-              <th className="nx-cell nx-cell--header">Default</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell">className</td>
-              <td className="nx-cell">string</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">
-                Any <code className="nx-code">className</code> attributes passed in on
-                the <code className="nx-code">NxModal</code> element will be added to
-                the <code className="nx-code">nx-modal</code> class on the modal div.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onCancel</td>
-              <td className="nx-cell">Function ((Event) =&gt; void)</td>
-              <td className="nx-cell">Yes</td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">
+        <NxH3>Props</NxH3>
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Default</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>className</NxTable.Cell>
+              <NxTable.Cell>string</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
+                Any <NxCode>className</NxCode> attributes passed in on
+                the <NxCode>NxModal</NxCode> element will be added to
+                the <NxCode>nx-modal</NxCode> class on the modal div.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onCancel</NxTable.Cell>
+              <NxTable.Cell>Function ((Event) =&gt; void)</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 <NxP>
                   A callback to be called when the browser's native <NxCode>cancel</NxCode> event for the
                   modal's <NxCode>HTMLDialogElement</NxCode> is fired. The circumstances which will fire this event
@@ -86,171 +94,171 @@ export default function NxModalPage() {
                   call <NxCode>preventDefault</NxCode> on any ESC keydowns that they handle in order to prevent the
                   modal from also handling them. <NxCode>NxDropdown</NxCode> does this automatically.
                 </NxP>
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onClose</td>
-              <td className="nx-cell">Function (() =&gt; void)</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onClose</NxTable.Cell>
+              <NxTable.Cell>Function (() =&gt; void)</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 <NxWarningAlert>
                   Deprecated. Old alias for <NxCode>onCancel</NxCode>. Using both at the same time is not supported.
                 </NxWarningAlert>
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">variant</td>
-              <td className="nx-cell">"wide" | "narrow" | "normal"</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">"normal"</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>variant</NxTable.Cell>
+              <NxTable.Cell>"wide" | "narrow" | "normal"</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>"normal"</NxTable.Cell>
+              <NxTable.Cell>
                 This prop specifies a style variant for the modal. Currently, variants only differ in width.
                 "wide" modals are 1000px wide, "normal" modals are 800px wide, and "narrow" modals are 600px wide.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://reactjs.org/docs/dom-elements.html#all-supported-html-attributes">
                   HTML Attributes
                 </NxTextLink>
-              </td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 NxModal supports any html attribute that's normally supported by
-                {' '}<code className="nx-code">&lt;div&gt;</code> elements.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <h3>Modal Style Classes</h3>
-        <table className="nx-table nx-table--gallery-props">
-          <thead>
-            <tr className="nx-table-row nx-table-row--header">
-              <th className="nx-cell nx-cell--header">Class</th>
-              <th className="nx-cell nx-cell--header">Location</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-modal-header</code></td>
-              <td className="nx-cell">HTML <code className="nx-code">header</code> element</td>
-              <td className="nx-cell">
-                The <code className="nx-code">NxModal</code> component supports any component that adheres to the
+                {' '}<NxCode>&lt;div&gt;</NxCode> elements.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
+        <NxH3>Modal Style Classes</NxH3>
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Class</NxTable.Cell>
+              <NxTable.Cell>Location</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-modal-header</NxCode></NxTable.Cell>
+              <NxTable.Cell>HTML <NxCode>header</NxCode> element</NxTable.Cell>
+              <NxTable.Cell>
+                The <NxCode>NxModal</NxCode> component supports any component that adheres to the
                 RSC guidelines for margin and padding. Most commonly, components will be included in
-                an <code className="nx-code">H2</code> title tag (with
-                the <code className="nx-code">.nx-h2</code> style associated with it)
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-modal-content</code></td>
-              <td className="nx-cell">Wrapping the modal content</td>
-              <td className="nx-cell">
+                an <NxCode>H2</NxCode> title tag (with
+                the <NxCode>.nx-h2</NxCode> style associated with it)
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-modal-content</NxCode></NxTable.Cell>
+              <NxTable.Cell>Wrapping the modal content</NxTable.Cell>
+              <NxTable.Cell>
                 All content between the header and footer should be wrapped in a div with
-                the <code className="nx-code">.nx-modal-content</code> className. This element (and thus the modal
+                the <NxCode>.nx-modal-content</NxCode> className. This element (and thus the modal
                 overall) will shrink to fit the content, or expand vertically until the modal reaches its maximum height
                 (determined as a distance from the viewport edges). If the contents of
-                the <code className="nx-code">nx-modal-content</code> continue to grow beyond that height, it
+                the <NxCode>nx-modal-content</NxCode> continue to grow beyond that height, it
                 introduces a scrollbar.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-footer</code></td>
-              <td className="nx-cell">HTML <code className="nx-code">footer</code> element</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-footer</NxCode></NxTable.Cell>
+              <NxTable.Cell>HTML <NxCode>footer</NxCode> element</NxTable.Cell>
+              <NxTable.Cell>
                 Each modal should contain a footer containing buttons for various actions. At a minimum, there
                 should be a button that enables the user to close the modal. Further, the footer may contain
-                an <code className="nx-code">NxAlert</code> as would typically be the case after a form submission
+                an <NxCode>NxAlert</NxCode> as would typically be the case after a form submission
                 which resulted in an error.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-modal-content--tabs</code></td>
-              <td className="nx-cell">Modifier of <code className="nx-code">.nx-modal-content</code></td>
-              <td className="nx-cell">
-                A modifier class that must be added to <code className="nx-code">.nx-modal-content</code> when
-                you want to use tabs within an <code className="nx-code">NxModal</code> as the sole contents of
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-modal-content--tabs</NxCode></NxTable.Cell>
+              <NxTable.Cell>Modifier of <NxCode>.nx-modal-content</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                A modifier class that must be added to <NxCode>.nx-modal-content</NxCode> when
+                you want to use tabs within an <NxCode>NxModal</NxCode> as the sole contents of
                 the modal body. The modifier keeps the tabs "sticky" while allowing the tab content to scroll.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
         <NxInfoAlert>
           Note: Placing content into the modal which exceeds its horizontal bounds is not supported. The resulting
           layout is unspecified.
         </NxInfoAlert>
-        <h3>Accessibility</h3>
-        <p className="nx-p">
-          <code className="nx-code">NxModal</code> uses the <code className="nx-code">dialog</code> role and needs
-          to have a label specified by the <code className="nx-code">aria-labelledby</code> or
-          {' '}<code className="nx-code">aria-label</code> attribute. Because the value
-          of <code className="nx-code">aria-labelledby</code> or <code className="nx-code">aria-label</code> is
-          typically the same as the modal header text <code className="nx-code">aria-labelledby</code> is the DRYer
+        <NxH3>Accessibility</NxH3>
+        <NxP>
+          <NxCode>NxModal</NxCode> uses the <NxCode>dialog</NxCode> role and needs
+          to have a label specified by the <NxCode>aria-labelledby</NxCode> or
+          {' '}<NxCode>aria-label</NxCode> attribute. Because the value
+          of <NxCode>aria-labelledby</NxCode> or <NxCode>aria-label</NxCode> is
+          typically the same as the modal header text <NxCode>aria-labelledby</NxCode> is the DRYer
           attribute.
-        </p>
+        </NxP>
         <NxWarningAlert>
-          Note: While the use of <code className="nx-code">aria-labelledby</code>
-          {' '}(or <code className="nx-code">aria-label</code>) is not required by the component it should be
+          Note: While the use of <NxCode>aria-labelledby</NxCode>
+          {' '}(or <NxCode>aria-label</NxCode>) is not required by the component it should be
           considered mandatory in order to comply with accessibility guidelines.
         </NxWarningAlert>
-        <table className="nx-table nx-table--gallery-props">
-          <thead>
-            <tr className="nx-table-row nx-table-row--header">
-              <th className="nx-cell nx-cell--header">Attribute</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">aria-labelledby</code></td>
-              <td className="nx-cell">
-                When the <code className="nx-code">aria-labelledby</code> attribute is used an ID is applied to the
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Attribute</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>aria-labelledby</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                When the <NxCode>aria-labelledby</NxCode> attribute is used an ID is applied to the
                 HTML element that will be providing the label information (typically the modal title H3), the ID is
-                referenced by <code className="nx-code">aria-labelledby</code>. See examples below.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">aria-label</code></td>
-              <td className="nx-cell">
-                When the <code className="nx-code">aria-label</code> attribute is used the text is added directly to the
+                referenced by <NxCode>aria-labelledby</NxCode>. See examples below.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>aria-label</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                When the <NxCode>aria-label</NxCode> attribute is used the text is added directly to the
                 attribute. See the NxModal Example with NxAlert example below.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
       </GalleryDescriptionTile>
 
       <GalleryExampleTile title="Simple NxModal Example"
                           id="nx-modal-simple-example"
                           liveExample={NxModalSimpleExample}
                           codeExamples={NxModalSimpleSourceCode}>
-        A basic example of an <code className="nx-code">NxModal</code>. Click the button to open the modal. Note that
+        A basic example of an <NxCode>NxModal</NxCode>. Click the button to open the modal. Note that
         this modal has sufficient content to induce scrolling (on most monitors). You will see in other examples that
         when modals have smaller contents, the scrollbar does not appear and the modal content area shrinks to fit.
-        This example uses <code className="nx-code">aria-labelledby</code>.
+        This example uses <NxCode>aria-labelledby</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal Example with NxAlert"
                           liveExample={NxModalAlertExample}
                           codeExamples={NxModalAlertSourceCode}>
-        An example of an <code className="nx-code">NxModal</code> containing
-        an <code className="nx-code">NxAlert</code>. As shown in this example, the most appropriate accessibility role
+        An example of an <NxCode>NxModal</NxCode> containing
+        an <NxCode>NxAlert</NxCode>. As shown in this example, the most appropriate accessibility role
         in this scenario is <NxCode>alertdialog</NxCode>.  Note that this is actually the only role you'd ever want to
         explicitly add to an <NxCode>NxModal</NxCode>. In non-alert cases, <NxCode>NxModal</NxCode> takes on the
         semantics of the <NxCode>dialog</NxCode> role as one would expect.
-        This example uses <code className="nx-code">aria-label</code>.
+        This example uses <NxCode>aria-label</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal with stacked modal example"
                           id="nx-modal-stacked-example"
                           liveExample={NxModalStackedExample}
                           codeExamples={NxModalStackedSourceCode}>
-        <code className="nx-code">NxModal</code> also supports stacked or nested modals. A second modal can be
-        generated from inside of an <code className="nx-code">NxModal</code>.
-        This example uses <code className="nx-code">aria-labelledby</code>.
+        <NxCode>NxModal</NxCode> also supports stacked or nested modals. A second modal can be
+        generated from inside of an <NxCode>NxModal</NxCode>.
+        This example uses <NxCode>aria-labelledby</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal example with other ESC-controller elements"
@@ -262,43 +270,43 @@ export default function NxModalPage() {
         component all working together such that pressing ESC only closes one of them at a time. Note
         that <NxCode>NxDropdown</NxCode> is designed so that pressing ESC when it is open only closes it if it is
         focused.
-        This example uses <code className="nx-code">aria-labelledby</code>.
+        This example uses <NxCode>aria-labelledby</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal Example with form"
                           id="nx-modal-form-example"
                           liveExample={NxModalFormExample}
                           codeExamples={NxModalFormSourceCode}>
-        <code className="nx-code">NxModal</code> also supports inclusion and styling of form elements.
-        This example uses <code className="nx-code">aria-labelledby</code>.
+        <NxCode>NxModal</NxCode> also supports inclusion and styling of form elements.
+        This example uses <NxCode>aria-labelledby</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxModal Example with form and error styling"
                           id="nx-modal-form-with-alert-example"
                           liveExample={NxModalFormErrorExample}
                           codeExamples={NxModalFormErrorSourceCode}>
-        This <code className="nx-code">NxModal</code> also contains a form, but additionally demonstrates the typical
+        This <NxCode>NxModal</NxCode> also contains a form, but additionally demonstrates the typical
         way that an error upon the submission of said form would be handled: with
-        an <code className="nx-code">NxErrorAlert</code> in the footer.
-        This example uses <code className="nx-code">aria-labelledby</code>.
+        an <NxCode>NxErrorAlert</NxCode> in the footer.
+        This example uses <NxCode>aria-labelledby</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Wide NxModal Example"
                           id="nx-modal-wide-example"
                           liveExample={NxModalExtraWideExample}
                           codeExamples={NxModalExtraWideSourceCode}>
-        A demonstration of the <code className="nx-code">wide</code> styles
-        for <code className="nx-code">NxModal</code>.
-        This example uses <code className="nx-code">aria-labelledby</code>.
+        A demonstration of the <NxCode>wide</NxCode> styles
+        for <NxCode>NxModal</NxCode>.
+        This example uses <NxCode>aria-labelledby</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Narrow NxModal Example"
                           id="nx-modal-narrow-example"
                           liveExample={NxModalNarrowExample}
                           codeExamples={NxModalNarrowSourceCode}>
-        A demonstration of the <code className="nx-code">narrow</code> styles
-        for <code className="nx-code">NxModal</code>.
-        This example uses <code className="nx-code">aria-labelledby</code>.
+        A demonstration of the <NxCode>narrow</NxCode> styles
+        for <NxCode>NxModal</NxCode>.
+        This example uses <NxCode>aria-labelledby</NxCode>.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
+++ b/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxH3, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxNexusPageHeaderExample from './NxNexusPageHeaderExample';
 import NxNexusPageHeaderCustomLogoExample from './NxNexusPageHeaderCustomLogoExample';

--- a/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
+++ b/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
@@ -7,13 +7,13 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP, NxH3, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxNexusPageHeaderExample from './NxNexusPageHeaderExample';
 import NxNexusPageHeaderCustomLogoExample from './NxNexusPageHeaderCustomLogoExample';
 import NxNexusPageHeaderMetaExample from './NxNexusPageHeaderMetaExample';
 import NxNexusPageHeaderVersionExample from './NxNexusPageHeaderVersionExample';
 import NxNexusPageHeaderMinimalExample from './NxNexusPageHeaderMinimalExample';
-import { NxCode } from '@sonatype/react-shared-components';
 
 const nxNexusPageHeaderExampleCode = require('./NxNexusPageHeaderExample?raw');
 const nxNexusPageHeaderCustomLogoExampleCode = require('./NxNexusPageHeaderCustomLogoExample?raw');
@@ -24,109 +24,109 @@ const nxNexusPageHeaderMinimalExampleCode = require('./NxNexusPageHeaderMinimalE
 const NxNexusPageHeaderPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxNexusPageHeader</code> is a React component encapsulating the Sonatype Nexus
+      <NxP>
+        <NxCode>NxNexusPageHeader</NxCode> is a React component encapsulating the Sonatype Nexus
         branded page header logo and structure. This header should only be used for products in the Sonatype Nexus
         family.
-      </p>
-      <h3 className="nx-h3 nx-tile__subsection-header">Props</h3>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">productInfo</td>
-            <td className="nx-cell">object</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
-              An object containing at least one field: <code className="nx-code">name</code>, the product
+      </NxP>
+      <NxH3>Props</NxH3>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>productInfo</NxTable.Cell>
+            <NxTable.Cell>object</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
+              An object containing at least one field: <NxCode>name</NxCode>, the product
               name to display in the header. Additionally, this object may contain
-              a <code className="nx-code">meta</code> field which might contain information about the license
+              a <NxCode>meta</NxCode> field which might contain information about the license
               (as it does in IQ), or other information about the product (e.g. beta, pre-release)
-              and a <code className="nx-code">version</code> field holding the product's version number to display.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">homeLink</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+              and a <NxCode>version</NxCode> field holding the product's version number to display.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>homeLink</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A URL (typically relative) that navigates to the home page of the application. If this prop is
               present, the logo in the header will be a link to this home page.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">logoPath</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>logoPath</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               The path to the image file that will display as the logo. If no URL is provided the default white hexagon
               on grey background will appear.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">links</td>
-            <td className="nx-cell">array</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>links</NxTable.Cell>
+            <NxTable.Cell>array</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               An optional array of objects describing navigation links to display in the middle section of the header.
-              Each link object should contain a <code className="nx-code">name</code> to be displayed and
-              a <code className="nx-code">href</code> for the link. Additionally, at most one link should include
-              a <code className="nx-code">current</code> flag set to true indicating that it should be styled as
+              Each link object should contain a <NxCode>name</NxCode> to be displayed and
+              a <NxCode>href</NxCode> for the link. Additionally, at most one link should include
+              a <NxCode>current</NxCode> flag set to true indicating that it should be styled as
               the currently active link.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">ReactNode</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>ReactNode</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Optional additional JSX content that will be displayed at the right end of the header.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <h3>Nexus Page Header Style Classes</h3>
-      <p className="nx-p">
-        Note that <code className="nx-code">NxNexusPageHeader</code> shares much of its styling with
-        {' '}<code className="nx-code">NxPageHeader</code>. If you don't see the class you're looking for described
-        below check out <a className="nx-text-link" href="#Pages/NxPageHeader/">NxPageHeader</a>.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">.nx-page-header__extra-content-divider</td>
-            <td className="nx-cell">Child Element</td>
-            <td className="nx-cell">
-              Applied to a <code className="nx-code">&lt;div&gt;</code> to create a vertical rule between children
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
+      <NxH3>Nexus Page Header Style Classes</NxH3>
+      <NxP>
+        Note that <NxCode>NxNexusPageHeader</NxCode> shares much of its styling with
+        {' '}<NxCode>NxPageHeader</NxCode>. If you don't see the class you're looking for described
+        below check out <NxTextLink href="#Pages/NxPageHeader/">NxPageHeader</NxTextLink>.
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>.nx-page-header__extra-content-divider</NxTable.Cell>
+            <NxTable.Cell>Child Element</NxTable.Cell>
+            <NxTable.Cell>
+              Applied to a <NxCode>&lt;div&gt;</NxCode> to create a vertical rule between children
               rendered in the extra content area at the right end of the header.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p className="nx-p">
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
+      <NxP>
         Note that the headers in the examples below have been tweaked to display in the normal page flow for the sake
         of demonstration.  Normally they would automatically display at the top of the viewport using CSS fixed
         positioning.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         It is the responsibility of calling code to ensure the that content included in the header fits in a single
         row at all supported resolutions. Behavior of this component when content exceeds the space allowed is
         unspecified.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Nexus Page Header with custom logo"
@@ -134,7 +134,7 @@ const NxNexusPageHeaderPage = () =>
                         codeExamples={nxNexusPageHeaderCustomLogoExampleCode}
                         liveExample={NxNexusPageHeaderCustomLogoExample}
                         defaultCheckeredBackground={true}>
-      An instance of <code className="nx-code">NxNexusPageHeader</code> that demonstrates how to load a custom logo.
+      An instance of <NxCode>NxNexusPageHeader</NxCode> that demonstrates how to load a custom logo.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Nexus Page Header"
@@ -142,7 +142,7 @@ const NxNexusPageHeaderPage = () =>
                         codeExamples={nxNexusPageHeaderExampleCode}
                         liveExample={NxNexusPageHeaderExample}
                         defaultCheckeredBackground={true}>
-      An instance of <code className="nx-code">NxNexusPageHeader</code> with default branding, navigation and
+      An instance of <NxCode>NxNexusPageHeader</NxCode> with default branding, navigation and
       examples of extra content. A note about the extra content: icon-only buttons added in this area will
       be of the smaller size that is also present in certain other areas (action buttons
       within <NxCode>nx-list</NxCode>, for example). Placing these buttons alongside other buttons which have actual
@@ -154,7 +154,7 @@ const NxNexusPageHeaderPage = () =>
                         codeExamples={nxNexusPageHeaderMetaExampleCode}
                         liveExample={NxNexusPageHeaderMetaExample}
                         defaultCheckeredBackground={true}>
-      An instance of <code className="nx-code">NxNexusPageHeader</code> with default branding, meta info, and
+      An instance of <NxCode>NxNexusPageHeader</NxCode> with default branding, meta info, and
       navigation.
     </GalleryExampleTile>
 
@@ -163,7 +163,7 @@ const NxNexusPageHeaderPage = () =>
                         codeExamples={nxNexusPageHeaderVersionExampleCode}
                         liveExample={NxNexusPageHeaderVersionExample}
                         defaultCheckeredBackground={true}>
-      <code className="nx-code">NxNexusPageHeader</code> with default branding, version, and navigation.
+      <NxCode>NxNexusPageHeader</NxCode> with default branding, version, and navigation.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Nexus Page Header Minimal"
@@ -171,7 +171,7 @@ const NxNexusPageHeaderPage = () =>
                         codeExamples={nxNexusPageHeaderMinimalExampleCode}
                         liveExample={NxNexusPageHeaderMinimalExample}
                         defaultCheckeredBackground={true}>
-      A minimal instance of <code className="nx-code">NxNexusPageHeader</code> with default branding.
+      A minimal instance of <NxCode>NxNexusPageHeader</NxCode> with default branding.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
+++ b/gallery/src/components/NxNexusPageHeader/NxNexusPageHeaderPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxH3, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxNexusPageHeaderExample from './NxNexusPageHeaderExample';

--- a/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipPage.tsx
+++ b/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipPage.tsx
@@ -5,13 +5,13 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
+import { NxCode, NxP, NxTextLink, NxWarningAlert } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxOverflowTooltipExample from './NxOverflowTooltipExample';
 import NxOverflowTooltipDescendantExample from './NxOverflowTooltipDescendantExample';
 import NxOverflowTooltipDynamicExample from './NxOverflowTooltipDynamicExample';
-import { NxWarningAlert } from '@sonatype/react-shared-components';
 
 import './NxOverflowTooltipExample.scss';
 

--- a/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipPage.tsx
+++ b/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
+import { NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxOverflowTooltipExample from './NxOverflowTooltipExample';
@@ -23,20 +23,20 @@ export default function NxOverflowTooltipPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
+        <NxP>
           For elements that truncate overflowing text, it is often desired to have a tooltip that repeats the text,
           but which is only active if the text is in fact truncated. This component provides that functionality.
-        </p>
-        <p className="nx-p">
+        </NxP>
+        <NxP>
           The props that this component takes are effectively the same as those
-          of <a className="nx-text-link" href="#/pages/NxTooltip"><code className="nx-code">NxTooltip</code></a>,
-          however there is a behavioral difference in regards to the <code className="nx-code">title</code> prop.
+          of <NxTextLink href="#/pages/NxTooltip"><NxCode>NxTooltip</NxCode></NxTextLink>,
+          however there is a behavioral difference in regards to the <NxCode>title</NxCode> prop.
           In typical use of this component, the title will be unspecified. This leaves it up to the component
           itself to determine the tooltip contents based on the "shallow-rendered" text content of the component's
           children. In cases where that does not accomplish the desired effect,
-          a <code className="nx-code">title</code> may still be specified explicitly. Additionally,
-          the <code className="nx-code">open</code> prop is not supported on this component.
-        </p>
+          a <NxCode>title</NxCode> may still be specified explicitly. Additionally,
+          the <NxCode>open</NxCode> prop is not supported on this component.
+        </NxP>
         <NxWarningAlert>
           Changes after initial render which affect size of the child element's content without affecting either the
           child element's text or the child element's size will not be detected. For instance, if an icon is added
@@ -50,9 +50,9 @@ export default function NxOverflowTooltipPage() {
                           id="nx-overflow-tooltip-simple-example"
                           codeExamples={overflowTooltipsExampleCode}
                           liveExample={NxOverflowTooltipExample}>
-        This example demonstrates an <code className="nx-code">nx-list</code> which
-        uses <code className="nx-code">NxOverflowTooltip</code> on each child element. Notice that on the last item
-        in the example, the <code className="nx-code">title</code> must be explicitly specified as the
+        This example demonstrates an <NxCode>nx-list</NxCode> which
+        uses <NxCode>NxOverflowTooltip</NxCode> on each child element. Notice that on the last item
+        in the example, the <NxCode>title</NxCode> must be explicitly specified as the
         automatically-computed title would miss the "Foo" text contributed by the child component.
       </GalleryExampleTile>
 
@@ -60,11 +60,11 @@ export default function NxOverflowTooltipPage() {
                           id="nx-overflow-tooltip-descendant-example"
                           codeExamples={overflowTooltipsDescendantExampleCode}
                           liveExample={NxOverflowTooltipDescendantExample}>
-        <code className="nx-code">NxOverflowTooltip</code> will trigger not only if its immediate child element
+        <NxCode>NxOverflowTooltip</NxCode> will trigger not only if its immediate child element
         has overflow, but also if any of its descendants have overflow. This example demonstrates that by
-        placing <code className="nx-code">NxOverflowTooltip</code> around
-        the <code className="nx-code">nx-list__item</code>s rather than
-        the <code className="nx-code">nx-list__text</code> elements where the overflow actually occurs
+        placing <NxCode>NxOverflowTooltip</NxCode> around
+        the <NxCode>nx-list__item</NxCode>s rather than
+        the <NxCode>nx-list__text</NxCode> elements where the overflow actually occurs
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Dynamic example"
@@ -72,7 +72,7 @@ export default function NxOverflowTooltipPage() {
                           codeExamples={overflowTooltipsDynamicExampleCode}
                           liveExample={NxOverflowTooltipDynamicExample}>
         This example displays user-controllable text in a paragraph wrapped
-        in <code className="nx-code">NxOverflowTooltip</code>. Observe that the tooltip enables/disables
+        in <NxCode>NxOverflowTooltip</NxCode>. Observe that the tooltip enables/disables
         appropriately as the text and/or container size (resizable by adjusting the browser window width) changes.
       </GalleryExampleTile>
     </>

--- a/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipPage.tsx
+++ b/gallery/src/components/NxOverflowTooltip/NxOverflowTooltipPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxP, NxTextLink, NxWarningAlert } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxOverflowTooltipExample from './NxOverflowTooltipExample';

--- a/gallery/src/components/NxPageHeader/NxPageHeaderPage.tsx
+++ b/gallery/src/components/NxPageHeader/NxPageHeaderPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import SimplePageHeaderExample from './SimplePageHeaderExample';

--- a/gallery/src/components/NxPageHeader/NxPageHeaderPage.tsx
+++ b/gallery/src/components/NxPageHeader/NxPageHeaderPage.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 
+import { NxTable, NxCode, NxP, NxH3 } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import SimplePageHeaderExample from './SimplePageHeaderExample';
@@ -28,112 +29,112 @@ const simplePageHeaderExampleCode = require('./SimplePageHeaderExample?raw'),
 const NxPageHeaderPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxPageHeader</code> is a React component encapsulating the standard Sonatype
+      <NxP>
+        <NxCode>NxPageHeader</NxCode> is a React component encapsulating the standard Sonatype
         page header structure and logo.
-      </p>
-      <h3 className="nx-h3 nx-tile__subsection-header">Props</h3>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">productInfo</td>
-            <td className="nx-cell">object</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              An optional object containing at least one field: <code className="nx-code">name</code>, the product
+      </NxP>
+      <NxH3>Props</NxH3>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>productInfo</NxTable.Cell>
+            <NxTable.Cell>object</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              An optional object containing at least one field: <NxCode>name</NxCode>, the product
               name to display in the header. Additionally, this object may contain
-              a <code className="nx-code">version</code> field holding the product's version number to display.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">homeLink</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+              a <NxCode>version</NxCode> field holding the product's version number to display.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>homeLink</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A URL (typically relative) that navigates to the home page of the application. If this prop is
               present, the <q>Sonatype</q> logo in the header will be a link to this home page.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">links</td>
-            <td className="nx-cell">array</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>links</NxTable.Cell>
+            <NxTable.Cell>array</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               An optional array of objects describing navigation links to display in the middle section of the header.
-              Each link object should contain a <code className="nx-code">name</code> to be displayed and
-              a <code className="nx-code">href</code> for the link. Additionally, at most one link should include
-              an <code className="nx-code">current</code> flag set to true indicating that it should be styled as
+              Each link object should contain a <NxCode>name</NxCode> to be displayed and
+              a <NxCode>href</NxCode> for the link. Additionally, at most one link should include
+              an <NxCode>current</NxCode> flag set to true indicating that it should be styled as
               the currently active link.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">ReactNode</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>ReactNode</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Optional additional JSX content that will be displayed at the right end of the header.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p className="nx-p">
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
+      <NxP>
         Note that in each of the following examples, the headers have been tweaked to display in the normal page
         flow for the sake of demonstration. Normally, they would automatically display at the top of the viewport
         using CSS fixed positioning.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         It is the responsibility of calling code to ensure the that content included in the header fits in a single
         row at all supported resolutions. Behavior of this component when content exceeds the space allowed is
         unspecified.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Header"
                         id="nx-page-header-simple-example"
                         codeExamples={simplePageHeaderExampleCode}
                         liveExample={SimplePageHeaderExample}>
-      A minimal instance of <code className="nx-code">NxPageHeader</code> which includes no
+      A minimal instance of <NxCode>NxPageHeader</NxCode> which includes no
       product name, no version, no links, and no additional content.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Header with Product Name"
                         codeExamples={productNamePageHeaderExampleCode}
                         liveExample={ProductNamePageHeaderExample}>
-      An instance of <code className="nx-code">NxPageHeader</code> which includes a product name.
+      An instance of <NxCode>NxPageHeader</NxCode> which includes a product name.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Header with Product Name and Version"
                         codeExamples={productNameAndVersionPageHeaderExampleCode}
                         liveExample={ProductNameAndVersionPageHeaderExample}>
-      An instance of <code className="nx-code">NxPageHeader</code> which includes a product name
+      An instance of <NxCode>NxPageHeader</NxCode> which includes a product name
       and version.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Header with Home Link"
                         codeExamples={homeLinkPageHeaderExampleCode}
                         liveExample={HomeLinkPageHeaderExample}>
-      An instance of <code className="nx-code">NxPageHeader</code> which includes a home link
+      An instance of <NxCode>NxPageHeader</NxCode> which includes a home link
       for the logo.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Header with Links"
                         codeExamples={linksPageHeaderExampleCode}
                         liveExample={LinksPageHeaderExample}>
-      An instance of <code className="nx-code">NxPageHeader</code> which includes links.
+      An instance of <NxCode>NxPageHeader</NxCode> which includes links.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Header with Extra Content"
                         codeExamples={extraContentPageHeaderExampleCode}
                         liveExample={ExtraContentPageHeaderExample}>
-      An instance of <code className="nx-code">NxPageHeader</code> with extra content on the
+      An instance of <NxCode>NxPageHeader</NxCode> with extra content on the
       right-hand side.
     </GalleryExampleTile>
 
@@ -141,7 +142,7 @@ const NxPageHeaderPage = () =>
                         id="nx-page-header-complex-example"
                         codeExamples={complexPageHeaderExampleCode}
                         liveExample={ComplexPageHeaderExample}>
-      An instance of <code className="nx-code">NxPageHeader</code> which includes all features
+      An instance of <NxCode>NxPageHeader</NxCode> which includes all features
       at once.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/components/NxPagination/NxPaginationPage.tsx
+++ b/gallery/src/components/NxPagination/NxPaginationPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxPaginationExample from './NxPaginationExample';
 import NxPaginationEmptyExample from './NxPaginationEmptyExample';
@@ -20,20 +20,20 @@ const nxPaginationCode = require('./NxPaginationExample?raw'),
 const NxPaginationPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Pagination controls are used when there is a great deal of content that needs to be sorted into separate
         "pages" rather than scrolled. The controls offer multiple methods of navigating the paged content, forward and
         backward controls, specific page controls, and an ellipsis control.
-        This component renders pagination buttons contained within an <code className="nx-code">.nx-btn-bar</code>.
-        It is intended to be used within an <code className="nx-code">.nx-footer</code> element.
+        This component renders pagination buttons contained within an <NxCode>.nx-btn-bar</NxCode>.
+        It is intended to be used within an <NxCode>.nx-footer</NxCode> element.
         There are essentially five different "types" of buttons which can appear within the pagination control:
-      </p>
+      </NxP>
       <ul className="nx-list">
         <li className="nx-list__item">
           <span className="nx-list__text">Current page button</span>
           <span className="nx-list__subtext">
             A button for the current page will always be visible and is distinguished via a dark blue background.
-            Clicking this button has no effect - the component's <code className="nx-code">onChange</code> handler
+            Clicking this button has no effect - the component's <NxCode>onChange</NxCode> handler
             does not get triggered.
           </span>
         </li>
@@ -70,62 +70,62 @@ const NxPaginationPage = () =>
           </span>
         </li>
       </ul>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">pageCount</code></td>
-            <td className="nx-cell">Non-negative integer</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">The total number of pages</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">currentPage</code></td>
-            <td className="nx-cell">Non-negative integer</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The currently selected page. Must be null or undefined if <code className="nx-code">pageCount</code>
-              is 0, and must <em>not</em> be null or undefined if <code className="nx-code">pageCount</code> is
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>pageCount</NxCode></NxTable.Cell>
+            <NxTable.Cell>Non-negative integer</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>The total number of pages</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>currentPage</NxCode></NxTable.Cell>
+            <NxTable.Cell>Non-negative integer</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The currently selected page. Must be null or undefined if <NxCode>pageCount</NxCode>
+              is 0, and must <em>not</em> be null or undefined if <NxCode>pageCount</NxCode> is
               greater than 0. Pages are counted in a zero-based manner - that is, the page numbers displayed in the
               UI are one higher than this property specifies.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">onChange</code></td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>onChange</NxCode></NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Handler function which gets called whenever the user selects a different page. Receives the selected
               page as its first argument (using zero-based counting), and the button's click event as its
               second argument.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                 HTML div Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              <code className="nx-code">NxPagination</code> supports any HTML attribute that's normally
-              supported by <code className="nx-code">&lt;div&gt;</code> elements.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p className="nx-p">
-        For an example of an <code className="nx-code">NxPagination</code> component within/connected to a table,
-        see the <a className="nx-text-link" href="#/pages/NxTable"><code className="nx-code">NxTable</code></a> page.
-      </p>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>NxPagination</NxCode> supports any HTML attribute that's normally
+              supported by <NxCode>&lt;div&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
+      <NxP>
+        For an example of an <NxCode>NxPagination</NxCode> component within/connected to a table,
+        see the <NxTextLink className="nx-text-link" href="#/pages/NxTable"><NxCode>NxTable</NxCode></NxTextLink> page.
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="NxPagination Example"
@@ -133,7 +133,7 @@ const NxPaginationPage = () =>
                         liveExample={NxPaginationExample}
                         codeExamples={nxPaginationCode}>
       An interactive example showing all possible types of buttons that can appear within
-      an <code className="nx-code">NxPagination</code> component. Take special note of what happens when within
+      an <NxCode>NxPagination</NxCode> component. Take special note of what happens when within
       the page 36 - 40 range: Since there are no additional pages between that range and the final page (41), no
       ellipsis button is rendered in between.
     </GalleryExampleTile>
@@ -141,8 +141,8 @@ const NxPaginationPage = () =>
     <GalleryExampleTile title="NxPagination Empty Example"
                         liveExample={NxPaginationEmptyExample}
                         codeExamples={nxPaginationEmptyCode}>
-      An example demonstrating that when there are no pages, <code className="nx-code">NxPagination</code> renders
-      an empty <code className="nx-code">nx-btn-bar</code>.
+      An example demonstrating that when there are no pages, <NxCode>NxPagination</NxCode> renders
+      an empty <NxCode>nx-btn-bar</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxPagination Single Page Example"

--- a/gallery/src/components/NxPagination/NxPaginationPage.tsx
+++ b/gallery/src/components/NxPagination/NxPaginationPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxPaginationExample from './NxPaginationExample';

--- a/gallery/src/components/NxPagination/NxPaginationPage.tsx
+++ b/gallery/src/components/NxPagination/NxPaginationPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxPaginationExample from './NxPaginationExample';
 import NxPaginationEmptyExample from './NxPaginationEmptyExample';

--- a/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
+++ b/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 
 import NxPolicyThreatSliderExample from './NxPolicyThreatSliderExample';
 import NxPolicyThreatSliderDisabledExample from './NxPolicyThreatSliderDisabledExample';
@@ -18,43 +19,43 @@ export default function NxPolicyThreatSliderPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">A slider for selecting a range of policy threats (e.g. values between 0 and 10)</p>
-        <table className="nx-table nx-table--gallery-props">
-          <thead>
-            <tr className="nx-table-row">
-              <th className="nx-cell nx-cell--header">Prop</th>
-              <th className="nx-cell nx-cell--header">Type</th>
-              <th className="nx-cell nx-cell--header">Required</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell">value</td>
-              <td className="nx-cell">2-value array of integers between 0 and 10 inclusive</td>
-              <td className="nx-cell">Yes</td>
-              <td className="nx-cell">The values to which to set the range slider handles</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">className</td>
-              <td className="nx-cell">string</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">Optional additional CSS classes to apply</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onChange</td>
-              <td className="nx-cell">Function which accepts 2-value array of integers between 0 and 10 inclusive</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">Callback executed when the user changes the range selection</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">disabled</td>
-              <td className="nx-cell">boolean</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">Set to true to disable interaction with this component.</td>
-            </tr>
-          </tbody>
-        </table>
+        <NxP>A slider for selecting a range of policy threats (e.g. values between 0 and 10)</NxP>
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>value</NxTable.Cell>
+              <NxTable.Cell>2-value array of integers between 0 and 10 inclusive</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell>The values to which to set the range slider handles</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>className</NxTable.Cell>
+              <NxTable.Cell>string</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>Optional additional CSS classes to apply</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onChange</NxTable.Cell>
+              <NxTable.Cell>Function which accepts 2-value array of integers between 0 and 10 inclusive</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>Callback executed when the user changes the range selection</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>disabled</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>Set to true to disable interaction with this component.</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
       </GalleryDescriptionTile>
 
       <GalleryExampleTile title="General Example"
@@ -69,7 +70,7 @@ export default function NxPolicyThreatSliderPage() {
                           id="nx-policy-threat-slider-disabled-example"
                           codeExamples={NxPolicyThreatSliderDisabledCode}
                           liveExample={NxPolicyThreatSliderDisabledExample}>
-        This <code className="nx-code">NxPolicyThreatSlider</code> is disabled.
+        This <NxCode>NxPolicyThreatSlider</NxCode> is disabled.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
+++ b/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxPolicyThreatSliderExample from './NxPolicyThreatSliderExample';
 import NxPolicyThreatSliderDisabledExample from './NxPolicyThreatSliderDisabledExample';

--- a/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
+++ b/gallery/src/components/NxPolicyThreatSlider/NxPolicyThreatSliderPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxPolicyThreatSliderExample from './NxPolicyThreatSliderExample';

--- a/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
+++ b/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxPolicyViolationIndicatorByCategoryExample from './NxPolicyViolationIndicatorByCategoryExample';
 import NxPolicyViolationIndicatorByPolicyNumberExample from './NxPolicyViolationIndicatorByPolicyNumberExample';
@@ -20,107 +20,107 @@ const nxPolicyViolationIndicatorByCategoryCode =
 const NxPolicyViolationIndicatorPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxPolicyViolationIndicator</code> is an element used to indicate IQ policy threat
+      <NxP>
+        <NxCode>NxPolicyViolationIndicator</NxCode> is an element used to indicate IQ policy threat
         level via color and text.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         There are two scales to choose from: threat level by category, and threat
         level by number. When using this component, it is expected that just one of the props will be passed. If both
-        are passed, <code className="nx-code">threatLevelCategory</code> takes precedence. If neither are passed,
-        the <code className="nx-code">unspecified</code> category is used.
-      </p>
-      <p className="nx-p">
+        are passed, <NxCode>threatLevelCategory</NxCode> takes precedence. If neither are passed,
+        the <NxCode>unspecified</NxCode> category is used.
+      </NxP>
+      <NxP>
         The text that appears inside the component can be specified by the user, or if no text is supplied the threat
         category will appear.
-      </p>
-      <table className="nx-table">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">threatLevelCategory</td>
-            <td className="nx-cell">One of 'unspecified', 'none', 'low', 'moderate', 'severe', or 'critical'</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A Threat Level Category off of which to base the indicator color</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">policyThreatLevel</td>
-            <td className="nx-cell">number (0 - 10 inclusive)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A Policy Threat Level Number off of which to base the indicator color</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>threatLevelCategory</NxTable.Cell>
+            <NxTable.Cell>One of 'unspecified', 'none', 'low', 'moderate', 'severe', or 'critical'</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A Threat Level Category off of which to base the indicator color</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>policyThreatLevel</NxTable.Cell>
+            <NxTable.Cell>number (0 - 10 inclusive)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A Policy Threat Level Number off of which to base the indicator color</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                 HTML div Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               NxPolicyViolationIndicator supports any HTML attribute that's normally supported
-              by <code className="nx-code">&lt;div&gt;</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              by <NxCode>&lt;div&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
 
-      <p className="nx-p">
+      <NxP>
         The following table shows the mapping between threat level number and threat level category.
-      </p>
-      <table className="nx-table">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Threat Level Number</th>
-            <th className="nx-cell nx-cell--header">Threat Level Category</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">0</td>
-            <td className="nx-cell">none</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">1</td>
-            <td className="nx-cell">low</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">2 - 3</td>
-            <td className="nx-cell">moderate</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">4 - 7</td>
-            <td className="nx-cell">severe</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">8 - 10</td>
-            <td className="nx-cell">critical</td>
-          </tr>
-        </tbody>
-      </table>
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Threat Level Number</NxTable.Cell>
+            <NxTable.Cell>Threat Level Category</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>0</NxTable.Cell>
+            <NxTable.Cell>none</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>1</NxTable.Cell>
+            <NxTable.Cell>low</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>2 - 3</NxTable.Cell>
+            <NxTable.Cell>moderate</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>4 - 7</NxTable.Cell>
+            <NxTable.Cell>severe</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>8 - 10</NxTable.Cell>
+            <NxTable.Cell>critical</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Policy Violation Indicators by Category"
                         id="nx-policy-violation-indicator-category-example"
                         liveExample={NxPolicyViolationIndicatorByCategoryExample}
                         codeExamples={nxPolicyViolationIndicatorByCategoryCode}>
-      Examples of <code className="nx-code">NxPolicyViolationIndicator</code> displaying each of the available
-      <code className="nx-code">threatLevelCategory</code> values with user specified text.
+      Examples of <NxCode>NxPolicyViolationIndicator</NxCode> displaying each of the available
+      <NxCode>threatLevelCategory</NxCode> values with user specified text.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Policy Violation Indicators by Policy Number"
                         id="nx-policy-violation-indicator-number-example"
                         liveExample={NxPolicyViolationIndicatorByPolicyNumberExample}
                         codeExamples={nxPolicyViolationIndicatorByPolicyNumberCode}>
-      Examples of <code className="nx-code">NxPolicyViolationIndicator</code> where the colours are specified by
-      the <code className="nx-code">policyThreatNumber</code> value and the text shown is the default category label.
+      Examples of <NxCode>NxPolicyViolationIndicator</NxCode> where the colours are specified by
+      the <NxCode>policyThreatNumber</NxCode> value and the text shown is the default category label.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
+++ b/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxPolicyViolationIndicatorByCategoryExample from './NxPolicyViolationIndicatorByCategoryExample';

--- a/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
+++ b/gallery/src/components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxPolicyViolationIndicatorByCategoryExample from './NxPolicyViolationIndicatorByCategoryExample';
 import NxPolicyViolationIndicatorByPolicyNumberExample from './NxPolicyViolationIndicatorByPolicyNumberExample';

--- a/gallery/src/components/NxRadio/NxRadioPage.tsx
+++ b/gallery/src/components/NxRadio/NxRadioPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxRadioExample from './NxRadioExample';
 import NxRadioNowrapExample from './NxRadioNowrapExample';
@@ -20,100 +20,99 @@ const disabledExampleCode = require('./NxRadioDisabledExample?raw');
 const NxRadioPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Custom Radio input.</p>
-      <p className="nx-p">Child VDOM will be used as a label following the radio button itself.</p>
-      <p className="nx-p">
+      <NxP>Custom Radio input.</NxP>
+      <NxP>Child VDOM will be used as a label following the radio button itself.</NxP>
+      <NxP>
         NxRadio can receive any attribute that would be valid on an
-        HTML <code className="nx-code">&lt;label&gt;</code> as well as the following props:
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">name</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">The name of the radio group</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">value</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">The value attribute for radio input</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isChecked</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">Whether the radio button should be rendered as on or off</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function ((currentValue: string) =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A callback for when the radio is selected. The value is passed as an argument.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+        HTML <NxCode>&lt;label&gt;</NxCode> as well as the following props:
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>name</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>The name of the radio group</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>value</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>The value attribute for radio input</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isChecked</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>Whether the radio button should be rendered as on or off</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function ((currentValue: string) =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A callback for when the radio is selected. The value is passed as an argument.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the radio should be rendered as disabled or not.  When disabled, the onChange callback will
               not fire.  Defaults to false
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">Virtual DOM</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>Virtual DOM</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Additional VDOM that will be rendered as label. Should be
               {' '}
-              <a href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content"
-                 className="nx-text-link">
+              <NxTextLink href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content">
                 phrasing content
-              </a>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">radioId</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">An id attribute to be added to the radio input</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">overflowTooltip</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+              </NxTextLink>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>radioId</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>An id attribute to be added to the radio input</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>overflowTooltip</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the radio label content should be wrapped in
-              an <code className="nx-code">NxOverflowTooltip</code>. Defaults to true. Set this to false when
-              the <code className="nx-code">NxRadio</code> is being wrapped in a tooltip externally, to prevent
+              an <NxCode>NxOverflowTooltip</NxCode>. Defaults to true. Set this to false when
+              the <NxCode>NxRadio</NxCode> is being wrapped in a tooltip externally, to prevent
               multiple overlapping tooltips from appearing.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;label&gt;</code> Attributes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;label&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/label">
                 HTML Label Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               NxRadio supports any html attribute that's normally supported by
-              {' '}<code className="nx-code">&lt;label&gt;</code> elements.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              {' '}<NxCode>&lt;label&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/components/NxRadio/NxRadioPage.tsx
+++ b/gallery/src/components/NxRadio/NxRadioPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxRadioExample from './NxRadioExample';
 import NxRadioNowrapExample from './NxRadioNowrapExample';

--- a/gallery/src/components/NxRadio/NxRadioPage.tsx
+++ b/gallery/src/components/NxRadio/NxRadioPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxRadioExample from './NxRadioExample';

--- a/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
+++ b/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
@@ -7,13 +7,12 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxSegmentedButtonPrimaryExample from './NxSegmentedButtonPrimaryExample';
 import NxSegmentedButtonSecondaryExample from './NxSegmentedButtonSecondaryExample';
 import NxSegmentedButtonTertiaryExample from './NxSegmentedButtonTertiaryExample';
 import NxSegmentedButtonCloseHandlerExample from './NxSegmentedButtonCloseHandlerExample';
-import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody, NxTextLink }
-  from '@sonatype/react-shared-components';
 
 const nxSegmentedButtonPrimaryCode = require('./NxSegmentedButtonPrimaryExample?raw'),
     nxSegmentedButtonSecondaryCode = require('./NxSegmentedButtonSecondaryExample?raw'),
@@ -24,126 +23,126 @@ export default function NxSegmentedButtonPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          <code className="nx-code">NxSegmentedButton</code> renders a "segmented" or "split" button - one which
+        <NxP>
+          <NxCode>NxSegmentedButton</NxCode> renders a "segmented" or "split" button - one which
           contains the usual button behavior but in addition has a separate section on the right-hand end which
           opens a dropdown menu.
-        </p>
+        </NxP>
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Prop</NxTableCell>
-              <NxTableCell>Type</NxTableCell>
-              <NxTableCell>Required</NxTableCell>
-              <NxTableCell>Default</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell>variant</NxTableCell>
-              <NxTableCell>'primary' | 'secondary' | 'tertiary'</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>The variant of button. See examples of each variant below.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>buttonContent</NxTableCell>
-              <NxTableCell>ReactNode</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>The content to display within the main button segment.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>children</NxTableCell>
-              <NxTableCell>ReactElement | ReactElement[]</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Default</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>variant</NxTable.Cell>
+              <NxTable.Cell>'primary' | 'secondary' | 'tertiary'</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>The variant of button. See examples of each variant below.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>buttonContent</NxTable.Cell>
+              <NxTable.Cell>ReactNode</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>The content to display within the main button segment.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>children</NxTable.Cell>
+              <NxTable.Cell>ReactElement | ReactElement[]</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 The items to display within the dropdown menu. Anything that can appear
-                within an <code className="nx-code">NxDropdown</code> is supported.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>isOpen</NxTableCell>
-              <NxTableCell>boolean</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>Set to true to have the dropdown menu rendered as open.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>onToggleOpen</NxTableCell>
-              <NxTableCell>Function</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+                within an <NxCode>NxDropdown</NxCode> is supported.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>isOpen</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>Set to true to have the dropdown menu rendered as open.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onToggleOpen</NxTable.Cell>
+              <NxTable.Cell>Function</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 Callback function called when the dropdown toggle segment of the button is activated.
                 This activation occurs when the dropdown button
                 is clicked and also, if the dropdown is currently open, whenever a click occurs anywhere on the
                 screen and any time the ESC key is pressed while focus is within the dropdown.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>onClick</NxTableCell>
-              <NxTableCell>Function</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onClick</NxTable.Cell>
+              <NxTable.Cell>Function</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 Click handler for the main segment of the button. Does not fire in response to dropdown interactions.
                 Receives the click event as a parameter.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>disabled</NxTableCell>
-              <NxTableCell>boolean</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>Disables both segments of the button when true.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>onCloseClick</NxTableCell>
-              <NxTableCell>Function (MouseEvent =&lt; void)</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell/>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>disabled</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>Disables both segments of the button when true.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onCloseClick</NxTable.Cell>
+              <NxTable.Cell>Function (MouseEvent =&lt; void)</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell/>
+              <NxTable.Cell>
                 A callback function to execute when a click is detected anywhere on the document which would by
                 default close this dropdown (i.e. any click while the dropdown is open). This callback is dispatched
                 before the dropdown is closed and is provided with a proxy of the <em>native</em> MouseEvent object.
-                Calling <code className="nx-code">preventDefault</code> on this MouseEvent will cause the dropdown
+                Calling <NxCode>preventDefault</NxCode> on this MouseEvent will cause the dropdown
                 not to close. Note however that the event is proxied in such a way that
-                calling <code className="nx-code">preventDefault</code> <em>will not</em> have any other
-                effects – that is, the true native MouseEvent's <code className="nx-code">defaultPrevented</code> flag
+                calling <NxCode>preventDefault</NxCode> <em>will not</em> have any other
+                effects – that is, the true native MouseEvent's <NxCode>defaultPrevented</NxCode> flag
                 will be untouched, and only the logic within the dropdown will be affected.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>onCloseKeyDown</NxTableCell>
-              <NxTableCell>Function (KeyboardEvent =&lt; void)</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell/>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onCloseKeyDown</NxTable.Cell>
+              <NxTable.Cell>Function (KeyboardEvent =&lt; void)</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell/>
+              <NxTable.Cell>
                 A callback function to execute when a key press is detected which would by
                 default close this dropdown (i.e. an ESC keypress occurring within the dropdown while it is open).
                 This callback is dispatched before the dropdown is closed and is provided with the React KeyboardEvent
-                object.  Calling <code className="nx-code">preventDefault</code> on this event object will cause the
+                object.  Calling <NxCode>preventDefault</NxCode> on this event object will cause the
                 dropdown not to close.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                   HTML div Attributes
                 </NxTextLink>
-              </NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>N/A</NxTableCell>
-              <NxTableCell>
-                <code className="nx-code">NxSegmentedButton</code> supports any HTML attribute that's normally
-                supported by <code className="nx-code">&lt;div&gt;</code>.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>N/A</NxTable.Cell>
+              <NxTable.Cell>
+                <NxCode>NxSegmentedButton</NxCode> supports any HTML attribute that's normally
+                supported by <NxCode>&lt;div&gt;</NxCode>.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </GalleryDescriptionTile>
 
@@ -151,8 +150,8 @@ export default function NxSegmentedButtonPage() {
                           id="nx-segmented-button-primary-example"
                           liveExample={NxSegmentedButtonPrimaryExample}
                           codeExamples={nxSegmentedButtonPrimaryCode}>
-        An <code className="nx-code">NxSegmentedButton</code> using primary styling, a disabled
-        primary-styled <code className="nx-code">NxSegmentedButton</code>, and a normal button to demonstrate
+        An <NxCode>NxSegmentedButton</NxCode> using primary styling, a disabled
+        primary-styled <NxCode>NxSegmentedButton</NxCode>, and a normal button to demonstrate
         alignment.
       </GalleryExampleTile>
 
@@ -160,8 +159,8 @@ export default function NxSegmentedButtonPage() {
                           id="nx-segmented-button-secondary-example"
                           liveExample={NxSegmentedButtonSecondaryExample}
                           codeExamples={nxSegmentedButtonSecondaryCode}>
-        An <code className="nx-code">NxSegmentedButton</code> using secondary styling, a disabled
-        secondary-styled <code className="nx-code">NxSegmentedButton</code>, and a normal button to demonstrate
+        An <NxCode>NxSegmentedButton</NxCode> using secondary styling, a disabled
+        secondary-styled <NxCode>NxSegmentedButton</NxCode>, and a normal button to demonstrate
         alignment.
       </GalleryExampleTile>
 
@@ -169,18 +168,18 @@ export default function NxSegmentedButtonPage() {
                           id="nx-segmented-button-tertiary-example"
                           liveExample={NxSegmentedButtonTertiaryExample}
                           codeExamples={nxSegmentedButtonTertiaryCode}>
-        An <code className="nx-code">NxSegmentedButton</code> using secondary styling, a disabled
-        secondary-styled <code className="nx-code">NxSegmentedButton</code>, and a normal button to demonstrate
+        An <NxCode>NxSegmentedButton</NxCode> using secondary styling, a disabled
+        secondary-styled <NxCode>NxSegmentedButton</NxCode>, and a normal button to demonstrate
         alignment.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Example with disabled close handlers"
                           liveExample={NxSegmentedButtonCloseHandlerExample}
                           codeExamples={nxSegmentedButtonCloseHandlerExampleCode}>
-        This example demonstrates the usage of the <code className="nx-code">onCloseClick</code>{' '}
-        and <code className="nx-code">onCloseKeyDown</code> props. These props can be used to disable the
+        This example demonstrates the usage of the <NxCode>onCloseClick</NxCode>{' '}
+        and <NxCode>onCloseKeyDown</NxCode> props. These props can be used to disable the
         close-on-click and close-on-ESC behaviors that the dropdown has by default, by
-        calling <code className="nx-code">preventDefault()</code> on the event. This example demonstrates both props
+        calling <NxCode>preventDefault()</NxCode> on the event. This example demonstrates both props
         simulataneously, but either can be used independently if desired.
       </GalleryExampleTile>
     </>

--- a/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
+++ b/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxSegmentedButtonPrimaryExample from './NxSegmentedButtonPrimaryExample';

--- a/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
+++ b/gallery/src/components/NxSegmentedButton/NxSegmentedButtonPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxSegmentedButtonPrimaryExample from './NxSegmentedButtonPrimaryExample';
 import NxSegmentedButtonSecondaryExample from './NxSegmentedButtonSecondaryExample';

--- a/gallery/src/components/NxStatefulAccordion/NxStatefulAccordionPage.tsx
+++ b/gallery/src/components/NxStatefulAccordion/NxStatefulAccordionPage.tsx
@@ -6,8 +6,9 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import NxStatefulAccordionExample from './NxStatefulAccordionExample';
 
 const NxStatefulAccordionCode = require('./NxStatefulAccordionExample?raw');

--- a/gallery/src/components/NxStatefulAccordion/NxStatefulAccordionPage.tsx
+++ b/gallery/src/components/NxStatefulAccordion/NxStatefulAccordionPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-
+import { NxCode, NxP } from '@sonatype/react-shared-components';
 import NxStatefulAccordionExample from './NxStatefulAccordionExample';
 
 const NxStatefulAccordionCode = require('./NxStatefulAccordionExample?raw');
@@ -15,20 +15,20 @@ const NxStatefulAccordionCode = require('./NxStatefulAccordionExample?raw');
 const NxStatefulAccordionPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxStatefulAccordion</code> is a wrapper
-        around <code className="nx-code">NxAccordion</code> which tracks its own toggle state. It accepts
-        the same props as <code className="nx-code">NxAccordion</code>, except that instead
-        of <code className="nx-code">open</code>, it accepts <code className="nx-code">defaultOpen</code> which
+      <NxP>
+        <NxCode>NxStatefulAccordion</NxCode> is a wrapper
+        around <NxCode>NxAccordion</NxCode> which tracks its own toggle state. It accepts
+        the same props as <NxCode>NxAccordion</NxCode>, except that instead
+        of <NxCode>open</NxCode>, it accepts <NxCode>defaultOpen</NxCode> which
         provides the initial toggle state.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Example"
                         defaultCheckeredBackground={true}
                         liveExample={NxStatefulAccordionExample}
                         codeExamples={NxStatefulAccordionCode}>
-      A simple example of an <code className="nx-code">NxStatefulAccordion</code> that is initially open.
+      A simple example of an <NxCode>NxStatefulAccordion</NxCode> that is initially open.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxStatefulAccordion/NxStatefulAccordionPage.tsx
+++ b/gallery/src/components/NxStatefulAccordion/NxStatefulAccordionPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulAccordionExample from './NxStatefulAccordionExample';

--- a/gallery/src/components/NxStatefulAlert/NxStatefulAlertPage.tsx
+++ b/gallery/src/components/NxStatefulAlert/NxStatefulAlertPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP } from '@sonatype/react-shared-components';
 
 import NxStatefulAlertExample from './NxStatefulAlertExample';
 import NxStatefulErrorAlertExample from './NxStatefulErrorAlertExample';
@@ -23,31 +24,31 @@ const nxStatefulErrorAlertExampleCode = require('./NxStatefulErrorAlertExample?r
 const NxStatefulAlertPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         A Stateful version of generic alert that tracks its own dismissal state. It contains preconfigured variations
         for the info, warning, error, and success styles.
-      </p>
-      <p className="nx-p">Accepts any prop that is valid on a div as well as the following:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">icon</td>
-            <td className="nx-cell">FontAwesome's Icons</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxP>Accepts any prop that is valid on a div as well as the following:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>icon</NxTable.Cell>
+            <NxTable.Cell>FontAwesome's Icons</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               A FontAwesome icon to use in the alert message
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Alert Example"
@@ -58,11 +59,9 @@ const NxStatefulAlertPage = () =>
     </GalleryExampleTile>
 
     <GalleryTile title="NxStatefulErrorAlert, etc.">
-      <p className="nx-p">Standard sonatype alerts.</p>
-      <p className="nx-p">They come in four variations: Error, Info, Warning, and Success.</p>
-      <p className="nx-p">
-        Accepts any prop that is valid on a div.
-      </p>
+      <NxP>Standard sonatype alerts.</NxP>
+      <NxP>They come in four variations: Error, Info, Warning, and Success.</NxP>
+      <NxP>Accepts any prop that is valid on a div.</NxP>
     </GalleryTile>
 
     <GalleryExampleTile title="Success Alert Example"

--- a/gallery/src/components/NxStatefulAlert/NxStatefulAlertPage.tsx
+++ b/gallery/src/components/NxStatefulAlert/NxStatefulAlertPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulAlertExample from './NxStatefulAlertExample';

--- a/gallery/src/components/NxStatefulAlert/NxStatefulAlertPage.tsx
+++ b/gallery/src/components/NxStatefulAlert/NxStatefulAlertPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile, GalleryTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulAlertExample from './NxStatefulAlertExample';
 import NxStatefulErrorAlertExample from './NxStatefulErrorAlertExample';

--- a/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
+++ b/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxStatefulCheckboxExample from './NxStatefulCheckboxExample';
 
@@ -15,74 +16,73 @@ const exampleCode = require('./NxStatefulCheckboxExample?raw');
 const NxStatefulCheckboxPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Custom stateful checkbox input.</p>
-      <p className="nx-p">Child VDOM will be used as a label following the stateful checkbox button itself.</p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">checkboxId</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">An id to identify the stateful checkbox</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">defaultChecked</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+      <NxP>Custom stateful checkbox input.</NxP>
+      <NxP>Child VDOM will be used as a label following the stateful checkbox button itself.</NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>checkboxId</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>An id to identify the stateful checkbox</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>defaultChecked</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Whether the stateful checkbox should initially be rendered as checked (true) or unchecked (false)
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function ((boolean) =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A callback for when the stateful checkbox is toggled</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function ((boolean) =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A callback for when the stateful checkbox is toggled</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the stateful checkbox should be rendered as disabled or not.
               When disabled, the onChange callback will not fire.  Defaults to false
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">overflowTooltip</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>overflowTooltip</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the checkbox label content should be wrapped in
-              an <code className="nx-code">NxOverflowTooltip</code>. Defaults to true. Set this to false when
-              the <code className="nx-code">NxStatefulCheckbox</code> is being wrapped in a tooltip externally, to
+              an <NxCode>NxOverflowTooltip</NxCode>. Defaults to true. Set this to false when
+              the <NxCode>NxStatefulCheckbox</NxCode> is being wrapped in a tooltip externally, to
               prevent multiple overlapping tooltips from appearing.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">Virtual DOM</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>Virtual DOM</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               VDOM rendered as a label. Should be
               {' '}
-              <a href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content"
-                 className="nx-text-link">
+              <NxTextLink href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content">
                 phrasing content
-              </a>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              </NxTextLink>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
+++ b/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulCheckboxExample from './NxStatefulCheckboxExample';
 

--- a/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
+++ b/gallery/src/components/NxStatefulCheckbox/NxStatefulCheckboxPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulCheckboxExample from './NxStatefulCheckboxExample';

--- a/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
+++ b/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxStatefulDropdownExample from './NxStatefulDropdownExample';
 
@@ -16,74 +16,74 @@ const nxStatefulDropdownExampleCode = require('./NxStatefulDropdownExample?raw')
 const NxStatefulDropdownPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Dropdown component.</p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">label</td>
-            <td className="nx-cell">string | VDOM</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">Content to render in the dropdown's button</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">variant</td>
-            <td className="nx-cell">"primary" | "secondary" | "tertiary"</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      <NxP>Dropdown component.</NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>label</NxTable.Cell>
+            <NxTable.Cell>string | VDOM</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>Content to render in the dropdown's button</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>variant</NxTable.Cell>
+            <NxTable.Cell>"primary" | "secondary" | "tertiary"</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               What type of button to render for the dropdown.
-              Defaults to <code className="nx-code">"tertiary"</code>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">className</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">Extra classes to apply to the component</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+              Defaults to <NxCode>"tertiary"</NxCode>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>className</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>Extra classes to apply to the component</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls if the component should be rendered as disabled.
-              Defaults to <code className="nx-code">false</code>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">toggleTooltip</td>
-            <td className="nx-cell">string | NxTooltip Props</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+              Defaults to <NxCode>false</NxCode>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>toggleTooltip</NxTable.Cell>
+            <NxTable.Cell>string | NxTooltip Props</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If present, describes a tooltip to be placed on the dropdown's toggle element. There are two ways
               to specify the tooltip: the simpler way is to simply specify the tooltip text as a string. If control
               of more complex tooltip options is desired, an object can be passed which will serve as the props for
               NxTooltip
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;div&gt;</code> Attributes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/element/div">
                 HTML div Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               NxStatefulDropdown supports any html attribute that's normally supported by
-              {' '}<code className="nx-code">&lt;div&gt;</code> elements.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              {' '}<NxCode>&lt;div&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
+++ b/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulDropdownExample from './NxStatefulDropdownExample';

--- a/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
+++ b/gallery/src/components/NxStatefulDropdown/NxStatefulDropdownPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulDropdownExample from './NxStatefulDropdownExample';
 

--- a/gallery/src/components/NxStatefulGlobalSidebar/NxStatefulGlobalSidebarPage.tsx
+++ b/gallery/src/components/NxStatefulGlobalSidebar/NxStatefulGlobalSidebarPage.tsx
@@ -5,10 +5,11 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import CodeExample from '../../CodeExample';
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxH3, NxH2, NxTile, NxTextLink } from '@sonatype/react-shared-components';
 
+import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+
+import CodeExample from '../../CodeExample';
 import './NxStatefulGlobalSidebarPage.scss';
 
 const NxStatefulGlobalSidebarExample = require('./NxStatefulGlobalSidebarExample.tsx?raw');

--- a/gallery/src/components/NxStatefulGlobalSidebar/NxStatefulGlobalSidebarPage.tsx
+++ b/gallery/src/components/NxStatefulGlobalSidebar/NxStatefulGlobalSidebarPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import CodeExample from '../../CodeExample';
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
-import { NxP, NxCode, NxTable, NxTile, NxH2 } from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP, NxH3, NxH2, NxTile, NxTextLink } from '@sonatype/react-shared-components';
 
 import './NxStatefulGlobalSidebarPage.scss';
 
@@ -19,12 +19,12 @@ export default function NxStatefulGlobalSidebarPage() {
       <GalleryDescriptionTile>
         <NxP>
           <NxCode>NxStatefulGlobalSidebar</NxCode> is the stateful version of <NxCode>NxGlobalSidebar</NxCode>. Please
-          {' '}<a className="nx-text-link" href="#/Pages/NxGlobalSidebar">refer to that component</a> for shared
+          {' '}<NxTextLink href="#/Pages/NxGlobalSidebar">refer to that component</NxTextLink> for shared
           props and documentation.
         </NxP>
         <NxTile.Subsection>
           <NxTile.SubsectionHeader>
-            <h3 className="nx-h3"><NxCode>NxStatefulGlobalSidebar</NxCode> Props</h3>
+            <NxH3><NxCode>NxStatefulGlobalSidebar</NxCode> Props</NxH3>
           </NxTile.SubsectionHeader>
           <NxTable>
             <NxTable.Head>
@@ -57,9 +57,9 @@ export default function NxStatefulGlobalSidebarPage() {
         </NxTile.Header>
         <NxTile.Content>
           <NxP>
-            <a className="nx-text-link" href="#/NxStatefulGlobalSidebarExample">
+            <NxTextLink href="#/NxStatefulGlobalSidebarExample">
               Click here to navigate to the live example.
-            </a>
+            </NxTextLink>
           </NxP>
           <CodeExample content={NxStatefulGlobalSidebarExample} />
         </NxTile.Content>

--- a/gallery/src/components/NxStatefulSegmentedButton/NxStatefulSegmentedButtonPage.tsx
+++ b/gallery/src/components/NxStatefulSegmentedButton/NxStatefulSegmentedButtonPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulSegmentedButtonExample from './NxStatefulSegmentedButtonExample';
 

--- a/gallery/src/components/NxStatefulSegmentedButton/NxStatefulSegmentedButtonPage.tsx
+++ b/gallery/src/components/NxStatefulSegmentedButton/NxStatefulSegmentedButtonPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulSegmentedButtonExample from './NxStatefulSegmentedButtonExample';

--- a/gallery/src/components/NxStatefulSegmentedButton/NxStatefulSegmentedButtonPage.tsx
+++ b/gallery/src/components/NxStatefulSegmentedButton/NxStatefulSegmentedButtonPage.tsx
@@ -7,10 +7,9 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxStatefulSegmentedButtonExample from './NxStatefulSegmentedButtonExample';
-import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody, NxTextLink }
-  from '@sonatype/react-shared-components';
 
 const nxStatefulSegmentedButtonCode = require('./NxStatefulSegmentedButtonExample?raw');
 
@@ -18,83 +17,83 @@ export default function NxStatefulSegmentedButtonPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
+        <NxP>
           Stateful variant of NxSegmentedButton which manages the dropdown open/close state and events internally.
-        </p>
+        </NxP>
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Prop</NxTableCell>
-              <NxTableCell>Type</NxTableCell>
-              <NxTableCell>Required</NxTableCell>
-              <NxTableCell>Default</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell>variant</NxTableCell>
-              <NxTableCell>'primary' | 'secondary' | 'tertiary'</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>The variant of button. See examples of each variant below.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>buttonContent</NxTableCell>
-              <NxTableCell>ReactNode</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>The content to display within the main button segment.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>children</NxTableCell>
-              <NxTableCell>ReactElement | ReactElement[]</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Default</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>variant</NxTable.Cell>
+              <NxTable.Cell>'primary' | 'secondary' | 'tertiary'</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>The variant of button. See examples of each variant below.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>buttonContent</NxTable.Cell>
+              <NxTable.Cell>ReactNode</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>The content to display within the main button segment.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>children</NxTable.Cell>
+              <NxTable.Cell>ReactElement | ReactElement[]</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 The items to display within the dropdown menu. Anything that can appear
-                within an <code className="nx-code">NxDropdown</code> is supported.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>onClick</NxTableCell>
-              <NxTableCell>Function</NxTableCell>
-              <NxTableCell>Yes</NxTableCell>
-              <NxTableCell></NxTableCell>
-              <NxTableCell>
+                within an <NxCode>NxDropdown</NxCode> is supported.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onClick</NxTable.Cell>
+              <NxTable.Cell>Function</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>
                 Click handler for the main segment of the button. Does not fire in response to dropdown interactions.
                 Receives the click event as a parameter.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>disabled</NxTableCell>
-              <NxTableCell>boolean</NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>Disables both segments of the button when true.</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>disabled</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>Disables both segments of the button when true.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                   HTML div Attributes
                 </NxTextLink>
-              </NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>N/A</NxTableCell>
-              <NxTableCell>
-                <code className="nx-code">NxSegmentedButton</code> supports any HTML attribute that's normally
-                supported by <code className="nx-code">&lt;div&gt;</code>.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>N/A</NxTable.Cell>
+              <NxTable.Cell>
+                <NxCode>NxSegmentedButton</NxCode> supports any HTML attribute that's normally
+                supported by <NxCode>&lt;div&gt;</NxCode>.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </GalleryDescriptionTile>
 
       <GalleryExampleTile title="Example"
                           liveExample={NxStatefulSegmentedButtonExample}
                           codeExamples={nxStatefulSegmentedButtonCode}>
-        Example of an <code className="nx-code">NxStatefulSegmentedButton</code>.
+        Example of an <NxCode>NxStatefulSegmentedButton</NxCode>.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
+++ b/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulSubmitMaskExample from './NxStatefulSubmitMaskExample';

--- a/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
+++ b/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
@@ -7,6 +7,8 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import NxStatefulSubmitMaskExample from './NxStatefulSubmitMaskExample';
 import NxStatefulSubmitMaskCustomMessageExample from './NxStatefulSubmitMaskCustomMessageExample';
 
@@ -16,67 +18,67 @@ const NxStatefulSubmitMaskCode = require('./NxStatefulSubmitMaskExample?raw'),
 const NxStatefulSubmitMaskPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        This is a wrapper around <code className="nx-code">NxSubmitMask</code> which manages the display and then
+      <NxP>
+        This is a wrapper around <NxCode>NxSubmitMask</NxCode> which manages the display and then
         hiding of the success phase of the mask.
-      </p>
-      <p className="nx-p">
-        The externally visible "success" state, specified by setting the <code className="nx-code">success</code> prop
+      </NxP>
+      <NxP>
+        The externally visible "success" state, specified by setting the <NxCode>success</NxCode> prop
         to true, encompasses two interally-managed states: the actual, visible success state, and then the automatic
         removal of the mask after the success state has been visible for a brief time.  Since this component manages
         these states internally, from an external perspective "success" is the end state
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row nx-table-row--header">
-            <td className="nx-cell">success</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>success</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the mask should display as a success. When true, the loading spinner will not be present,
-              the mask will have green styling, and the <code className="nx-code">successMessage</code> will be used
-              instead of the <code className="nx-code">message</code> as described below. In this stateful component,
+              the mask will have green styling, and the <NxCode>successMessage</NxCode> will be used
+              instead of the <NxCode>message</NxCode> as described below. In this stateful component,
               the success state will only be visible briefly and then will automatically hide. Defaults to false
-            </td>
-          </tr>
-          <tr className="nx-table-row nx-table-row--header">
-            <td className="nx-cell">message</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The text to display inside of the mask when <code className="nx-code">success</code> is false.  Defaults
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>message</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The text to display inside of the mask when <NxCode>success</NxCode> is false.  Defaults
               to "Submitting…"
-            </td>
-          </tr>
-          <tr className="nx-table-row nx-table-row--header">
-            <td className="nx-cell">successMessage</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The text to display inside of the mask when <code className="nx-code">success</code> is true. Defaults
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>successMessage</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The text to display inside of the mask when <NxCode>success</NxCode> is true. Defaults
               to "Success!"
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <p className="nx-p">
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
+      <NxP>
         The examples on this page each start in a non-success state for five seconds before being updated to the
         success state
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"
                         liveExample={NxStatefulSubmitMaskExample}
                         codeExamples={NxStatefulSubmitMaskCode}>
-      An example of a simple <code className="nx-code">NxStatefulSubmitMask</code>. Click the button below to begin
+      An example of a simple <NxCode>NxStatefulSubmitMask</NxCode>. Click the button below to begin
       the example.  Once the button is clicked, the example is set up to stay in the non-success state for five
       seconds, demonstrating the delay in the completion of some asynchronous processing. Then, after five seconds,
       the mask reaches the Sucess state which it automatically displays for a brief period of time.

--- a/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
+++ b/gallery/src/components/NxStatefulSubmitMask/NxStatefulSubmitMaskPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulSubmitMaskExample from './NxStatefulSubmitMaskExample';
 import NxStatefulSubmitMaskCustomMessageExample from './NxStatefulSubmitMaskCustomMessageExample';

--- a/gallery/src/components/NxStatefulTabs/NxStatefulTabsPage.tsx
+++ b/gallery/src/components/NxStatefulTabs/NxStatefulTabsPage.tsx
@@ -5,10 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-
-import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxStatefulTabsSimpleExample from './NxStatefulTabsSimpleExample';
 

--- a/gallery/src/components/NxStatefulTabs/NxStatefulTabsPage.tsx
+++ b/gallery/src/components/NxStatefulTabs/NxStatefulTabsPage.tsx
@@ -8,13 +8,7 @@ import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow
-} from '@sonatype/react-shared-components';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxStatefulTabsSimpleExample from './NxStatefulTabsSimpleExample';
 
@@ -24,45 +18,45 @@ export default function NxStatefulTabsPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          This component simply wraps the <code className="nx-code">NxTabs</code> component
+        <NxP>
+          This component simply wraps the <NxCode>NxTabs</NxCode> component
           to track the currently selected tab.
-        </p>
+        </NxP>
 
-        <NxTable className="nx-table--gallery-props">
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Prop</NxTableCell>
-              <NxTableCell>Type</NxTableCell>
-              <NxTableCell>Required</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell>defaultActiveTab</NxTableCell>
-              <NxTableCell>number</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>defaultActiveTab</NxTable.Cell>
+              <NxTable.Cell>number</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>
                 The index of the tab that should be active initially. If not set, no tab will be activated.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>onTabSelect</NxTableCell>
-              <NxTableCell>function(number)</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onTabSelect</NxTable.Cell>
+              <NxTable.Cell>function(number)</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>
                 Called with the index of the newly selected tab when the currently selected tab changes.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </GalleryDescriptionTile>
 
       <GalleryExampleTile title="Simple NxTabs Example"
                           liveExample={NxStatefulTabsSimpleExample}
                           codeExamples={NxStatefulTabsSimpleCode}>
-        A basic example of how to use the <code className="nx-code">NxTabs</code> family of components.
+        A basic example of how to use the <NxCode>NxTabs</NxCode> family of components.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
+++ b/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 
 import NxStatefulTextInputSimpleExample from './NxStatefulTextInputSimpleExample';
 import NxStatefulTextInputValidationExample from './NxStatefulTextInputValidationExample';
@@ -23,60 +24,60 @@ const disabledSourceCode = require('./NxStatefulTextInputDisabledExample?raw');
 const NxStatefulTextInputPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Standard text input with pristine state tracking and pluggable validation handling</p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">type</td>
-            <td className="nx-cell">"textarea" | "text" | "password"</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">What type of text input to render.  Defaults to "text"</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">defaultValue</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">The initial value rendered in the text input</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">validator</td>
-            <td className="nx-cell">Function ((string) =&gt; string | string[] | null)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      <NxP>Standard text input with pristine state tracking and pluggable validation handling</NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>type</NxTable.Cell>
+            <NxTable.Cell>"textarea" | "text" | "password"</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>What type of text input to render.  Defaults to "text"</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>defaultValue</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>The initial value rendered in the text input</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>validator</NxTable.Cell>
+            <NxTable.Cell>Function ((string) =&gt; string | string[] | null)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A function that validates user-inputted changes to the text field value. Accepts the new value
               as a string and returns zero or more validation error messages
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              HTML <code className="nx-code">&lt;input&gt;</code> Attributes |
-              HTML <code className="nx-code">&lt;textarea&gt;</code> Attributes
-            </td>
-            <td className="nx-cell">
-              <code className="nx-code">NxTextInput</code> props
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              Any attribute supported by <code className="nx-code">NxTextInput</code>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              HTML <NxCode>&lt;input&gt;</NxCode> Attributes |
+              HTML <NxCode>&lt;textarea&gt;</NxCode> Attributes
+            </NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>NxTextInput</NxCode> props
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              Any attribute supported by <NxCode>NxTextInput</NxCode>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"
                         liveExample={NxStatefulTextInputSimpleExample}
                         codeExamples={simpleSourceCode}>
-      A simple example of an <code className="nx-code">NxStatefileTextInput</code>. Note that the content of the text
+      A simple example of an <NxCode>NxStatefileTextInput</NxCode>. Note that the content of the text
       input does not need to be tracked separately.
     </GalleryExampleTile>
 

--- a/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
+++ b/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulTextInputSimpleExample from './NxStatefulTextInputSimpleExample';
 import NxStatefulTextInputValidationExample from './NxStatefulTextInputValidationExample';

--- a/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
+++ b/gallery/src/components/NxStatefulTextInput/NxStatefulTextInputPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulTextInputSimpleExample from './NxStatefulTextInputSimpleExample';

--- a/gallery/src/components/NxStatefulToggle/NxStatefulTogglePage.tsx
+++ b/gallery/src/components/NxStatefulToggle/NxStatefulTogglePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulToggleExample from './NxStatefulToggleExample';

--- a/gallery/src/components/NxStatefulToggle/NxStatefulTogglePage.tsx
+++ b/gallery/src/components/NxStatefulToggle/NxStatefulTogglePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxTable, NxTextLink, NxP } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxStatefulToggleExample from './NxStatefulToggleExample';
 

--- a/gallery/src/components/NxStatefulToggle/NxStatefulTogglePage.tsx
+++ b/gallery/src/components/NxStatefulToggle/NxStatefulTogglePage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+import { NxTable, NxTextLink, NxP } from '@sonatype/react-shared-components';
 
 import NxStatefulToggleExample from './NxStatefulToggleExample';
 
@@ -15,65 +16,64 @@ const exampleCode = require('./NxStatefulToggleExample?raw');
 const NxStatefulTogglePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Custom toggle control, which uses a hidden checkbox input for its on/checked &amp; off/unselected states.
-      </p>
-      <p className="nx-p">Child VDOM will be used as a label preceeding the stateful toggle control.</p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">inputId</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">An id to identify the stateful toggle</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">defaultChecked</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxP>Child VDOM will be used as a label preceeding the stateful toggle control.</NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>inputId</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>An id to identify the stateful toggle</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>defaultChecked</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Whether the stateful toggle should initially be rendered as checked (true) or unchecked (false)
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function ((boolean) =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A callback for when the stateful toggle is toggled</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function ((boolean) =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A callback for when the stateful toggle is toggled</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the stateful toggle should be rendered as disabled or not.
               When disabled, the onChange callback will not fire.  Defaults to false
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">Virtual DOM</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>Virtual DOM</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               VDOM rendered as a label. Should be
               {' '}
-              <a href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content"
-                 className="nx-text-link">
+              <NxTextLink href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content">
                 phrasing content
-              </a>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              </NxTextLink>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulTreeViewMultiSelectExample from './NxStatefulTreeViewMultiSelectExample';
 import NxStatefulTreeViewMultiSelectDisabledExample from './NxStatefulTreeViewMultiSelectDisabledExample';

--- a/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 
 import NxStatefulTreeViewMultiSelectExample from './NxStatefulTreeViewMultiSelectExample';
 import NxStatefulTreeViewMultiSelectDisabledExample from './NxStatefulTreeViewMultiSelectDisabledExample';
@@ -18,156 +19,156 @@ const nxStatefulTreeViewMultiSelectExampleCode = require('./NxStatefulTreeViewMu
 const NxStatefulTreeViewMultiSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Stateful Multi select component using tree view with checkboxes. It handles tree view toggling and filter state.
-      </p>
+      </NxP>
 
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">options</td>
-            <td className="nx-cell">Array of {'{id:String, name:String}'}</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
-              <p className="nx-p">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>options</NxTable.Cell>
+            <NxTable.Cell>Array of {'{id:String, name:String}'}</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 An array of objects that corresponds to the possible options of the component (the checkboxes).
-                These objects need to at least have an <code className="nx-code">id: string</code> property and a{' '}
-                <code className="nx-code">name: string</code> property. If an empty array is passed in, the component
+                These objects need to at least have an <NxCode>id: string</NxCode> property and a{' '}
+                <NxCode>name: string</NxCode> property. If an empty array is passed in, the component
                 will be disabled.
-              </p>
-              <p className="nx-p">
-                <code className="nx-code">id</code> will be the value provided to the{' '}
-                <code className="nx-code">onChange</code> callback, and{' '}
-                <code className="nx-code">name</code> will be used to render the option.
-              </p>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">name</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+              </NxP>
+              <NxP>
+                <NxCode>id</NxCode> will be the value provided to the{' '}
+                <NxCode>onChange</NxCode> callback, and{' '}
+                <NxCode>name</NxCode> will be used to render the option.
+              </NxP>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>name</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Name used in the default disabled tooltip and in the generated checkbox id.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">VDOM</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>VDOM</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               The content to be used as the tree view trigger.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Called whenever selection change occurs; it will receive two arguments:
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
-                  <code className="nx-code">Set</code> of ids of the currently selected options
+                  <NxCode>Set</NxCode> of ids of the currently selected options
                 </li>
                 <li className="nx-list__item">
-                  <code className="nx-code">id</code> of the toggled option
-                  or <code className="nx-code">undefined</code> if all/none option was toggled
+                  <NxCode>id</NxCode> of the toggled option
+                  or <NxCode>undefined</NxCode> if all/none option was toggled
                 </li>
               </ul>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">selectedIds</td>
-            <td className="nx-cell">Set</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The <code className="nx-code" >Set</code> of ids of options to be selected.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isOpen</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>selectedIds</NxTable.Cell>
+            <NxTable.Cell>Set</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The <NxCode >Set</NxCode> of ids of options to be selected.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isOpen</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the tree view is open or closed initially. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">id</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>id</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Id to assign to the component
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view should be rendered as disabled or not. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabledTooltip</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabledTooltip</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Enables the tooltip that appears when the component is disabled.
-              If no <code className="nx-code">disabledTooltip</code> is passed in and the component is disabled due
-              to lack of <code className="nx-code">options</code>, a default tooltip will be provided. If the
-              component is disabled explicitly and no <code className="nx-code">disabledTooltip</code> is provided,
+              If no <NxCode>disabledTooltip</NxCode> is passed in and the component is disabled due
+              to lack of <NxCode>options</NxCode>, a default tooltip will be provided. If the
+              component is disabled explicitly and no <NxCode>disabledTooltip</NxCode> is provided,
               no tooltip will be shown.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">optionTooltipGenerator</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>optionTooltipGenerator</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Callback to generate tooltip text for each option. Called with the option object. If not supplied, the
               default overflow tooltip behavior of the checkboxes will be active.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">tooltipModifierClass</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>tooltipModifierClass</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Custom class to be applied to all the tooltips rendered by this component.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterPlaceholder</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterPlaceholder</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Placeholder to be used in filter text input.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterThreshold</td>
-            <td className="nx-cell">Number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterThreshold</NxTable.Cell>
+            <NxTable.Cell>Number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If number of options is greater than filter-threshold - allows filtering the options. Default is 10.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"
                         codeExamples={nxStatefulTreeViewMultiSelectExampleCode}
                         liveExample={NxStatefulTreeViewMultiSelectExample}>
-      This example demonstrates basic usage of <code className="nx-code">NxStatefulTreeViewMultiSelect</code>. Note that
+      This example demonstrates basic usage of <NxCode>NxStatefulTreeViewMultiSelect</NxCode>. Note that
       the component tracks the collapse/expand state and filter text internally, and the calling
       code only needs to track which items are selected.
     </GalleryExampleTile>
@@ -175,7 +176,7 @@ const NxStatefulTreeViewMultiSelectPage = () =>
     <GalleryExampleTile title="Disabled Example With Tooltip"
                         liveExample={NxStatefulTreeViewMultiSelectDisabledExample}
                         codeExamples={nxStatefulTreeViewMultiSelectDisabledExampleCode}>
-      This example shows a disabled <code className="nx-code">NxStatefulTreeViewMultiSelect</code> with a tooltip.
+      This example shows a disabled <NxCode>NxStatefulTreeViewMultiSelect</NxCode> with a tooltip.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewMultiSelect/NxStatefulTreeViewMultiSelectPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulTreeViewMultiSelectExample from './NxStatefulTreeViewMultiSelectExample';

--- a/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulTreeViewRadioSelectExample from './NxStatefulTreeViewRadioSelectExample';
 import NxStatefulTreeViewRadioSelectDisabledExample from './NxStatefulTreeViewRadioSelectDisabledExample';

--- a/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxStatefulTreeViewRadioSelectExample from './NxStatefulTreeViewRadioSelectExample';

--- a/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxStatefulTreeViewRadioSelect/NxStatefulTreeViewRadioSelectPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 
 import NxStatefulTreeViewRadioSelectExample from './NxStatefulTreeViewRadioSelectExample';
 import NxStatefulTreeViewRadioSelectDisabledExample from './NxStatefulTreeViewRadioSelectDisabledExample';
@@ -18,152 +19,152 @@ const nxStatefulTreeViewRadioSelectExampleCode = require('./NxStatefulTreeViewRa
 const NxStatefulTreeViewRadioSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Stateful Radio select component using tree view with radios. It handles tree view toggling and filter state.
-      </p>
+      </NxP>
 
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">options</td>
-            <td className="nx-cell">Array of {'{id:String, name:String}'}</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
-              <p className="nx-p">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>options</NxTable.Cell>
+            <NxTable.Cell>Array of {'{id:String, name:String}'}</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 An array of objects that corresponds to the possible options of the component (the radios).
-                These objects need to at least have an <code className="nx-code">id: string | null</code> property{' '}
-                and a <code className="nx-code">name: string</code> property. If an empty array is passed in,{' '}
+                These objects need to at least have an <NxCode>id: string | null</NxCode> property{' '}
+                and a <NxCode>name: string</NxCode> property. If an empty array is passed in,{' '}
                 the component will be disabled.
-              </p>
-              <p className="nx-p">
-                <code className="nx-code">id</code> will be the value provided to the{' '}
-                <code className="nx-code">onChange</code> callback, and{' '}
-                <code className="nx-code">name</code> will be used to render the option.
-              </p>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">name</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+              </NxP>
+              <NxP>
+                <NxCode>id</NxCode> will be the value provided to the{' '}
+                <NxCode>onChange</NxCode> callback, and{' '}
+                <NxCode>name</NxCode> will be used to render the option.
+              </NxP>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>name</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Name used in the default disabled tooltip and in the generated checkbox id.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">VDOM</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>VDOM</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               The content to be used as the tree view trigger.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Called whenever selection change occurs; it will receive one argument:
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
-                  <code className="nx-code">id</code> of the toggled option
+                  <NxCode>id</NxCode> of the toggled option
                 </li>
               </ul>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">selectedId</td>
-            <td className="nx-cell">string | null</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The <code className="nx-code" >id</code> of the option to be selected.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isOpen</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>selectedId</NxTable.Cell>
+            <NxTable.Cell>string | null</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The <NxCode >id</NxCode> of the option to be selected.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isOpen</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the tree view is open or closed initially. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">id</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>id</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Id to assign to the component
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view should be rendered as disabled or not. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabledTooltip</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabledTooltip</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Enables the tooltip that appears when the component is disabled.
-              If no <code className="nx-code">disabledTooltip</code> is passed in and the component is disabled due
-              to lack of <code className="nx-code">options</code>, a default tooltip will be provided. If the
-              component is disabled explicitly and no <code className="nx-code">disabledTooltip</code> is provided,
+              If no <NxCode>disabledTooltip</NxCode> is passed in and the component is disabled due
+              to lack of <NxCode>options</NxCode>, a default tooltip will be provided. If the
+              component is disabled explicitly and no <NxCode>disabledTooltip</NxCode> is provided,
               no tooltip will be shown.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">optionTooltipGenerator</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>optionTooltipGenerator</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Callback to generate tooltip text for each option. Called with the option object. If not supplied, the
               default overflow tooltip behavior of the checkboxes will be active.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">tooltipModifierClass</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>tooltipModifierClass</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Custom class to be applied to all the tooltips rendered by this component.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterPlaceholder</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterPlaceholder</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Placeholder to be used in filter text input.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterThreshold</td>
-            <td className="nx-cell">Number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterThreshold</NxTable.Cell>
+            <NxTable.Cell>Number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If number of options is greater than filter-threshold - allows filtering the options. Default is 10.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"
                         codeExamples={nxStatefulTreeViewRadioSelectExampleCode}
                         liveExample={NxStatefulTreeViewRadioSelectExample}>
-      This example demonstrates basic usage of <code className="nx-code">NxStatefulTreeViewRadioSelect</code>. Note that
+      This example demonstrates basic usage of <NxCode>NxStatefulTreeViewRadioSelect</NxCode>. Note that
       the component tracks the collapse/expand state and filter text internally, and the calling
       code only needs to track which items are selected.
     </GalleryExampleTile>
@@ -171,7 +172,7 @@ const NxStatefulTreeViewRadioSelectPage = () =>
     <GalleryExampleTile title="Disabled Example With Tooltip"
                         liveExample={NxStatefulTreeViewRadioSelectDisabledExample}
                         codeExamples={nxStatefulTreeViewRadioSelectDisabledExampleCode}>
-      This example shows a disabled <code className="nx-code">NxStatefulTreeViewRadioSelect</code> with a tooltip.
+      This example shows a disabled <NxCode>NxStatefulTreeViewRadioSelect</NxCode> with a tooltip.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
+++ b/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxSubmitMaskCustomMessageExample from './NxSubmitMaskCustomMessageExample';

--- a/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
+++ b/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
@@ -7,6 +7,8 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import NxSubmitMaskCustomMessageExample from './NxSubmitMaskCustomMessageExample';
 import NxSubmitMaskSuccessExample from './NxSubmitMaskSuccessExample';
 import NxSubmitMaskCustomSuccessMessageExample from './NxSubmitMaskCustomSuccessMessageExample';
@@ -20,59 +22,59 @@ const NxSubmitMaskCustomMessageCode = require('./NxSubmitMaskCustomMessageExampl
 const NxSubmitMaskPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         NxSubmitMask creates a mask that covers the page while submission of a form or similar element
         is in progress, in order to indicate to the user that the submission is in-progress, and typically, when it
         has completed.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         Handling the brief display of the "success" part of the mask is left up to the caller, as it is often
         intertwined with other business logic (for example closing a modal) and may be best managed in redux or similar.
-        A constant, <code className="nx-code">SUBMIT_MASK_SUCCESS_VISIBLE_TIME_MS</code>, is exported in order to
+        A constant, <NxCode>SUBMIT_MASK_SUCCESS_VISIBLE_TIME_MS</NxCode>, is exported in order to
         provide said external business logic with a standard value for the amount of time to show the success mask.
         If you do not need to tie the showing and hiding of the success mask to other business logic, consider
-        using <code className="nx-code">NxStatefulSubmitMask</code> which encapsulates the success mask management.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row nx-table-row--header">
-            <td className="nx-cell">success</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+        using <NxCode>NxStatefulSubmitMask</NxCode> which encapsulates the success mask management.
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>success</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the mask should display as a success. When true, the loading spinner will not be present,
-              the mask will have green styling, and the <code className="nx-code">successMessage</code> will be used
-              instead of the <code className="nx-code">message</code> as described below. Defaults to false
-            </td>
-          </tr>
-          <tr className="nx-table-row nx-table-row--header">
-            <td className="nx-cell">message</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The text to display inside of the mask when <code className="nx-code">success</code> is false.  Defaults
+              the mask will have green styling, and the <NxCode>successMessage</NxCode> will be used
+              instead of the <NxCode>message</NxCode> as described below. Defaults to false
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>message</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The text to display inside of the mask when <NxCode>success</NxCode> is false.  Defaults
               to "Submitting…"
-            </td>
-          </tr>
-          <tr className="nx-table-row nx-table-row--header">
-            <td className="nx-cell">successMessage</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The text to display inside of the mask when <code className="nx-code">success</code> is true. Defaults
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>successMessage</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The text to display inside of the mask when <NxCode>success</NxCode> is true. Defaults
               to "Success!"
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"
@@ -87,21 +89,21 @@ const NxSubmitMaskPage = () =>
     <GalleryExampleTile title="Custom Message Example"
                         liveExample={NxSubmitMaskCustomMessageExample}
                         codeExamples={NxSubmitMaskCustomMessageCode}>
-      An <code className="nx-code">NxSubmitMask</code> in the non-success phase with a custom message.
+      An <NxCode>NxSubmitMask</NxCode> in the non-success phase with a custom message.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Success Example"
                         id="nx-submit-mask-success-example"
                         liveExample={NxSubmitMaskSuccessExample}
                         codeExamples={NxSubmitMaskSuccessCode}>
-      An <code className="nx-code">NxSubmitMask</code> in the success phase.
+      An <NxCode>NxSubmitMask</NxCode> in the success phase.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Custom Success Message Example"
                         liveExample={NxSubmitMaskCustomSuccessMessageExample}
                         codeExamples={NxSubmitMaskCustomSuccessMessageCode}>
-      An <code className="nx-code">NxSubmitMask</code> in the success phase with a custom success message. Note that the
-      success message is a separate <code className="nx-code">prop</code> from the non-success message.
+      An <NxCode>NxSubmitMask</NxCode> in the success phase with a custom success message. Note that the
+      success message is a separate <NxCode>prop</NxCode> from the non-success message.
     </GalleryExampleTile>
 
   </>;

--- a/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
+++ b/gallery/src/components/NxSubmitMask/NxSubmitMaskPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxSubmitMaskCustomMessageExample from './NxSubmitMaskCustomMessageExample';
 import NxSubmitMaskSuccessExample from './NxSubmitMaskSuccessExample';

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -50,19 +50,19 @@ export default function NxTablePage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
+        <NxP>
           A set of React components which encapsulate and assist with the styles for HTML tables.
-        </p>
+        </NxP>
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTable</h3>
+            <NxH3>NxTable</NxH3>
           </header>
-          <p className="nx-p">
+          <NxP>
             The top-level component to use when displaying tables of data.
-            It can have <code className="nx-code">NxTable.Head</code> and
-            {' '}<code className="nx-code">NxTable.Body</code> components as children.
-          </p>
+            It can have <NxCode>NxTable.Head</NxCode> and
+            {' '}<NxCode>NxTable.Body</NxCode> components as children.
+          </NxP>
           <NxTable>
             <NxTable.Head>
               <NxTable.Row>
@@ -74,7 +74,7 @@ export default function NxTablePage() {
             </NxTable.Head>
             <NxTable.Body>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;table&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;table&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/table">
                     HTML table Attributes
@@ -82,8 +82,8 @@ export default function NxTablePage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxTable</code> supports any HTML attribute that's normally
-                  supported by <code className="nx-code">&lt;table&gt;</code>.
+                  <NxCode>NxTable</NxCode> supports any HTML attribute that's normally
+                  supported by <NxCode>&lt;table&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -92,12 +92,12 @@ export default function NxTablePage() {
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTable.Head</h3>
+            <NxH3>NxTable.Head</NxH3>
           </header>
-          <p className="nx-p">
-            Equivalent to the <code className="nx-code">&lt;thead&gt;</code> element.
-            The <code className="nx-code">NxTable.Row</code> component is the only valid child.
-          </p>
+          <NxP>
+            Equivalent to the <NxCode>&lt;thead&gt;</NxCode> element.
+            The <NxCode>NxTable.Row</NxCode> component is the only valid child.
+          </NxP>
           <NxTable>
             <NxTable.Head>
               <NxTable.Row>
@@ -109,7 +109,7 @@ export default function NxTablePage() {
             </NxTable.Head>
             <NxTable.Body>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;thead&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;thead&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/thead">
                     HTML thead Attributes
@@ -117,8 +117,8 @@ export default function NxTablePage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxTable.Head</code> supports any HTML attribute that's normally
-                  supported by <code className="nx-code">&lt;thead&gt;</code>.
+                  <NxCode>NxTable.Head</NxCode> supports any HTML attribute that's normally
+                  supported by <NxCode>&lt;thead&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -127,12 +127,12 @@ export default function NxTablePage() {
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTable.Body</h3>
+            <NxH3>NxTable.Body</NxH3>
           </header>
-          <p className="nx-p">
-            Equivalent to the <code className="nx-code">&lt;tbody&gt;</code> element.
-            It should have <code className="nx-code">NxTable.Row</code> for children.
-          </p>
+          <NxP>
+            Equivalent to the <NxCode>&lt;tbody&gt;</NxCode> element.
+            It should have <NxCode>NxTable.Row</NxCode> for children.
+          </NxP>
           <NxTable>
             <NxTable.Head>
               <NxTable.Row>
@@ -161,7 +161,7 @@ export default function NxTablePage() {
                 <NxTable.Cell>false</NxTable.Cell>
                 <NxTable.Cell>
                   Used to provide the handler for the Retry button that appears when the error state is active.
-                  Required when <code className="nx-code">error</code> is present.
+                  Required when <NxCode>error</NxCode> is present.
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
@@ -176,7 +176,7 @@ export default function NxTablePage() {
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;tbody&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;tbody&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tbody">
                     HTML tbody Attributes
@@ -184,8 +184,8 @@ export default function NxTablePage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxTable.Body</code> supports any HTML attribute that's normally
-                  supported by <code className="nx-code">&lt;tbody&gt;</code>.
+                  <NxCode>NxTable.Body</NxCode> supports any HTML attribute that's normally
+                  supported by <NxCode>&lt;tbody&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -194,12 +194,12 @@ export default function NxTablePage() {
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTable.Row</h3>
+            <NxH3>NxTable.Row</NxH3>
           </header>
-          <p className="nx-p">
-            Equivalent to the <code className="nx-code">&lt;tr&gt;</code> element.
-            It should have <code className="nx-code">NxTable.Cell</code> for children.
-          </p>
+          <NxP>
+            Equivalent to the <NxCode>&lt;tr&gt;</NxCode> element.
+            It should have <NxCode>NxTable.Cell</NxCode> for children.
+          </NxP>
           <NxTable>
             <NxTable.Head>
               <NxTable.Row>
@@ -241,7 +241,7 @@ export default function NxTablePage() {
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;tr&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;tr&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tr">
                     HTML tr Attributes
@@ -249,8 +249,8 @@ export default function NxTablePage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxTable.Row</code> supports any HTML attribute that's normally
-                  supported by <code className="nx-code">&lt;tr&gt;</code>.
+                  <NxCode>NxTable.Row</NxCode> supports any HTML attribute that's normally
+                  supported by <NxCode>&lt;tr&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -259,12 +259,12 @@ export default function NxTablePage() {
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTable.Cell</h3>
+            <NxH3>NxTable.Cell</NxH3>
           </header>
-          <p className="nx-p">
-            Equivalent to the <code className="nx-code">&lt;th&gt;</code> or
-            {' '}<code className="nx-code">&lt;td&gt;</code> element.
-          </p>
+          <NxP>
+            Equivalent to the <NxCode>&lt;th&gt;</NxCode> or
+            {' '}<NxCode>&lt;td&gt;</NxCode> element.
+          </NxP>
 
           <NxTable>
             <NxTable.Head>
@@ -281,15 +281,15 @@ export default function NxTablePage() {
                 <NxTable.Cell>boolean</NxTable.Cell>
                 <NxTable.Cell>false</NxTable.Cell>
                 <NxTable.Cell>
-                  Sets the <code className="nx-code">.nx-cell--meta-info</code> class on the cell. This class is
+                  Sets the <NxCode>.nx-cell--meta-info</NxCode> class on the cell. This class is
                   applied to table cells that provide meta-information about the table data, such as loading, error,
                   and empty table states. For those three states, the caller of
-                  the <code className="nx-code">NxTable</code> react component does not manage the table cells
-                  directly (instead using the appropriate props on <code className="nx-code">NxTable.Body</code>), and
+                  the <NxCode>NxTable</NxCode> react component does not manage the table cells
+                  directly (instead using the appropriate props on <NxCode>NxTable.Body</NxCode>), and
                   therefore does not need to use this prop. However, the prop is available for any
                   other meta-info states that the caller might wish to convey. The intended usage is that a cell
                   using this prop would be the only cell in the only row in the table body, and would have
-                  a <code className="nx-code">colspan</code> attribute causing it to span all the way across the
+                  a <NxCode>colspan</NxCode> attribute causing it to span all the way across the
                   table.
                 </NxTable.Cell>
               </NxTable.Row>
@@ -314,8 +314,8 @@ export default function NxTablePage() {
                 <NxTable.Cell>
                   Used to indicate the sorting direction applied.
                   A null value indicates the column is not yet sorted.
-                  This should only be used for <code className="nx-code">NxTable.Cell</code> components
-                  in the <code className="nx-code">NxTable.Head</code>
+                  This should only be used for <NxCode>NxTable.Cell</NxCode> components
+                  in the <NxCode>NxTable.Head</NxCode>
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
@@ -324,7 +324,7 @@ export default function NxTablePage() {
                 <NxTable.Cell>false</NxTable.Cell>
                 <NxTable.Cell>
                   Used to indicate a column whose data cells contain only one or
-                  more <code className="nx-code">NxFontAwesomeIcon</code>s
+                  more <NxCode>NxFontAwesomeIcon</NxCode>s
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
@@ -333,15 +333,15 @@ export default function NxTablePage() {
                 <NxTable.Cell>false</NxTable.Cell>
                 <NxTable.Cell>
                   Desginates a cell that should contain only the right-facing chevron icon used at that end of
-                  clickable table cells. <code className="nx-code">NxTable.Cell</code>s with this prop set will
-                  self-populate with the icon, and do not take <code className="nx-code">children</code>. The icon
+                  clickable table cells. <NxCode>NxTable.Cell</NxCode>s with this prop set will
+                  self-populate with the icon, and do not take <NxCode>children</NxCode>. The icon
                   will be wrapped in a button for accessibility purposes, with the button's accessible name set by
                   the row's <NxCode>clickAccessibleLabel</NxCode> prop or generated from the text contents of the
                   rest of the row.
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell>HTML <code className="nx-code">&lt;td&gt;</code> Attributes</NxTable.Cell>
+                <NxTable.Cell>HTML <NxCode>&lt;td&gt;</NxCode> Attributes</NxTable.Cell>
                 <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/td">
                     HTML td Attributes
@@ -349,8 +349,8 @@ export default function NxTablePage() {
                 </NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>
-                  <code className="nx-code">NxTable.Cell</code> supports any HTML attribute that's normally
-                  supported by <code className="nx-code">&lt;td&gt;</code>.
+                  <NxCode>NxTable.Cell</NxCode> supports any HTML attribute that's normally
+                  supported by <NxCode>&lt;td&gt;</NxCode>.
                 </NxTable.Cell>
               </NxTable.Row>
             </NxTable.Body>
@@ -365,28 +365,28 @@ export default function NxTablePage() {
             As seen above, the various child components of <NxCode>NxTable</NxCode> are attached as properties on the
             <NxCode>NxTable</NxCode> object and typically accessed using JavaScript dot notation. In previous versions
             of RSC, this was not the case and the subobjects were instead exposed as top level exports with names along
-            the lines of <NxCode>NxTableRow</NxCode>, <NxCode>NxTableCell</NxCode>, and so on. These old names are still
-            exported by RSC for backwards compatibility, but are deprecated and may be removed in a future major version
-            release.
+            the lines of <NxCode>NxTable.Row</NxCode>, <NxCode>NxTable.Cell</NxCode>, and so on. These old names are
+            still exported by RSC for backwards compatibility, but are deprecated and may be removed in a future major
+            version release.
           </NxP>
         </NxTile.Subsection>
 
         <section className="nx-tile-subsection">
           <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">SCSS Helper Functions</h3>
+            <NxH3>SCSS Helper Functions</NxH3>
           </header>
-          <p className="nx-p">
+          <NxP>
             When constructing a table of paginated data, it is often the case that the table is intended to be exactly
             tall enough to contain one full page's worth of rows, even when on the last page, which may contain fewer
             rows. Achieving this effect requires setting an explicit height on the table container element that is
             equal to the height that it would implicitly get when full. Calculating this height however is
             somewhat complex, requiring summing up the heights of the various table elements in play. Therefore
             RSC provides a SCSS helper function which will return the height of
-            the <code className="nx-code">.nx-table-container</code>'s content box for a paginated table with the
+            the <NxCode>.nx-table-container</NxCode>'s content box for a paginated table with the
             given parameters. The function, located in
-            the <code className="nx-code">scss-shared/_nx-table-helpers.scss</code> file, is named
-            <code className="nx-code">pagination-table-height</code>. See the description of its parameters below.
-          </p>
+            the <NxCode>scss-shared/_nx-table-helpers.scss</NxCode> file, is named
+            <NxCode>pagination-table-height</NxCode>. See the description of its parameters below.
+          </NxP>
           <NxTable>
             <NxTable.Head>
               <NxTable.Row>
@@ -398,7 +398,7 @@ export default function NxTablePage() {
             </NxTable.Head>
             <NxTable.Body>
               <NxTable.Row>
-                <NxTable.Cell><code className="nx-code">$body-row-count</code></NxTable.Cell>
+                <NxTable.Cell><NxCode>$body-row-count</NxCode></NxTable.Cell>
                 <NxTable.Cell>Yes</NxTable.Cell>
                 <NxTable.Cell>N/A</NxTable.Cell>
                 <NxTable.Cell>
@@ -408,7 +408,7 @@ export default function NxTablePage() {
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell><code className="nx-code">$header-filter-row-count</code></NxTable.Cell>
+                <NxTable.Cell><NxCode>$header-filter-row-count</NxCode></NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>0</NxTable.Cell>
                 <NxTable.Cell>
@@ -416,7 +416,7 @@ export default function NxTablePage() {
                 </NxTable.Cell>
               </NxTable.Row>
               <NxTable.Row>
-                <NxTable.Cell><code className="nx-code">$header-row-count</code></NxTable.Cell>
+                <NxTable.Cell><NxCode>$header-row-count</NxCode></NxTable.Cell>
                 <NxTable.Cell>No</NxTable.Cell>
                 <NxTable.Cell>1</NxTable.Cell>
                 <NxTable.Cell>
@@ -428,16 +428,16 @@ export default function NxTablePage() {
           </NxTable>
         </section>
 
-        <p className="nx-p">
+        <NxP>
           For guidance on the construction of a scrolling table, see the scrolling example on
-          the <code className="nx-code">nx-table-container</code> HTML element page.
-        </p>
+          the <NxCode>nx-table-container</NxCode> HTML element page.
+        </NxP>
       </GalleryDescriptionTile>
 
       <GalleryExampleTile title="Simple Example"
                           liveExample={NxTableSimpleExample}
                           codeExamples={tableSimpleExampleCode}>
-        A basic example of <code className="nx-code">NxTable</code>.
+        A basic example of <NxCode>NxTable</NxCode>.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Clickable Row Example"
@@ -469,7 +469,7 @@ export default function NxTablePage() {
                           id="nx-table-pagination-example"
                           liveExample={NxTablePaginationExample}
                           codeExamples={paginationCodeExamples}>
-        An example of a table with an <code className="nx-code">NxPagination</code> component in the footer to control
+        An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
         paging.
       </GalleryExampleTile>
 
@@ -477,37 +477,37 @@ export default function NxTablePage() {
                           id="nx-table-pagination-filter-example"
                           liveExample={NxTablePaginationFilterExample}
                           codeExamples={paginationFilterCodeExamples}>
-        An example of a table with an <code className="nx-code">NxPagination</code> component in the footer to control
+        An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
         paging as well as a row of filter headers. Demonstrates the use of
-        the <code className="nx-code">pagination-table-height</code> SCSS function when a filter row is present.
+        the <NxCode>pagination-table-height</NxCode> SCSS function when a filter row is present.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Loading Example"
                           id="nx-table-loading-example"
                           liveExample={NxTableLoadingExample}
                           codeExamples={tableLoadingExample}>
-        An example of how <code className="nx-code">NxTable</code> should be used while its data is loading.
+        An example of how <NxCode>NxTable</NxCode> should be used while its data is loading.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Error Example"
                           id="nx-table-error-example"
                           liveExample={NxTableErrorExample}
                           codeExamples={tableErrorExample}>
-        An example of how <code className="nx-code">NxTable</code> should be used to indicate that there was an error
+        An example of how <NxCode>NxTable</NxCode> should be used to indicate that there was an error
         loading its data.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Empty Example"
                           liveExample={NxTableEmptyExample}
                           codeExamples={tableEmptyExample}>
-        An example of how <code className="nx-code">NxTable</code> should be used to indicate that there is no data
+        An example of how <NxCode>NxTable</NxCode> should be used to indicate that there is no data
         to be seen.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Custom Meta-Info Example"
                           liveExample={NxTableMetaInfoExample}
                           codeExamples={tableMetaInfoExample}>
-        An example of how <code className="nx-code">NxTable</code> should be used with a custom meta-info situation.
+        An example of how <NxCode>NxTable</NxCode> should be used with a custom meta-info situation.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -6,9 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
-
 import { NxTable, NxTile, NxH3, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxTableSimpleExample from './NxTableSimpleExample';
 import NxTableClickableExample from './NxTableClickableExample';

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -54,10 +54,10 @@ export default function NxTablePage() {
           A set of React components which encapsulate and assist with the styles for HTML tables.
         </NxP>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
             <NxH3>NxTable</NxH3>
-          </header>
+          </NxTile.SubsectionHeader>
           <NxP>
             The top-level component to use when displaying tables of data.
             It can have <NxCode>NxTable.Head</NxCode> and
@@ -88,12 +88,12 @@ export default function NxTablePage() {
               </NxTable.Row>
             </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
             <NxH3>NxTable.Head</NxH3>
-          </header>
+          </NxTile.SubsectionHeader>
           <NxP>
             Equivalent to the <NxCode>&lt;thead&gt;</NxCode> element.
             The <NxCode>NxTable.Row</NxCode> component is the only valid child.
@@ -123,12 +123,12 @@ export default function NxTablePage() {
               </NxTable.Row>
             </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
             <NxH3>NxTable.Body</NxH3>
-          </header>
+          </NxTile.SubsectionHeader>
           <NxP>
             Equivalent to the <NxCode>&lt;tbody&gt;</NxCode> element.
             It should have <NxCode>NxTable.Row</NxCode> for children.
@@ -190,12 +190,12 @@ export default function NxTablePage() {
               </NxTable.Row>
             </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
             <NxH3>NxTable.Row</NxH3>
-          </header>
+          </NxTile.SubsectionHeader>
           <NxP>
             Equivalent to the <NxCode>&lt;tr&gt;</NxCode> element.
             It should have <NxCode>NxTable.Cell</NxCode> for children.
@@ -255,12 +255,12 @@ export default function NxTablePage() {
               </NxTable.Row>
             </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
             <NxH3>NxTable.Cell</NxH3>
-          </header>
+          </NxTile.SubsectionHeader>
           <NxP>
             Equivalent to the <NxCode>&lt;th&gt;</NxCode> or
             {' '}<NxCode>&lt;td&gt;</NxCode> element.
@@ -355,7 +355,7 @@ export default function NxTablePage() {
               </NxTable.Row>
             </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
         <NxTile.Subsection>
           <NxTile.SubsectionHeader>
@@ -371,10 +371,10 @@ export default function NxTablePage() {
           </NxP>
         </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
             <NxH3>SCSS Helper Functions</NxH3>
-          </header>
+          </NxTile.SubsectionHeader>
           <NxP>
             When constructing a table of paginated data, it is often the case that the table is intended to be exactly
             tall enough to contain one full page's worth of rows, even when on the last page, which may contain fewer
@@ -426,7 +426,7 @@ export default function NxTablePage() {
               </NxTable.Row>
             </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
         <NxP>
           For guidance on the construction of a scrolling table, see the scrolling example on

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTile, NxH3, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxTableSimpleExample from './NxTableSimpleExample';

--- a/gallery/src/components/NxTabs/NxTabsPage.tsx
+++ b/gallery/src/components/NxTabs/NxTabsPage.tsx
@@ -7,16 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow,
-  NxCode,
-  NxTextLink
-} from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxTextLink, NxP, NxTile, NxH3 } from '@sonatype/react-shared-components';
 
 import NxTabsTileHeaderExample from './NxTabsTileHeaderExample';
 import NxTabsOutsideTileExample from './NxTabsOutsideTileExample';
@@ -34,178 +25,178 @@ export default function NxTabsPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
+        <NxP>
           A set of accessible tab components which must be used together.
-        </p>
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTabs</h3>
-          </header>
-          <p className="nx-p">
+        </NxP>
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
+            <NxH3>NxTabs</NxH3>
+          </NxTile.SubsectionHeader>
+          <NxP>
             The top-level container for tabbed navigation.
-            It can have <code className="nx-code">&lt;NxTabList&gt;</code> and
-            {' '}<code className="nx-code">&lt;NxTabPanel&gt;</code> components as children.
-          </p>
+            It can have <NxCode>&lt;NxTabList&gt;</NxCode> and
+            {' '}<NxCode>&lt;NxTabPanel&gt;</NxCode> components as children.
+          </NxP>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Prop</NxTableCell>
-                <NxTableCell>Type</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Details</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell>activeTab</NxTableCell>
-                <NxTableCell>number</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>activeTab</NxTable.Cell>
+                <NxTable.Cell>number</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   The index of the active tab. If not set no tab contents will be shown.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell>onTabSelect</NxTableCell>
-                <NxTableCell>function(number)</NxTableCell>
-                <NxTableCell>false</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell>onTabSelect</NxTable.Cell>
+                <NxTable.Cell>function(number)</NxTable.Cell>
+                <NxTable.Cell>false</NxTable.Cell>
+                <NxTable.Cell>
                   Called with the index of the newly selected tab when the currently selected tab changes.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTabList</h3>
-          </header>
-          <p className="nx-p">
-            The parent container for the <code className="nx-code">&lt;NxTab&gt;</code> components.
-            Passes through all attributes to an underlying <code className="nx-code">ul</code> element.
-          </p>
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
+            <NxH3>NxTabList</NxH3>
+          </NxTile.SubsectionHeader>
+          <NxP>
+            The parent container for the <NxCode>&lt;NxTab&gt;</NxCode> components.
+            Passes through all attributes to an underlying <NxCode>ul</NxCode> element.
+          </NxP>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Prop</NxTableCell>
-                <NxTableCell>Type</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Details</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>
                   HTML <NxCode>&lt;ul&gt;</NxCode> Attributes
-                </NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+                <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/ul">
                     HTML ul Attributes
                   </NxTextLink><br/>
-                </NxTableCell>
-                <NxTableCell>No</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
                   <NxCode>NxTabList</NxCode> supports any html attributes that are normally supported by the
                   {' '}<NxCode>&lt;ul&gt;</NxCode> element.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTab</h3>
-          </header>
-          <p className="nx-p">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
+            <NxH3>NxTab</NxH3>
+          </NxTile.SubsectionHeader>
+          <NxP>
             The component the user selects to switch tabs.
-            The index prop is automatically configured by the <code className="nx-code">NxTabs</code> component.
-            There should be one of these for each <code className="nx-code">NxTabPanel</code> component.
+            The index prop is automatically configured by the <NxCode>NxTabs</NxCode> component.
+            There should be one of these for each <NxCode>NxTabPanel</NxCode> component.
             Passes through all attributes to an underlying li element.
-          </p>
+          </NxP>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Prop</NxTableCell>
-                <NxTableCell>Type</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Details</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>
                   HTML <NxCode>&lt;li&gt;</NxCode> Attributes
-                </NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+                <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/li">
                     HTML li Attributes
                   </NxTextLink>
-                </NxTableCell>
-                <NxTableCell>No</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
                   <NxCode>NxTab</NxCode> supports any html attributes that are normally supported by the
                   {' '}<NxCode>&lt;li&gt;</NxCode> element.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
 
-        <section className="nx-tile-subsection">
-          <header className="nx-tile-subsection__header">
-            <h3 className="nx-h3">NxTabPanel</h3>
-          </header>
-          <p className="nx-p">
+        <NxTile.Subsection>
+          <NxTile.SubsectionHeader>
+            <NxH3>NxTabPanel</NxH3>
+          </NxTile.SubsectionHeader>
+          <NxP>
             Container component for the tab contents.
-            The index prop is automatically configured by the <code className="nx-code">NxTabs</code> component.
-            There should be one of these for each <code className="nx-code">NxTab</code> component.
+            The index prop is automatically configured by the <NxCode>NxTabs</NxCode> component.
+            There should be one of these for each <NxCode>NxTab</NxCode> component.
             Passes through all attributes to an underlying div element.
-          </p>
+          </NxP>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Prop</NxTableCell>
-                <NxTableCell>Type</NxTableCell>
-                <NxTableCell>Required</NxTableCell>
-                <NxTableCell>Details</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Prop</NxTable.Cell>
+                <NxTable.Cell>Type</NxTable.Cell>
+                <NxTable.Cell>Required</NxTable.Cell>
+                <NxTable.Cell>Details</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell>
                   HTML <NxCode>&lt;div&gt;</NxCode> Attributes
-                </NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+                <NxTable.Cell>
                   <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/div">
                     HTML div Attributes
                   </NxTextLink>
-                </NxTableCell>
-                <NxTableCell>No</NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+                <NxTable.Cell>No</NxTable.Cell>
+                <NxTable.Cell>
                   <NxCode>NxTabPanel</NxCode> supports any html attributes that are normally supported by the
                   {' '}<NxCode>&lt;div&gt;</NxCode> element.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
-        </section>
+        </NxTile.Subsection>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="NxTabs in NxTile Example"
                           id="nx-tab-tile-example"
                           defaultCheckeredBackground={true}
                           liveExample={NxTabsTileHeaderExample}
                           codeExamples={NxTabsTileHeaderExampleCode}>
-        A basic example of how to use the <code className="nx-code">NxTabs</code> family of components in an
-        {' '}<code className="nx-code">NxTile</code>.
+        A basic example of how to use the <NxCode>NxTabs</NxCode> family of components in an
+        {' '}<NxCode>NxTile</NxCode>.
       </GalleryExampleTile>
       <GalleryExampleTile title="NxTabs in NxTile with no header Example"
                           id="nx-tab-tile-no-header-example"
                           defaultCheckeredBackground={true}
                           liveExample={NxTabsTileNoHeaderExample}
                           codeExamples={NxTabsTileNoHeaderExampleCode}>
-        A basic example of how to use the <code className="nx-code">NxTabs</code> family of components in an
-        {' '}<code className="nx-code">NxTile</code> where there is no tile header and the tabs are top most within
+        A basic example of how to use the <NxCode>NxTabs</NxCode> family of components in an
+        {' '}<NxCode>NxTile</NxCode> where there is no tile header and the tabs are top most within
         the tile.
       </GalleryExampleTile>
       <GalleryExampleTile title="NxTabs outside of NxTile Example"
@@ -213,22 +204,22 @@ export default function NxTabsPage() {
                           defaultCheckeredBackground={true}
                           liveExample={NxTabsOutsideTileExample}
                           codeExamples={NxTabsOutsideTileExampleCode}>
-        A basic example of how to use the <code className="nx-code">NxTabs</code> family of components at the page
+        A basic example of how to use the <NxCode>NxTabs</NxCode> family of components at the page
         level, outside of tiles or tables.
       </GalleryExampleTile>
       <GalleryExampleTile title="NxTabs in NxModal Example"
                           id="nx-tab-modal-example"
                           liveExample={NxTabsModalExample}
                           codeExamples={NxTabsModalExampleCode}>
-        A basic example of how to use the <code className="nx-code">NxTabs</code> family of components in an
-        {' '}<code className="nx-code">NxModal</code>.
+        A basic example of how to use the <NxCode>NxTabs</NxCode> family of components in an
+        {' '}<NxCode>NxModal</NxCode>.
       </GalleryExampleTile>
       <GalleryExampleTile title="NxTabs in NxModal with No Header Example"
                           id="nx-tab-modal-no-header-example"
                           liveExample={NxTabsModalNoHeaderExample}
                           codeExamples={NxTabsModalNoHeaderExampleCode}>
-        A basic example of how to use the <code className="nx-code">NxTabs</code> family of components in an
-        {' '}<code className="nx-code">NxModal</code> with no modal header.
+        A basic example of how to use the <NxCode>NxTabs</NxCode> family of components in an
+        {' '}<NxCode>NxModal</NxCode> with no modal header.
       </GalleryExampleTile>
     </>
   );

--- a/gallery/src/components/NxTabs/NxTabsPage.tsx
+++ b/gallery/src/components/NxTabs/NxTabsPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxTextLink, NxP, NxTile, NxH3 } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTabsTileHeaderExample from './NxTabsTileHeaderExample';
 import NxTabsOutsideTileExample from './NxTabsOutsideTileExample';

--- a/gallery/src/components/NxTabs/NxTabsPage.tsx
+++ b/gallery/src/components/NxTabs/NxTabsPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxTextLink, NxP, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTabsTileHeaderExample from './NxTabsTileHeaderExample';

--- a/gallery/src/components/NxTag/NxTagPage.tsx
+++ b/gallery/src/components/NxTag/NxTagPage.tsx
@@ -10,8 +10,7 @@ import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-componen
 import NxTagExample from './NxTagExample';
 import NxSelectableTagExample from './NxSelectableTagExample';
 import NxTagNarrowExample from './NxTagNarrowExample';
-import { NxTable, NxTableHead, NxTableCell, NxTableRow, NxTableBody, NxTextLink }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxP, NxCode, NxH3 } from '@sonatype/react-shared-components';
 
 const NxTagExampleCode = require('./NxTagExample?raw');
 const NxSelectableTagExampleCode = require('./NxSelectableTagExample?raw');
@@ -20,91 +19,91 @@ const NxTagNarrowExampleCode = require('./NxTagNarrowExample?raw');
 const NxTagPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        There are two types of <code className="nx-code">NxTag</code>. The basic tags have a single state.
-        <code className="nx-code">NxSelectableTag</code> can be selected and deselected. It is up to the consumer
+      <NxP>
+        There are two types of <NxCode>NxTag</NxCode>. The basic tags have a single state.
+        <NxCode>NxSelectableTag</NxCode> can be selected and deselected. It is up to the consumer
         what that means in the context of the UI. The are many colors provided
-        for <code className="nx-code">NxTag</code> which can be specified via props.
-      </p>
-      <h3 className="nx-h3">Common Props</h3>
+        for <NxCode>NxTag</NxCode> which can be specified via props.
+      </NxP>
+      <NxH3>Common Props</NxH3>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Default</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>color</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Default</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>color</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink href="#/pages/Selectable Colors">SelectableColor</NxTextLink>
               <br/>
               ('light-blue' | 'purple' | 'pink' | 'blue' | 'red' | 'green' | 'orange' | 'yellow' | 'lime' | 'indigo')
 
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell>indigo</NxTableCell>
-            <NxTableCell>
-              If no <code className="nx-code">color</code> is specified then the default (dark grey/blue with a lighter
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>indigo</NxTable.Cell>
+            <NxTable.Cell>
+              If no <NxCode>color</NxCode> is specified then the default (dark grey/blue with a lighter
               grey/blue unselected state) colors are used.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>HTML <code className="nx-code">&lt;div&gt;</code> Attributes</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;div&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/element/div">
                 HTML div Attributes
               </NxTextLink>
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell></NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell></NxTable.Cell>
+            <NxTable.Cell>
               NxTag supports any html attribute that's normally supported by
-              {' '}<code className="nx-code">&lt;div&gt;</code> elements.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+              {' '}<NxCode>&lt;div&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
-      <h3 className="nx-h3">Selectable Tag Props</h3>
+      <NxH3>Selectable Tag Props</NxH3>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Prop</NxTableCell>
-            <NxTableCell>Type</NxTableCell>
-            <NxTableCell>Required</NxTableCell>
-            <NxTableCell>Default</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell>onSelect</NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Default</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>onSelect</NxTable.Cell>
+            <NxTable.Cell>
               Function
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell></NxTableCell>
-            <NxTableCell>
-              Callback that changes the value of <code className="nx-code">selected</code> below between true
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell></NxTable.Cell>
+            <NxTable.Cell>
+              Callback that changes the value of <NxCode>selected</NxCode> below between true
               (selected) and false (unselected).
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell>selected</NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>selected</NxTable.Cell>
+            <NxTable.Cell>
               Boolean
-            </NxTableCell>
-            <NxTableCell>No</NxTableCell>
-            <NxTableCell></NxTableCell>
-            <NxTableCell>
-              Boolean for the selected/unselected state of a <code className="nx-code">NxSelectableTag</code>
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell></NxTable.Cell>
+            <NxTable.Cell>
+              Boolean for the selected/unselected state of a <NxCode>NxSelectableTag</NxCode>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 

--- a/gallery/src/components/NxTag/NxTagPage.tsx
+++ b/gallery/src/components/NxTag/NxTagPage.tsx
@@ -6,11 +6,12 @@
  */
 import React from 'react';
 
+import { NxTable, NxTextLink, NxP, NxCode, NxH3 } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+
 import NxTagExample from './NxTagExample';
 import NxSelectableTagExample from './NxSelectableTagExample';
 import NxTagNarrowExample from './NxTagNarrowExample';
-import { NxTable, NxTextLink, NxP, NxCode, NxH3 } from '@sonatype/react-shared-components';
 
 const NxTagExampleCode = require('./NxTagExample?raw');
 const NxSelectableTagExampleCode = require('./NxSelectableTagExample?raw');

--- a/gallery/src/components/NxTag/NxTagPage.tsx
+++ b/gallery/src/components/NxTag/NxTagPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP, NxCode, NxH3 } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxTagExample from './NxTagExample';

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTextInputSimpleExample from './NxTextInputSimpleExample';

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTextInputSimpleExample from './NxTextInputSimpleExample';
 import NxTextInputValidationExample from './NxTextInputValidationExample';

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxTextInputSimpleExample from './NxTextInputSimpleExample';
 import NxTextInputValidationExample from './NxTextInputValidationExample';
@@ -15,7 +16,6 @@ import NxTextInputTextAreaExample from './NxTextInputTextAreaExample';
 import NxTextInputTextAreaValidationExample from './NxTextInputTextAreaValidationExample';
 import NxTextInputLongExample from './NxTextInputLongExample';
 import NxTextInputDisabledExample from './NxTextInputDisabledExample';
-import { NxTextLink } from '@sonatype/react-shared-components';
 
 const simpleSourceCode = require('./NxTextInputSimpleExample?raw');
 const validationSourceCode = require('./NxTextInputValidationExample?raw');
@@ -28,110 +28,110 @@ const disabledSourceCode = require('./NxTextInputDisabledExample?raw');
 const NxTextInputPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Standard text input with validation styling</p>
-      <p className="nx-p">Props:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">type</td>
-            <td className="nx-cell">"textarea" | "text" | "password"</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">What type of text input to render.  Defaults to "text"</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">value</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">The value rendered in the text input</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isPristine</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+      <NxP>Standard text input with validation styling</NxP>
+      <NxP>Props:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>type</NxTable.Cell>
+            <NxTable.Cell>"textarea" | "text" | "password"</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>What type of text input to render.  Defaults to "text"</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>value</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>The value rendered in the text input</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isPristine</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Should be set to true when the user has not yet adjusted the value of the input
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">validatable</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>validatable</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If true, this NxTextInput is subject to validation, the result of which should be passed in via
-              the <code className="nx-code">validationErrors</code> prop, resulting in validation CSS classes being
+              the <NxCode>validationErrors</NxCode> prop, resulting in validation CSS classes being
               applied (see below). If false, the NxTextInput is not considered to be subject to validation, the
-              <code className="nx-code">validationErrors</code> prop is ignored, and validation-related CSS classes
+              <NxCode>validationErrors</NxCode> prop is ignored, and validation-related CSS classes
               are never applied.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">validationErrors</td>
-            <td className="nx-cell">string | string[]</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              Validation failure messages for components where <code className="nx-code">validatable</code> is
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>validationErrors</NxTable.Cell>
+            <NxTable.Cell>string | string[]</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              Validation failure messages for components where <NxCode>validatable</NxCode> is
               true. Any strings contained by this prop's value are taken to be error messages describing a validation
               failure. These trigger the invalid styling on the component and the first such error message is
               displayed within the component. If this prop's value does not contain any strings (i.e. if it is null,
               undefined, or an empty array), the component value is taken to be valid, and corresponding styles
               are added. For non-validatable components, this prop is ignored.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function ((string) =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function ((string) =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A callback for when the user changes the value of the text box (e.g. by typing a letter)
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onKeyPress</td>
-            <td className="nx-cell">Function ((string) =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              <p className="nx-p">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onKeyPress</NxTable.Cell>
+            <NxTable.Cell>Function ((string) =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 A callback for when the user presses a key that doesn't necessarily change the input value
                 (e.g. by hitting enter)
-              </p>
-              <p className="nx-p">
+              </NxP>
+              <NxP>
                 The value given to the callback will be that of the key name, as described in the spec
                 for{' '}
                 <NxTextLink external href="https://www.w3.org/TR/uievents-key/#named-key-attribute-values">
                   named keys
                 </NxTextLink>
-              </p>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              HTML <code className="nx-code">&lt;input&gt;</code> Attributes |
-              HTML <code className="nx-code">&lt;textarea&gt;</code> Attributes
-            </td>
-            <td className="nx-cell">
+              </NxP>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              HTML <NxCode>&lt;input&gt;</NxCode> Attributes |
+              HTML <NxCode>&lt;textarea&gt;</NxCode> Attributes
+            </NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/input">
                 Input Attributes
               </NxTextLink>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/textarea">
                 Textarea Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               NxTextInput supports any html attribute that's normally supported by either HTML
-              <code className="nx-code">&lt;input&gt;</code> or HTML
-              <code className="nx-code">&lt;textarea&gt;</code>. The only notable exceptions are:
+              <NxCode>&lt;input&gt;</NxCode> or HTML
+              <NxCode>&lt;textarea&gt;</NxCode>. The only notable exceptions are:
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
-                  <code className="nx-code">defaultValue</code> which is left out because it creates what's commonly
+                  <NxCode>defaultValue</NxCode> which is left out because it creates what's commonly
                   known as{' '}
                   <NxTextLink external href="https://reactjs.org/docs/uncontrolled-components.html">
                     uncontrolled inputs
@@ -142,70 +142,70 @@ const NxTextInputPage = () =>
                   react propTypes.
                 </li>
               </ul>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
       <h3>State Helpers</h3>
-      <p className="nx-p">
-        The <code className="nx-code">nxTextInputStateHelpers</code>{' '}
+      <NxP>
+        The <NxCode>nxTextInputStateHelpers</NxCode>{' '}
         includes the following recommended state helper functions, which each return an object containining the
         "stateful" parts of the NxTextInput props{' '}
-        (<code className="nx-code">value</code>, <code className="nx-code">isPristine</code>, and{' '}
-        <code className="nx-code">validationErrors</code>) as well as <code className="nx-code">trimmedValue</code>,
-        which holds a whitespace-trimmed copy of the <code className="nx-code">value</code>:
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Function</th>
-            <th className="nx-cell nx-cell--header">Arguments</th>
-            <th className="nx-cell nx-cell--header">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">initialState</td>
-            <td className="nx-cell">(initialValue: string)</td>
-            <td className="nx-cell">
-              Returns an initialized state with the specified value and <code className="nx-code">isPristine</code>
+        (<NxCode>value</NxCode>, <NxCode>isPristine</NxCode>, and{' '}
+        <NxCode>validationErrors</NxCode>) as well as <NxCode>trimmedValue</NxCode>,
+        which holds a whitespace-trimmed copy of the <NxCode>value</NxCode>:
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Arguments</NxTable.Cell>
+            <NxTable.Cell>Description</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>initialState</NxTable.Cell>
+            <NxTable.Cell>(initialValue: string)</NxTable.Cell>
+            <NxTable.Cell>
+              Returns an initialized state with the specified value and <NxCode>isPristine</NxCode>
               set to true.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">userInput</td>
-            <td className="nx-cell">(validator, newValue: string)</td>
-            <td className="nx-cell">
-              <p className="nx-p">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>userInput</NxTable.Cell>
+            <NxTable.Cell>(validator, newValue: string)</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 Meant to be used to handle user changes to the text input value. The first argument is an optional
                 validator function that receives the new input value (trimmed) as a string and returns zero or more
                 validation error messages. The next argument is the new (raw, untrimmed) value of the text box after
                 the user's input.  Returns a state object that is not pristine, with the specified
-                <code className="nx-code">value</code>, and with <code className="nx-code">validationErrors</code> as
+                <NxCode>value</NxCode>, and with <NxCode>validationErrors</NxCode> as
                 computed by the validator function.
-              </p>
-              <p className="nx-p">
+              </NxP>
+              <NxP>
                 This function is curried, so that it can be partially applied over the
-                <code className="nx-code">validator</code>.
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                <NxCode>validator</NxCode>.
+              </NxP>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"
                         id="nx-text-input-simple-example"
                         liveExample={NxTextInputSimpleExample}
                         codeExamples={simpleSourceCode}>
-      A basic example of an <code className="nx-code">NxTextInput</code>.
+      A basic example of an <NxCode>NxTextInput</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Example with non-emptiness validation"
                         id="nx-text-input-validation-example"
                         liveExample={NxTextInputValidationExample}
                         codeExamples={validationSourceCode}>
-      An example of an <code className="nx-code">NxTextInput</code> that validates that its contents are non-empty.
+      An example of an <NxCode>NxTextInput</NxCode> that validates that its contents are non-empty.
       Notice that once the user has entered some content, the input from then on displays either the valid or invalid
       styles, depending on whether it has any contents.
     </GalleryExampleTile>
@@ -214,37 +214,37 @@ const NxTextInputPage = () =>
                         id="nx-text-input-password-example"
                         liveExample={NxTextInputPasswordExample}
                         codeExamples={passwordSourceCode}>
-      An example of an <code className="nx-code">NxTextInput</code> for password entry.
+      An example of an <NxCode>NxTextInput</NxCode> for password entry.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="TextArea input example"
                         id="nx-text-input-textarea-example"
                         liveExample={NxTextInputTextAreaExample}
                         codeExamples={textAreaSourceCode}>
-      An example of an <code className="nx-code">NxTextInput</code> set up to be a multi-line text area.
+      An example of an <NxCode>NxTextInput</NxCode> set up to be a multi-line text area.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="TextArea input example with validation"
                         id="nx-text-input-textarea-validation-example"
                         liveExample={NxTextInputTextAreaValidationExample}
                         codeExamples={textAreaValidationSourceCode}>
-      An example of an <code className="nx-code">NxTextInput</code> set up to be a multi-line text area with validation.
+      An example of an <NxCode>NxTextInput</NxCode> set up to be a multi-line text area with validation.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Long example"
                         id="nx-text-input-long-example"
                         liveExample={NxTextInputLongExample}
                         codeExamples={longSourceCode}>
-      Examples of <code className="nx-code">NxTextInput</code>s using
-      the <code className="nx-code">long</code> modifier, which makes them wider.
+      Examples of <NxCode>NxTextInput</NxCode>s using
+      the <NxCode>long</NxCode> modifier, which makes them wider.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Disabled example"
                         id="nx-text-input-disabled-example"
                         liveExample={NxTextInputDisabledExample}
                         codeExamples={disabledSourceCode}>
-      Examples of disabled <code className="nx-code">NxTextInput</code>s. Notice that when
-      disabled, <code className="nx-code">NxTextInput</code> never shows style variations for validation, hover, etc.
+      Examples of disabled <NxCode>NxTextInput</NxCode>s. Notice that when
+      disabled, <NxCode>NxTextInput</NxCode> never shows style variations for validation, hover, etc.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxTextLink/NxTextLinkPage.tsx
+++ b/gallery/src/components/NxTextLink/NxTextLinkPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTextLinkInternalExample from './NxTextLinkInternalExample';

--- a/gallery/src/components/NxTextLink/NxTextLinkPage.tsx
+++ b/gallery/src/components/NxTextLink/NxTextLinkPage.tsx
@@ -7,15 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-
-import {
-  NxTable,
-  NxTableBody,
-  NxTableCell,
-  NxTableHead,
-  NxTableRow,
-  NxTextLink
-} from '@sonatype/react-shared-components';
+import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxTextLinkInternalExample from './NxTextLinkInternalExample';
 import NxTextLinkExternalExample from './NxTextLinkExternalExample';
@@ -27,70 +19,70 @@ export default function NxTabsPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
+        <NxP>
           A text hyperlink with standard styles and behaviors for both internal and external links.
-        </p>
+        </NxP>
 
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Prop</NxTableCell>
-              <NxTableCell>Type</NxTableCell>
-              <NxTableCell>Required</NxTableCell>
-              <NxTableCell>Default</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell>external</NxTableCell>
-              <NxTableCell>boolean</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Default</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>external</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>
                 Whether or not this link is to an external page outside of the current web application. If true,
                 the link text will be appended with an "external link" icon. This prop also affects the defaults of the
-                <code className="nx-code">noReferrer</code> and <code className="nx-code">newTab</code> props.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>noReferrer</NxTableCell>
-              <NxTableCell>boolean</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>false for internal links, true for external links</NxTableCell>
-              <NxTableCell>
-                When set to true, the <code className="nx-code">noreferrer</code> rel is added to the link which
+                <NxCode>noReferrer</NxCode> and <NxCode>newTab</NxCode> props.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>noReferrer</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>false for internal links, true for external links</NxTable.Cell>
+              <NxTable.Cell>
+                When set to true, the <NxCode>noreferrer</NxCode> rel is added to the link which
                 prevents certain properties from being passed through to the link target that can allow the target
-                to discern what site was linked from, specificall, the <code className="nx-code">Referer</code> HTTP
-                header and the <code className="nx-code">window.opener</code> JavaScript property.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>newTab</NxTableCell>
-              <NxTableCell>boolean</NxTableCell>
-              <NxTableCell>false</NxTableCell>
-              <NxTableCell>false for internal links, true for external links</NxTableCell>
-              <NxTableCell>
+                to discern what site was linked from, specificall, the <NxCode>Referer</NxCode> HTTP
+                header and the <NxCode>window.opener</NxCode> JavaScript property.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>newTab</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>false</NxTable.Cell>
+              <NxTable.Cell>false for internal links, true for external links</NxTable.Cell>
+              <NxTable.Cell>
                 Whether or not this link should open in a new tab/window. Note that this is accomplished via the
-                link's <code className="nx-code">target</code> attribute, and any explictly
-                set <code className="nx-code">target</code> will override this prop.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell>HTML <code className="nx-code">&lt;a&gt;</code> Attributes</NxTableCell>
-              <NxTableCell>
+                link's <NxCode>target</NxCode> attribute, and any explictly
+                set <NxCode>target</NxCode> will override this prop.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>HTML <NxCode>&lt;a&gt;</NxCode> Attributes</NxTable.Cell>
+              <NxTable.Cell>
                 <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/a">
                   HTML a Attributes
                 </NxTextLink>
-              </NxTableCell>
-              <NxTableCell>No</NxTableCell>
-              <NxTableCell>N/A</NxTableCell>
-              <NxTableCell>
+              </NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>N/A</NxTable.Cell>
+              <NxTable.Cell>
                 NxTextLink supports any HTML attribute that's normally supported
-                by <code className="nx-code">&lt;a&gt;</code>.
-              </NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+                by <NxCode>&lt;a&gt;</NxCode>.
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </GalleryDescriptionTile>
 
@@ -98,14 +90,14 @@ export default function NxTabsPage() {
                           id="nx-text-link-internal-example"
                           liveExample={NxTextLinkInternalExample}
                           codeExamples={NxTextLinkInternalExampleCode}>
-        A simple <code className="nx-code">NxTextLink</code> to an internal page.
+        A simple <NxCode>NxTextLink</NxCode> to an internal page.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="NxTextLink External Link Example"
                           id="nx-text-link-external-example"
                           liveExample={NxTextLinkExternalExample}
                           codeExamples={NxTextLinkExternalExampleCode}>
-        A simple <code className="nx-code">NxTextLink</code> to an external page. Note the icon and that it opens
+        A simple <NxCode>NxTextLink</NxCode> to an external page. Note the icon and that it opens
         in a new tab.
       </GalleryExampleTile>
     </>

--- a/gallery/src/components/NxTextLink/NxTextLinkPage.tsx
+++ b/gallery/src/components/NxTextLink/NxTextLinkPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxTextLink, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTextLinkInternalExample from './NxTextLinkInternalExample';
 import NxTextLinkExternalExample from './NxTextLinkExternalExample';

--- a/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
+++ b/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxThreatCounterExample from './NxThreatCounterExample';

--- a/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
+++ b/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxThreatCounterExample from './NxThreatCounterExample';
 import NxThreatCounterSmallExample from './NxThreatCounterSmallExample';
@@ -26,135 +26,135 @@ const NxThreatCounterCode = require('./NxThreatCounterExample?raw'),
 const NxThreatCounterPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Component for a series of small counters which display a number representing a count of threats/violations,
         and a short pre-set text string which displays the severity (critical, severe, moderate, low, and none).
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         Each count is optional. If no value is provided for a given count, then the indicator for that severity level
         will not be rendered.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         Three basic layouts have been demonstrated below. It is expected that one of these should satisfy any
         requirement.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">criticalCount</td>
-            <td className="nx-cell">number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>criticalCount</NxTable.Cell>
+            <NxTable.Cell>number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A numerical value, the number of critical threats. If no value is provided, then the count will be hidden.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">severeCount</td>
-            <td className="nx-cell">number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>severeCount</NxTable.Cell>
+            <NxTable.Cell>number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A numerical value, the number of severe threats. If no value is provided, then the count will be hidden.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">moderateCount</td>
-            <td className="nx-cell">number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>moderateCount</NxTable.Cell>
+            <NxTable.Cell>number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A numerical value, the number of moderate threats. If no value is provided, then the count will be hidden.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">lowCount</td>
-            <td className="nx-cell">number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>lowCount</NxTable.Cell>
+            <NxTable.Cell>number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A numerical value, the number of low threats. If no value is provided, then the count will be hidden.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">noneCount</td>
-            <td className="nx-cell">number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>noneCount</NxTable.Cell>
+            <NxTable.Cell>number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               A numerical value, the number of counted items posing no threat. If no value is provided, then the count
               will be hidden.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">layout</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>layout</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Sets the layout of the counters. If no value is provided then "row" layout will be specified. The other
-              options are <code className="nx-code">column</code> and <code className="nx-code">grid</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;dl&gt;</code> Attributes</td>
-            <td className="nx-cell">
+              options are <NxCode>column</NxCode> and <NxCode>grid</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;dl&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/dl">
                 HTML dl Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              <code className="nx-code">NxThreatCounter</code> supports any HTML attribute that's normally
-              supported by <code className="nx-code">&lt;dl&gt;</code> elements.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>NxThreatCounter</NxCode> supports any HTML attribute that's normally
+              supported by <NxCode>&lt;dl&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="NxThreatCounter Default Example"
                         id="nx-threat-counter-row"
                         liveExample={NxThreatCounterExample}
                         codeExamples={NxThreatCounterCode}>
-      <code className="nx-code">nx-threat-counter</code>s in the default (row) layout.
+      <NxCode>nx-threat-counter</NxCode>s in the default (row) layout.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxThreatCounter Small Default Example"
                         id="nx-threat-counter-small-row"
                         liveExample={NxThreatCounterSmallExample}
                         codeExamples={NxThreatCounterSmallCode}>
-      <code className="nx-code">nx-threat-counter</code>s in the default (row) layout with only two counts.
+      <NxCode>nx-threat-counter</NxCode>s in the default (row) layout with only two counts.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxThreatCounter Column Example"
                         id="nx-threat-counter-column"
                         liveExample={NxThreatCounterColumnExample}
                         codeExamples={NxThreatCounterColumnCode}>
-      <code className="nx-code">nx-threat-counter</code>s in column layout.
+      <NxCode>nx-threat-counter</NxCode>s in column layout.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxThreatCounter Small Column Example"
                         id="nx-threat-counter-small-column"
                         liveExample={NxThreatCounterSmallColumnExample}
                         codeExamples={NxThreatCounterSmallColumnCode}>
-      <code className="nx-code">nx-threat-counter</code>s in column layout with only two counts.
+      <NxCode>nx-threat-counter</NxCode>s in column layout with only two counts.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxThreatCounter Grid Example"
                         id="nx-threat-counter-grid"
                         liveExample={NxThreatCounterGridExample}
                         codeExamples={NxThreatCounterGridCode}>
-      <code className="nx-code">nx-threat-counter</code>s in a 3x2 "grid" layout.
+      <NxCode>nx-threat-counter</NxCode>s in a 3x2 "grid" layout.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxThreatCounter Small Grid Example"
                         id="nx-threat-counter-small-grid"
                         liveExample={NxThreatCounterSmallGridExample}
                         codeExamples={NxThreatCounterSmallGridCode}>
-      <code className="nx-code">nx-threat-counter</code>s in a 1x2 "grid" layout.
+      <NxCode>nx-threat-counter</NxCode>s in a 1x2 "grid" layout.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
+++ b/gallery/src/components/NxThreatCounter/NxThreatCounterPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxThreatCounterExample from './NxThreatCounterExample';
 import NxThreatCounterSmallExample from './NxThreatCounterSmallExample';

--- a/gallery/src/components/NxThreatIndicator/NxThreatIndicatorPage.tsx
+++ b/gallery/src/components/NxThreatIndicator/NxThreatIndicatorPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxThreatIndicatorByCategoryExample from './NxThreatIndicatorByCategoryExample';
 import NxThreatIndicatorByPolicyNumberExample from './NxThreatIndicatorByPolicyNumberExample';

--- a/gallery/src/components/NxThreatIndicator/NxThreatIndicatorPage.tsx
+++ b/gallery/src/components/NxThreatIndicator/NxThreatIndicatorPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 
 import NxThreatIndicatorByCategoryExample from './NxThreatIndicatorByCategoryExample';
 import NxThreatIndicatorByPolicyNumberExample from './NxThreatIndicatorByPolicyNumberExample';
@@ -21,97 +22,97 @@ const nxThreatIndicatorByCategoryCode = require('./NxThreatIndicatorByCategoryEx
 const NxThreatIndicatorPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">NxThreatIndicator</code> is an inline element used
+      <NxP>
+        <NxCode>NxThreatIndicator</NxCode> is an inline element used
         to indicate via color the IQ policy threat level of the information to follow that follows it.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         There are two scales to choose from: threat level by category, and threat
         level by number. When using this component, it is expected that just one of the props will be passed. If both
-        are passed, <code className="nx-code">threatLevelCategory</code> takes precedence. If neither are passed,
-        the <code className="nx-code">unspecified</code> category is used
-      </p>
-      <table className="nx-table">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">threatLevelCategory</td>
-            <td className="nx-cell">One of 'unspecified', 'none', 'low', 'moderate', 'severe', or 'critical'</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A Threat Level Category off of which to base the indicator color</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">policyThreatLevel</td>
-            <td className="nx-cell">number (0 - 10 inclusive)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A Policy Threat Level Number off of which to base the indicator color</td>
-          </tr>
-        </tbody>
-      </table>
+        are passed, <NxCode>threatLevelCategory</NxCode> takes precedence. If neither are passed,
+        the <NxCode>unspecified</NxCode> category is used
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>threatLevelCategory</NxTable.Cell>
+            <NxTable.Cell>One of 'unspecified', 'none', 'low', 'moderate', 'severe', or 'critical'</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A Threat Level Category off of which to base the indicator color</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>policyThreatLevel</NxTable.Cell>
+            <NxTable.Cell>number (0 - 10 inclusive)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A Policy Threat Level Number off of which to base the indicator color</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
 
-      <p className="nx-p">
+      <NxP>
         The following table shows the mapping between threat level number and threat level category.
-      </p>
-      <table className="nx-table">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Threat Level Number</th>
-            <th className="nx-cell nx-cell--header">Threat Level Category</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">0</td>
-            <td className="nx-cell">none</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">1</td>
-            <td className="nx-cell">low</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">2 - 3</td>
-            <td className="nx-cell">moderate</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">4 - 7</td>
-            <td className="nx-cell">severe</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">8 - 10</td>
-            <td className="nx-cell">critical</td>
-          </tr>
-        </tbody>
-      </table>
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Threat Level Number</NxTable.Cell>
+            <NxTable.Cell>Threat Level Category</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>0</NxTable.Cell>
+            <NxTable.Cell>none</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>1</NxTable.Cell>
+            <NxTable.Cell>low</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>2 - 3</NxTable.Cell>
+            <NxTable.Cell>moderate</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>4 - 7</NxTable.Cell>
+            <NxTable.Cell>severe</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>8 - 10</NxTable.Cell>
+            <NxTable.Cell>critical</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Threat Indicators by Category"
                         id="nx-threat-indicator-simple-example"
                         liveExample={NxThreatIndicatorByCategoryExample}
                         codeExamples={nxThreatIndicatorByCategoryCode}>
-      A series of lines of text, each beginning with an <code className="nx-code">NxThreatIndicator</code> whose
-      color is set to a different <code className="nx-code">threatLevelCategory</code> value.
+      A series of lines of text, each beginning with an <NxCode>NxThreatIndicator</NxCode> whose
+      color is set to a different <NxCode>threatLevelCategory</NxCode> value.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Threat Indicators by Policy Number"
                         liveExample={NxThreatIndicatorByPolicyNumberExample}
                         codeExamples={nxThreatIndicatorByPolicyNumberCode}>
-      A series of lines of text, each beginning with an <code className="nx-code">NxThreatIndicator</code> whose
-      color is set to a different <code className="nx-code">policyThreatNumber</code> value.
+      A series of lines of text, each beginning with an <NxCode>NxThreatIndicator</NxCode> whose
+      color is set to a different <NxCode>policyThreatNumber</NxCode> value.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Threat Indicators in nx-list"
                         id="nx-threat-indicator-list-example"
                         liveExample={NxThreatIndicatorListExample}
                         codeExamples={nxThreatIndicatorListCode}>
-      An <code className="nx-code">.nx-list</code> including rows in various configurations, each starting with
-      an <code className="nx-code">NxThreatIndicator</code>. Note that this list uses such a wide variety of
+      An <NxCode>.nx-list</NxCode> including rows in various configurations, each starting with
+      an <NxCode>NxThreatIndicator</NxCode>. Note that this list uses such a wide variety of
       items for layout illustration purposes only. In practice you would not, for instance, have action buttons within
       an item of a clickable list.
     </GalleryExampleTile>
@@ -120,8 +121,8 @@ const NxThreatIndicatorPage = () =>
                         id="nx-threat-indicator-table-example"
                         liveExample={NxThreatIndicatorTableExample}
                         codeExamples={nxThreatIndicatorTableCode}>
-      Since <code className="nx-code">nx-table</code> is one of the primary places
-      that <code className="nx-code">NxThreatIndicator</code> is intended to be used, this example demonstrates a
+      Since <NxCode>nx-table</NxCode> is one of the primary places
+      that <NxCode>NxThreatIndicator</NxCode> is intended to be used, this example demonstrates a
       typical usage of it. Note that no special classes or placements are needed here, it is essentially just the
       usual inline layout of the threat indicator and adjacent content, within a table cell.
     </GalleryExampleTile>

--- a/gallery/src/components/NxThreatIndicator/NxThreatIndicatorPage.tsx
+++ b/gallery/src/components/NxThreatIndicator/NxThreatIndicatorPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxThreatIndicatorByCategoryExample from './NxThreatIndicatorByCategoryExample';

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxToggleExample from './NxToggleExample';

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
@@ -16,75 +16,75 @@ const exampleCode = require('./NxToggleExample?raw');
 const NxTogglePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Custom toggle control, which uses a hidden checkbox input for its on/checked &amp; off/unselected states.
-      </p>
-      <p className="nx-p">Child VDOM will be used as a label with the text following the toggle control.</p>
-      <table className="nx-table">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">inputId</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">An id to identify the toggle</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isChecked</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">Whether the toggle should be rendered as on/checked or off/unchecked</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function (() =&gt; void)</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">A callback for when the toggle control is toggled</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      </NxP>
+      <NxP>Child VDOM will be used as a label with the text following the toggle control.</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>inputId</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>An id to identify the toggle</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isChecked</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>Whether the toggle should be rendered as on/checked or off/unchecked</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function (() =&gt; void)</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>A callback for when the toggle control is toggled</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Whether the toggle should be rendered as disabled or not. When disabled, the onChange callback will
               not fire. Defaults to false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">Virtual DOM</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>Virtual DOM</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               VDOM rendered as a label. Should be
               {' '}
               <NxTextLink external
                           href="https://www.w3.org/TR/2011/WD-html-markup-20110525/terminology.html#phrasing-content">
                 phrasing content
               </NxTextLink>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">HTML <code className="nx-code">&lt;label&gt;</code> Attributes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>HTML <NxCode>&lt;label&gt;</NxCode> Attributes</NxTable.Cell>
+            <NxTable.Cell>
               <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/label">
                 HTML label Attributes
               </NxTextLink>
-            </td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              <code className="nx-code">NxToggle</code> supports any HTML attribute that's normally
-              supported by <code className="nx-code">&lt;label&gt;</code> elements.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>NxToggle</NxCode> supports any HTML attribute that's normally
+              supported by <NxCode>&lt;label&gt;</NxCode> elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General NxToggle Example"

--- a/gallery/src/components/NxToggle/NxTogglePage.tsx
+++ b/gallery/src/components/NxToggle/NxTogglePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
+import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxToggleExample from './NxToggleExample';

--- a/gallery/src/components/NxTooltip/NxTooltipPage.tsx
+++ b/gallery/src/components/NxTooltip/NxTooltipPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxInfoAlert, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxTooltipExample from './NxTooltipExample';

--- a/gallery/src/components/NxTooltip/NxTooltipPage.tsx
+++ b/gallery/src/components/NxTooltip/NxTooltipPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert } from '@sonatype/react-shared-components';
+import { NxInfoAlert, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
@@ -22,68 +22,68 @@ export default function NxTooltipPage() {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
+        <NxP>
           A tooltip component that can wrap other components in order to apply a tooltip to them. The wrapped component
           must be able to receive a ref which it must forward to its top-most native DOM element.
-        </p>
+        </NxP>
         <NxInfoAlert>
           Tooltips that are open at page load appear to exhibit a race condition in regards to their positioning.
-          Use the <code className="nx-code">open</code> prop with caution
+          Use the <NxCode>open</NxCode> prop with caution
         </NxInfoAlert>
-        <table className="nx-table nx-table--gallery-props">
-          <thead>
-            <tr className="nx-table-row">
-              <th className="nx-cell nx-cell--header">Prop</th>
-              <th className="nx-cell nx-cell--header">Type</th>
-              <th className="nx-cell nx-cell--header">Required</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell">title</td>
-              <td className="nx-cell">React Node (e.g. VDOM or string)</td>
-              <td className="nx-cell">Yes</td>
-              <td className="nx-cell">The tooltip content. If empty, the tooltip is not shown.</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">placement</td>
-              <td className="nx-cell">"top" | "bottom" | "left" | "right" | "top-end" | "bottom-end"</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>title</NxTable.Cell>
+              <NxTable.Cell>React Node (e.g. VDOM or string)</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell>The tooltip content. If empty, the tooltip is not shown.</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>placement</NxTable.Cell>
+              <NxTable.Cell>"top" | "bottom" | "left" | "right" | "top-end" | "bottom-end"</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 Which side of the element the tooltip should render on. Defaults to top. "top" and "bottom" position
                 the tooltip flush to the left edge of the element, while "top-end" and "bottom-end" position it flush
                 to the right edge.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">className</td>
-              <td className="nx-cell">string</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>className</NxTable.Cell>
+              <NxTable.Cell>string</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>
                 A CSS class to apply to the tooltip element, to be used for customized styling
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">open</td>
-              <td className="nx-cell">boolean</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">Whether the tooltip should be open initially. Defaults to false</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onOpen</td>
-              <td className="nx-cell">Function</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">A callback function executed when the tooltip opens</td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell">onClose</td>
-              <td className="nx-cell">Function</td>
-              <td className="nx-cell">No</td>
-              <td className="nx-cell">A callback function executed when the tooltip closes</td>
-            </tr>
-          </tbody>
-        </table>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>open</NxTable.Cell>
+              <NxTable.Cell>boolean</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>Whether the tooltip should be open initially. Defaults to false</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onOpen</NxTable.Cell>
+              <NxTable.Cell>Function</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>A callback function executed when the tooltip opens</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell>onClose</NxTable.Cell>
+              <NxTable.Cell>Function</NxTable.Cell>
+              <NxTable.Cell>No</NxTable.Cell>
+              <NxTable.Cell>A callback function executed when the tooltip closes</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="General Example"
                           codeExamples={codeExamples}

--- a/gallery/src/components/NxTooltip/NxTooltipPage.tsx
+++ b/gallery/src/components/NxTooltip/NxTooltipPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
+import { NxInfoAlert, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import NxTooltipExample from './NxTooltipExample';

--- a/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
+++ b/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxTreeViewExample from './NxTreeViewExample';
 import NxTreeViewTooltipExample from './NxTreeViewTooltipExample';
@@ -31,112 +32,112 @@ const nxTreeViewCode = require('./NxTreeViewExample?raw'),
 const NxTreeViewPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         A set of default styles and basic React for an expanding tree view.
-      </p>
+      </NxP>
 
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">id</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>id</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Id to assign to the tree view element
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isOpen</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isOpen</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view is open or closed. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onToggleCollapse</td>
-            <td className="nx-cell">() =&gt; void</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onToggleCollapse</NxTable.Cell>
+            <NxTable.Cell>() =&gt; void</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Callback that fires when the tree view collapse/expand toggle is clicked. Typically is a function
-              that toggles the state value which controls the tree view's <code className="nx-code">isOpen</code> prop.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+              that toggles the state value which controls the tree view's <NxCode>isOpen</NxCode> prop.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view should be rendered as disabled or not. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">triggerContent</td>
-            <td className="nx-cell">VirtualDOM</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>triggerContent</NxTable.Cell>
+            <NxTable.Cell>VirtualDOM</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               The content of the tree view trigger. While not strictly speaking required if there is no content then
               nothing but the caret icon will appear.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">triggerTooltip</td>
-            <td className="nx-cell">string | NxTooltip Props</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>triggerTooltip</NxTable.Cell>
+            <NxTable.Cell>string | NxTooltip Props</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If present, describes a tooltip to be places on the tree view's trigger element. There are two ways
               to specify the tooltip: the simpler way is to simply specify the tooltip text as a string. If control
               of more complex tooltip options is desired, an object can be passed which will serve as the props for
               NxTooltip
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">className</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">Classes to apply to the root element</td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>className</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>Classes to apply to the root element</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__header">
           <h3 className="nx-h3">Children</h3>
         </header>
-        <p className="nx-p">
-          The "children" of an <code className="nx-code">NxTreeView</code> are the elements which appear when the
+        <NxP>
+          The "children" of an <NxCode>NxTreeView</NxCode> are the elements which appear when the
           tree view is expanded. All tree view children should be wrapped
-          in <code className="nx-code">NxTreeViewChild</code> components.{' '}
-          <code className="nx-code">NxTreeViewChild</code> does not actually create an element of its own – unless
+          in <NxCode>NxTreeViewChild</NxCode> components.{' '}
+          <NxCode>NxTreeViewChild</NxCode> does not actually create an element of its own – unless
           its children consist only of text – but rather augments the classes and attributes of its child element
           in order to apply the appropriate styles and accessibility roles. Note that NxTreeViewChild expects to have
           exactly one child, and this restriction is enforced in the typescript types. NxTreeViewChild can receive
           standard global HTML attributes.
-        </p>
-        <p className="nx-p">Certain types of tree view children get special styling treatment as described below.</p>
+        </NxP>
+        <NxP>Certain types of tree view children get special styling treatment as described below.</NxP>
         <ul className="nx-list">
           <li className="nx-list__item">
             <span className="nx-list__text">Clickable/selectable children</span>
             <span className="nx-list__subtext">
-              Links (<code className="nx-code">&lt;a&gt;</code> tags)
-              and <code className="nx-code">&lt;button&gt;</code>s get hover, focus, and click styles which
+              Links (<NxCode>&lt;a&gt;</NxCode> tags)
+              and <NxCode>&lt;button&gt;</NxCode>s get hover, focus, and click styles which
               lay them out slightly differently from normal tree view children. When constructing
-              a navigation list within an <code className="nx-code">NxTreeView</code>, the link representing the
-              current page should be given the <code className="nx-code">.selected</code> class.
+              a navigation list within an <NxCode>NxTreeView</NxCode>, the link representing the
+              current page should be given the <NxCode>.selected</NxCode> class.
             </span>
           </li>
           <li className="nx-list__item">
             <span className="nx-list__text">Radio/Checkbox children</span>
             <span className="nx-list__subtext">
-              Tree view children which are <code className="nx-code">NxRadio</code>s or{' '}
-              <code className="nx-code">NxCheckbox</code>s get special indentation.
+              Tree view children which are <NxCode>NxRadio</NxCode>s or{' '}
+              <NxCode>NxCheckbox</NxCode>s get special indentation.
             </span>
           </li>
         </ul>
@@ -146,14 +147,14 @@ const NxTreeViewPage = () =>
     <GalleryExampleTile title="NxTreeView Basic Example"
                         liveExample={NxTreeViewExample}
                         codeExamples={nxTreeViewCode}>
-      A basic example of an <code className="nx-code">NxTreeView</code> with the corresponding logic necessary to
+      A basic example of an <NxCode>NxTreeView</NxCode> with the corresponding logic necessary to
       track its collapse/expand state. The trigger content is long to demonstrate ellipsis truncation.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxTreeView Example with trigger tooltip"
                         liveExample={NxTreeViewTooltipExample}
                         codeExamples={nxTreeViewTooltipCode}>
-      Examples of <code className="nx-code">NxTreeView</code>s with tooltips configured on their triggers. The first
+      Examples of <NxCode>NxTreeView</NxCode>s with tooltips configured on their triggers. The first
       example uses a simple string for the tooltip while the second example demonstrates a more custom tooltip
       configuration.
     </GalleryExampleTile>
@@ -162,8 +163,8 @@ const NxTreeViewPage = () =>
                         id="nx-tree-view-example"
                         liveExample={NxTreeViewExtras}
                         codeExamples={nxTreeViewExtrasCode}>
-      These examples demonstrate <code className="nx-code">NxTreeView</code>s with extra content such as icons and
-      <code className="nx-code">nx-counter</code>s in their triggers. Note that the last example also demonstrates
+      These examples demonstrate <NxCode>NxTreeView</NxCode>s with extra content such as icons and
+      <NxCode>nx-counter</NxCode>s in their triggers. Note that the last example also demonstrates
       text overflow behavior
     </GalleryExampleTile>
 
@@ -171,16 +172,16 @@ const NxTreeViewPage = () =>
                         id="nx-tree-view-clickable-example"
                         liveExample={NxTreeViewClickable}
                         codeExamples={nxTreeViewClickableCode}>
-      Example of an <code className="nx-code">NxTreeView</code> with clickable children one of which is selected
+      Example of an <NxCode>NxTreeView</NxCode> with clickable children one of which is selected
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxTreeView Clickable Sidebar Example"
                         id="nx-tree-view-clickable-sidebar-example"
                         liveExample={NxTreeViewClickableSidebar}
                         codeExamples={nxTreeViewClickableSidebarCode}>
-      Example of an <code className="nx-code">NxTreeView</code> with clickable children one of which is selected.
+      Example of an <NxCode>NxTreeView</NxCode> with clickable children one of which is selected.
       This example differs from the previous one in that the tree view is contained within
-      an <code className="nx-code">.nx-page-sidebar</code>. <code className="nx-code">NxTreeView</code>s that are
+      an <NxCode>.nx-page-sidebar</NxCode>. <NxCode>NxTreeView</NxCode>s that are
       descendants of sidebars use different colors for their hover and selected states.
     </GalleryExampleTile>
 
@@ -188,7 +189,7 @@ const NxTreeViewPage = () =>
                         id="nx-tree-view-checkbox-example"
                         liveExample={NxTreeViewCheckbox}
                         codeExamples={nxTreeViewCheckboxCode}>
-      Example showing how to construct <code className="nx-code">NxTreeView</code>s with checkboxes and radios as
+      Example showing how to construct <NxCode>NxTreeView</NxCode>s with checkboxes and radios as
       children. This example omits the input state management and is focused on demonstrating the styling.
     </GalleryExampleTile>
 
@@ -203,14 +204,14 @@ const NxTreeViewPage = () =>
                         id="nx-tree-view-empty-example"
                         liveExample={NxTreeViewEmpty}
                         codeExamples={nxTreeViewEmptyCode}>
-      Example of an <code className="nx-code">NxTreeView</code> that cannot be opened because it has no children.
+      Example of an <NxCode>NxTreeView</NxCode> that cannot be opened because it has no children.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxTreeView Disabled Example"
                         id="nx-tree-view-disabled-example"
                         liveExample={NxTreeViewDisabled}
                         codeExamples={nxTreeViewDisabledCode}>
-      Example of a disabled <code className="nx-code">NxTreeView</code>.
+      Example of a disabled <NxCode>NxTreeView</NxCode>.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
+++ b/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
 
 import NxTreeViewExample from './NxTreeViewExample';
 import NxTreeViewTooltipExample from './NxTreeViewTooltipExample';
@@ -107,10 +107,10 @@ const NxTreeViewPage = () =>
           </NxTable.Row>
         </NxTable.Body>
       </NxTable>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">Children</h3>
-        </header>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
+          <NxH3>Children</NxH3>
+        </NxTile.SubsectionHeader>
         <NxP>
           The "children" of an <NxCode>NxTreeView</NxCode> are the elements which appear when the
           tree view is expanded. All tree view children should be wrapped
@@ -141,7 +141,7 @@ const NxTreeViewPage = () =>
             </span>
           </li>
         </ul>
-      </section>
+      </NxTile.Subsection>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="NxTreeView Basic Example"

--- a/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
+++ b/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTreeViewExample from './NxTreeViewExample';
 import NxTreeViewTooltipExample from './NxTreeViewTooltipExample';

--- a/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
+++ b/gallery/src/components/NxTreeView/NxTreeViewPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTreeViewExample from './NxTreeViewExample';

--- a/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTreeViewMultiSelectExample from './NxTreeViewMultiSelectExample';
 import NxTreeViewMultiSelectCustomTooltipExample from './NxTreeViewMultiSelectCustomTooltipExample';

--- a/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxTreeViewMultiSelectExample from './NxTreeViewMultiSelectExample';
 import NxTreeViewMultiSelectCustomTooltipExample from './NxTreeViewMultiSelectCustomTooltipExample';
@@ -20,191 +21,191 @@ const nxTreeViewMultiSelectExampleCode = require('./NxTreeViewMultiSelectExample
 const NxTreeViewMultiSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Multi select component using tree view with checkboxes.
-      </p>
+      </NxP>
 
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">options</td>
-            <td className="nx-cell">Array of {'{id:String, name:String}'}</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
-              <p className="nx-p">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>options</NxTable.Cell>
+            <NxTable.Cell>Array of {'{id:String, name:String}'}</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 An array of objects that corresponds to the possible options of the component (the checkboxes).
-                These objects need to at least have an <code className="nx-code">id: string</code> property and a{' '}
-                <code className="nx-code">name: string</code> property. If an empty array is passed in, the component
+                These objects need to at least have an <NxCode>id: string</NxCode> property and a{' '}
+                <NxCode>name: string</NxCode> property. If an empty array is passed in, the component
                 will be disabled.
-              </p>
-              <p className="nx-p">
-                <code className="nx-code">id</code> will be the value provided to the{' '}
-                <code className="nx-code">onChange</code> callback, and{' '}
-                <code className="nx-code">name</code> will be used to render the option.
-              </p>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">name</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+              </NxP>
+              <NxP>
+                <NxCode>id</NxCode> will be the value provided to the{' '}
+                <NxCode>onChange</NxCode> callback, and{' '}
+                <NxCode>name</NxCode> will be used to render the option.
+              </NxP>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>name</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Name used in the default disabled tooltip and in the generated checkbox id.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">VDOM</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>VDOM</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               The content to be used as the tree view trigger.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Called whenever selection change occurs; it will receive two arguments:{' '}
               <ul className="nx-list nx-list--bulleted">
                 <li className="nx-list__item">
-                  <code className="nx-code" >Set</code> of ids of the currently selected options
+                  <NxCode >Set</NxCode> of ids of the currently selected options
                 </li>
                 <li className="nx-list__item">
-                  <code className="nx-code">id</code> of the toggled option
-                  or <code className="nx-code">undefined</code> if all/none option was toggled
+                  <NxCode>id</NxCode> of the toggled option
+                  or <NxCode>undefined</NxCode> if all/none option was toggled
                 </li>
               </ul>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">selectedIds</td>
-            <td className="nx-cell">Set</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The <code className="nx-code" >Set</code> of ids of options to be selected.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isOpen</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>selectedIds</NxTable.Cell>
+            <NxTable.Cell>Set</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The <NxCode >Set</NxCode> of ids of options to be selected.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isOpen</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view is open or closed. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">id</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>id</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Id to assign to the component
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view should be rendered as disabled or not. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onToggleCollapse</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onToggleCollapse</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Called whenever the NxTreeView is toggled.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabledTooltip</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabledTooltip</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Enables the tooltip that appears when the component is disabled.
-              If no <code className="nx-code">disabledTooltip</code> is passed in and the component is disabled due
-              to lack of <code className="nx-code">options</code>, a default tooltip will be provided. If the
-              component is disabled explicitly and no <code className="nx-code">disabledTooltip</code> is provided,
+              If no <NxCode>disabledTooltip</NxCode> is passed in and the component is disabled due
+              to lack of <NxCode>options</NxCode>, a default tooltip will be provided. If the
+              component is disabled explicitly and no <NxCode>disabledTooltip</NxCode> is provided,
               no tooltip will be shown.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">optionTooltipGenerator</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>optionTooltipGenerator</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Callback to generate tooltip text for each option. Called with the option object. If not supplied, the
               default overflow tooltip behavior of the checkboxes will be active.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">tooltipModifierClass</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>tooltipModifierClass</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Custom class to be applied to all the tooltips rendered by this component.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onFilterChange</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onFilterChange</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Called whenever filter term is changed. It will receive the current value of the filter term.
               If not provided the filter text input will not be rendered and filtering will be disabled.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filter</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filter</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Current value of filter term.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filteredOptions</td>
-            <td className="nx-cell">Array of {'{id:String, name:String}'}</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filteredOptions</NxTable.Cell>
+            <NxTable.Cell>Array of {'{id:String, name:String}'}</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Options filtered using current filter term.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterPlaceholder</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterPlaceholder</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Placeholder to be used in filter text input. Defaults to "filter" but recommended to
               be something clearer for screenreading purposes.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterThreshold</td>
-            <td className="nx-cell">Number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterThreshold</NxTable.Cell>
+            <NxTable.Cell>Number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If number of options is greater than filter-threshold - allows filtering the options. Default is 10.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="NxTreeViewMultiSelect Example"
                         id="nx-tree-view-multi-select-example"
                         liveExample={NxTreeViewMultiSelectExample}
                         codeExamples={nxTreeViewMultiSelectExampleCode}>
-      Basic example of a <code className="nx-code">NxTreeViewMultiSelect</code>. Note that the overflowing label gets
+      Basic example of a <NxCode>NxTreeViewMultiSelect</NxCode>. Note that the overflowing label gets
       a tooltip.
     </GalleryExampleTile>
 
@@ -212,14 +213,14 @@ const NxTreeViewMultiSelectPage = () =>
                         id="nx-tree-view-multi-select-custom-tooltip-example"
                         liveExample={NxTreeViewMultiSelectCustomTooltipExample}
                         codeExamples={nxTreeViewMultiSelectCustomTooltipExampleCode}>
-      Example of an <code className="nx-code">NxTreeViewMultiSelect</code> which generates a tooltip for each option
+      Example of an <NxCode>NxTreeViewMultiSelect</NxCode> which generates a tooltip for each option
       based on a custom field.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxTreeViewMultiSelect Disabled Example With Tooltip"
                         liveExample={NxTreeViewMultiSelectDisabledExample}
                         codeExamples={nxTreeViewMultiSelectDisabledExampleCode}>
-      An example of an <code className="nx-code">NxTreeViewMultiSelect</code> which is disabled and which displays
+      An example of an <NxCode>NxTreeViewMultiSelect</NxCode> which is disabled and which displays
       a tooltip to explain why.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewMultiSelect/NxTreeViewMultiSelectPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTreeViewMultiSelectExample from './NxTreeViewMultiSelectExample';

--- a/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTreeViewRadioSelectExample from './NxTreeViewRadioSelectExample';

--- a/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTreeViewRadioSelectExample from './NxTreeViewRadioSelectExample';
 import NxTreeViewRadioSelectCustomTooltipExample from './NxTreeViewRadioSelectCustomTooltipExample';

--- a/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
+++ b/gallery/src/components/NxTreeViewRadioSelect/NxTreeViewRadioSelectPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxTreeViewRadioSelectExample from './NxTreeViewRadioSelectExample';
 import NxTreeViewRadioSelectCustomTooltipExample from './NxTreeViewRadioSelectCustomTooltipExample';
@@ -20,184 +21,184 @@ const nxTreeViewRadioSelectExampleCode = require('./NxTreeViewRadioSelectExample
 const NxTreeViewRadioSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         A tree view radio group component.
-      </p>
+      </NxP>
 
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Prop</th>
-            <th className="nx-cell nx-cell--header">Type</th>
-            <th className="nx-cell nx-cell--header">Required</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell">options</td>
-            <td className="nx-cell">Array of {'{id:string, name:string}'}</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
-              <p className="nx-p">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Prop</NxTable.Cell>
+            <NxTable.Cell>Type</NxTable.Cell>
+            <NxTable.Cell>Required</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell>options</NxTable.Cell>
+            <NxTable.Cell>Array of {'{id:string, name:string}'}</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
+              <NxP>
                 An array of objects that corresponds to the possible options of the component (the checkboxes).
-                These objects need to at least have an <code className="nx-code">id: string</code> property and a{' '}
-                <code className="nx-code">name: string</code> property. If an empty array is passed in, the component
+                These objects need to at least have an <NxCode>id: string</NxCode> property and a{' '}
+                <NxCode>name: string</NxCode> property. If an empty array is passed in, the component
                 will be disabled.
-              </p>
-              <p className="nx-p">
-                <code className="nx-code">id</code> will be the value provided to the{' '}
-                <code className="nx-code">onChange</code> callback, and{' '}
-                <code className="nx-code">name</code> will be used to render the option.
-              </p>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">name</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+              </NxP>
+              <NxP>
+                <NxCode>id</NxCode> will be the value provided to the{' '}
+                <NxCode>onChange</NxCode> callback, and{' '}
+                <NxCode>name</NxCode> will be used to render the option.
+              </NxP>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>name</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               Name used in the default disabled tooltip and to identify the radio group.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">children</td>
-            <td className="nx-cell">VDOM</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>children</NxTable.Cell>
+            <NxTable.Cell>VDOM</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               The content to be used as the tree view trigger.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onChange</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">Yes</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onChange</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>Yes</NxTable.Cell>
+            <NxTable.Cell>
               A function that will be called whenever a change occurs; it will receive the{' '}
-              <code className="nx-code">id</code> of the selected radio.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">selectedId</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
-              The <code className="nx-code">id</code> of the <code className="nx-code">option</code> to be selected.
+              <NxCode>id</NxCode> of the selected radio.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>selectedId</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
+              The <NxCode>id</NxCode> of the <NxCode>option</NxCode> to be selected.
               If not provided no option will be selected.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">isOpen</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>isOpen</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view is open or closed. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">id</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>id</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Id to assign to the component
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabled</td>
-            <td className="nx-cell">boolean</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabled</NxTable.Cell>
+            <NxTable.Cell>boolean</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Controls whether the tree view should be rendered as disabled or not. Default is false.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onToggleCollapse</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onToggleCollapse</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Called whenever the NxTreeView is toggled.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">disabledTooltip</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>disabledTooltip</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Enables the tooltip that appears when the component is disabled.
-              If no <code className="nx-code">disabledTooltip</code> is passed in and the component is disabled due
-              to lack of <code className="nx-code">options</code>, a default tooltip will be provided. If the
-              component is disabled explicitly and no <code className="nx-code">disabledTooltip</code> is provided,
+              If no <NxCode>disabledTooltip</NxCode> is passed in and the component is disabled due
+              to lack of <NxCode>options</NxCode>, a default tooltip will be provided. If the
+              component is disabled explicitly and no <NxCode>disabledTooltip</NxCode> is provided,
               no tooltip will be shown.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">optionTooltipGenerator</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>optionTooltipGenerator</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Callback to generate tooltip text for each option. Called with the option object. If not supplied, the
               default overflow tooltip behavior of the checkboxes will be active.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">tooltipModifierClass</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>tooltipModifierClass</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Custom class to be applied to all the tooltips rendered by this component.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">onFilterChange</td>
-            <td className="nx-cell">Function</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>onFilterChange</NxTable.Cell>
+            <NxTable.Cell>Function</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Called whenever filter term is changed. It will receive the current value of the filter term.
               If not provided the filter text input will not be rendered and filtering will be disabled.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filter</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filter</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Current value of filter term.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filteredOptions</td>
-            <td className="nx-cell">Array of {'{id:string, name:string}'}</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filteredOptions</NxTable.Cell>
+            <NxTable.Cell>Array of {'{id:string, name:string}'}</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Options filtered using current filter term.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterPlaceholder</td>
-            <td className="nx-cell">string</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterPlaceholder</NxTable.Cell>
+            <NxTable.Cell>string</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               Placeholder to be used in filter text input. Defaults to "filter" but recommended to
               be something clearer for screenreading purposes.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">filterThreshold</td>
-            <td className="nx-cell">Number</td>
-            <td className="nx-cell">No</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>filterThreshold</NxTable.Cell>
+            <NxTable.Cell>Number</NxTable.Cell>
+            <NxTable.Cell>No</NxTable.Cell>
+            <NxTable.Cell>
               If number of options is greater than filter-threshold - allows filtering the options. Default is 10.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="NxTreeViewRadioSelect Basic Example"
                         id="nx-tree-view-radio-select-example"
                         liveExample={NxTreeViewRadioSelectExample}
                         codeExamples={nxTreeViewRadioSelectExampleCode}>
-      A basic example of <code className="nx-code">NxTreeViewRadioSelect</code>, with working collapse/expand,
+      A basic example of <NxCode>NxTreeViewRadioSelect</NxCode>, with working collapse/expand,
       filtering, and selection. Note that the overflowing label gets a tooltip.
     </GalleryExampleTile>
 
@@ -205,14 +206,14 @@ const NxTreeViewRadioSelectPage = () =>
                         id="nx-tree-view-radio-select-example"
                         liveExample={NxTreeViewRadioSelectCustomTooltipExample}
                         codeExamples={nxTreeViewRadioSelectCustomTooltipExampleCode}>
-      Example of an <code className="nx-code">NxTreeViewRadioSelect</code> which generates a tooltip for each option
+      Example of an <NxCode>NxTreeViewRadioSelect</NxCode> which generates a tooltip for each option
       based on a custom field.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxTreeViewRadioSelect Disabled Example"
                         liveExample={NxTreeViewRadioSelectDisabledExample}
                         codeExamples={nxTreeViewRadioSelectDisabledExampleCode}>
-      A disabled <code className="nx-code">NxTreeViewRadioSelect</code>
+      A disabled <NxCode>NxTreeViewRadioSelect</NxCode>
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
+++ b/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxVulnerabilityDetailsExample from './NxVulnerabilityDetailsExample';

--- a/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
+++ b/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxVulnerabilityDetailsExample from './NxVulnerabilityDetailsExample';
 import NxVulnerabilityDetailsThirdPartyScanExample from './NxVulnerabilityDetailsThirdPartyScanExample';

--- a/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
+++ b/gallery/src/components/NxVulnerabilityDetails/NxVulnerabilityDetailsPage.tsx
@@ -7,6 +7,8 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+
 import NxVulnerabilityDetailsExample from './NxVulnerabilityDetailsExample';
 import NxVulnerabilityDetailsThirdPartyScanExample from './NxVulnerabilityDetailsThirdPartyScanExample';
 
@@ -29,45 +31,39 @@ const NxVulnerabilityDetailsPage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">Renders vulnerability details from vulnerabilityDetails JSON</p>
-        <p className="nx-p">Props:</p>
-        <table className="nx-table nx-table--gallery-props">
-          <thead>
-            <tr className="nx-table-row">
-              <th className="nx-cell nx-cell--header">Prop</th>
-              <th className="nx-cell nx-cell--header">Type</th>
-              <th className="nx-cell nx-cell--header">Required</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell">vulnerabilityDetails</td>
-              <td className="nx-cell">Object</td>
-              <td className="nx-cell">Yes</td>
-              <td className="nx-cell">
-                see <code className="nx-code">VulnerabilityDetails</code> interface
-                and <code className="nx-code">vulnerabilityDetailsJson</code> example below
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p className="nx-p">
+        <NxP>Renders vulnerability details from vulnerabilityDetails JSON</NxP>
+        <NxP>Props:</NxP>
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Prop</NxTable.Cell>
+              <NxTable.Cell>Type</NxTable.Cell>
+              <NxTable.Cell>Required</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell>vulnerabilityDetails</NxTable.Cell>
+              <NxTable.Cell>Object</NxTable.Cell>
+              <NxTable.Cell>Yes</NxTable.Cell>
+              <NxTable.Cell>
+                see <NxCode>VulnerabilityDetails</NxCode> interface
+                and <NxCode>vulnerabilityDetailsJson</NxCode> example below
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
+        <NxP>
           VulnerabilityDetails PropType can be imported separately
-          as <code className="nx-code">vulnerabilityDetailsPropType</code>.
-        </p>
-        <p className="nx-p">
-          Note that markdown fields in <code className="nx-code">vulnerabilityDetails</code> JSON are expected to use
-          {' '}
-          <a className="nx-text-link"
-             target="_blank"
-             rel="noreferrer"
-             href="https://spec.commonmark.org/">
-            CommonMark
-          </a> flavored markdown.
+          as <NxCode>vulnerabilityDetailsPropType</NxCode>.
+        </NxP>
+        <NxP>
+          Note that markdown fields in <NxCode>vulnerabilityDetails</NxCode> JSON are expected to use{' '}
+          <NxTextLink external href="https://spec.commonmark.org/">CommonMark</NxTextLink> flavored markdown.
           <br/>Also, in addition to CommonMark spec, a "soft break" is supported: a new line within a paragraph will be
-          converted to <code className="nx-code">&lt;br&gt;</code> tag.
-        </p>
+          converted to <NxCode>&lt;br&gt;</NxCode> tag.
+        </NxP>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="General Example"
                           codeExamples={[exampleSourceCode, serializedVulnDetailsJson]}

--- a/gallery/src/guidelines/FontSize/FontSizePage.tsx
+++ b/gallery/src/guidelines/FontSize/FontSizePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode, NxH3, NxH4, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import CodeExample from '../../CodeExample';
 import FontLayoutExample from './FontLayoutExample';

--- a/gallery/src/guidelines/FontSize/FontSizePage.tsx
+++ b/gallery/src/guidelines/FontSize/FontSizePage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
-import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { NxP, NxCode, NxH3, NxH4, NxTextLink } from '@sonatype/react-shared-components';
 
 import CodeExample from '../../CodeExample';
 import FontLayoutExample from './FontLayoutExample';
@@ -46,7 +46,7 @@ const FontSizePage = () =>
     </NxP>
 
     <section>
-      <h3 className="nx-h3">Vocabulary</h3>
+      <NxH3>Vocabulary</NxH3>
       <ul className="nx-list">
         <li className="nx-list__item">
           <span className="nx-list__text">Glyph:</span>
@@ -71,7 +71,7 @@ const FontSizePage = () =>
     </section>
 
     <section>
-      <h3 className="nx-h3">Boxes</h3>
+      <NxH3>Boxes</NxH3>
       <NxP>
         There are a number of boxes which get sized and positioned as the layout of inline text is determined.
         Some of these are familiar to any HTML/CSS developer, but others are lower level concepts that get into
@@ -80,7 +80,7 @@ const FontSizePage = () =>
       </NxP>
 
       <section>
-        <h4 className="nx-h4">Font Em-Square</h4>
+        <NxH4>Font Em-Square</NxH4>
         <NxP>
           Font glyphs are defined in a unitless coordinate space known as the em-square. The font defines
           this coordinate space using two values: the Ascent and the Descent. The Ascent gives the extent of the box
@@ -114,7 +114,7 @@ const FontSizePage = () =>
       </section>
 
       <section>
-        <h4 className="nx-h4">Text Node Content Area</h4>
+        <NxH4>Text Node Content Area</NxH4>
         <NxP>
           As we've established, <NxCode>font-size</NxCode> sets the height of the em-square, a box
           that is at a lower level than the HTML/CSS model. So what about HTML nodes and elements, what sets their
@@ -153,7 +153,7 @@ const FontSizePage = () =>
       </section>
 
       <section>
-        <h4 className="nx-h4">Line Boxes</h4>
+        <NxH4>Line Boxes</NxH4>
         <NxP>
           In HTML/CSS, inline elements are contained within block elements, in which the inline elements get laid
           out into a series of line boxes. The line boxes are a layout detail and not a manipulatable part of
@@ -212,7 +212,7 @@ const FontSizePage = () =>
       </section>
 
       <section>
-        <h4 className="nx-h4">Block Elements</h4>
+        <NxH4>Block Elements</NxH4>
         <NxP>
           Block Elements are more firmly within the realm of CSS itself and more directly controlled by CSS
           properties such as <NxCode>height</NxCode> and <NxCode>width</NxCode>,
@@ -230,7 +230,7 @@ const FontSizePage = () =>
     </section>
 
     <section>
-      <h3 className="nx-h3">Additional Nuances</h3>
+      <NxH3>Additional Nuances</NxH3>
       <NxP>
         Here is an incomplete list of additional nuances to consider when dealing with inline formatting
       </NxP>
@@ -248,7 +248,7 @@ const FontSizePage = () =>
           inline-block elements use the baseline of their last line box as their baseline, unless they have no text
           content or have <NxCode>overflow</NxCode> set to something other
           than <NxCode>visible</NxCode>. In these cases the baseline is the bottom margin
-          edge. <a href={css2SpecUrl}>[3]</a>
+          edge. <NxTextLink external href={css2SpecUrl}>[3]</NxTextLink>
         </li>
         <li className="nx-list__item">
           Things get more complicated when a line box includes inline elements of multiple heights. In this
@@ -265,7 +265,7 @@ const FontSizePage = () =>
         <li className="nx-list__item">
           Due to the off-center nature of the baseline, vertical-alignment of elements of different font sizes is
           extremely, unavoidably counterintuitive. See the examples in the vertical alignment section
-          of <a href={firstReferenceUrl}>[1]</a>
+          of <NxTextLink external href={firstReferenceUrl}>[1]</NxTextLink>
         </li>
         <li className="nx-list__item">
           <NxP>
@@ -307,22 +307,24 @@ const FontSizePage = () =>
     </section>
 
     <section>
-      <h3 className="nx-h3">References, further reading</h3>
+      <NxH3>References, further reading</NxH3>
       <NxP>
         The first reference here is particularly valuable, and is where the bulk of the knowledge on this page come
         from.
       </NxP>
       <ol>
         <li>
-          <a id="font-size-ref-1" href={firstReferenceUrl}>
+          <NxTextLink external id="font-size-ref-1" href={firstReferenceUrl}>
             Deep dive CSS: font metrics, line-height and vertical-align
-          </a>
+          </NxTextLink>
         </li>
         <li>
-          <a href="https://glyphsapp.com/tutorials/vertical-metrics">Vertical Metrics - Glyphs</a>
+          <NxTextLink external href="https://glyphsapp.com/tutorials/vertical-metrics">
+            Vertical Metrics - Glyphs
+          </NxTextLink>
         </li>
         <li>
-          <a href={css2SpecUrl}>Line Height Calculatons: CSS 2.1 Spec</a>
+          <NxTextLink external href={css2SpecUrl}>Line Height Calculatons: CSS 2.1 Spec</NxTextLink>
         </li>
       </ol>
     </section>

--- a/gallery/src/guidelines/FontSize/FontSizePage.tsx
+++ b/gallery/src/guidelines/FontSize/FontSizePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode, NxH3, NxH4, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import CodeExample from '../../CodeExample';

--- a/gallery/src/guidelines/FontSize/FontSizePage.tsx
+++ b/gallery/src/guidelines/FontSize/FontSizePage.tsx
@@ -7,6 +7,8 @@
 import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import CodeExample from '../../CodeExample';
 import FontLayoutExample from './FontLayoutExample';
 import BlockLayoutExample from './BlockLayoutExample';
@@ -30,18 +32,18 @@ const firstReferenceUrl = 'https://iamvdo.me/en/blog/css-font-metrics-line-heigh
 
 const FontSizePage = () =>
   <GalleryDescriptionTile>
-    <p className="nx-p">
+    <NxP>
       The layout details of inline elements - rendered height, line box height, vertical alignments, etc, is
       one of the more poorly understood areas of CSS and HTML rendering. This page seeks to lay out some
       of these less-well-known details in the context of the specific styles (e.g. font faces) used within
       the React Shared Components.
-    </p>
-    <p className="nx-p">
+    </NxP>
+    <NxP>
       At the time of writing, RSC uses the OpenSans font. This font will be used as the example for this guide,
       with screenshots showing its configuration as observed using the font editing program FontForge. Several
       FontForge screenshots are displayed here. If you'd like to see this information in FontForge yourself, it is
       located in the UI under Element -&gt; Font Info.
-    </p>
+    </NxP>
 
     <section>
       <h3 className="nx-h3">Vocabulary</h3>
@@ -70,30 +72,30 @@ const FontSizePage = () =>
 
     <section>
       <h3 className="nx-h3">Boxes</h3>
-      <p className="nx-p">
+      <NxP>
         There are a number of boxes which get sized and positioned as the layout of inline text is determined.
         Some of these are familiar to any HTML/CSS developer, but others are lower level concepts that get into
         the realm of the fonts themselves. This guide will start at the lowest relevant level and work its way
         up to the CSS block element level.
-      </p>
+      </NxP>
 
       <section>
         <h4 className="nx-h4">Font Em-Square</h4>
-        <p className="nx-p">
+        <NxP>
           Font glyphs are defined in a unitless coordinate space known as the em-square. The font defines
           this coordinate space using two values: the Ascent and the Descent. The Ascent gives the extent of the box
           above the baseline, and the Descent gives the extent of the box below. The sum of these values is the
           em-square. Em-squares are typically one of the following sizes, though they could be anything: 1000, 1024,
           or 2048. Again, these are unitless, abstract values we are talking about; so far this has nothing to do
           with the rendered size on the page.
-        </p>
-        <p className="nx-p">
+        </NxP>
+        <NxP>
           OpenSans has an Em-square of 2048, broken down into an ascent of 1638 and a descent of 410, as seen in
           FontForge below
-        </p>
+        </NxP>
         <img src={openSansEmSquareImg}/>
 
-        <p className="nx-p">
+        <NxP>
           Theoretically, the em-square can be thought of as roughly the extent of the visible area of the font's
           glyphs. This isn't strictly true, as the font writer is perfectly allowed to draw outside the lines,
           and in particular things like accent marks may fall outside of it. Additionally there is no guarantee
@@ -101,33 +103,33 @@ const FontSizePage = () =>
           font, the Capital Height, which indicates the actual (unitless) size of capital letters -
           capital <q>X</q> to be specific. In OpenSans, this number is 1462, which you might note is smaller than
           the em-square's Ascent value.
-        </p>
-        <p className="nx-p">
+        </NxP>
+        <NxP>
           Despite the nuances described above, we now get to the first connection with familiar CSS concepts:{' '}
           <strong>
-            the actual rendered size of the em-square box is what the CSS <code className="nx-code">font-size</code>
+            the actual rendered size of the em-square box is what the CSS <NxCode>font-size</NxCode>
             {' '}property specifies.
           </strong>
-        </p>
+        </NxP>
       </section>
 
       <section>
         <h4 className="nx-h4">Text Node Content Area</h4>
-        <p className="nx-p">
-          As we've established, <code className="nx-code">font-size</code> sets the height of the em-square, a box
+        <NxP>
+          As we've established, <NxCode>font-size</NxCode> sets the height of the em-square, a box
           that is at a lower level than the HTML/CSS model. So what about HTML nodes and elements, what sets their
           height? Let's start with text nodes, and by extension, simple inline elements that only contain text
           nodes.
-        </p>
-        <p className="nx-p">
+        </NxP>
+        <NxP>
           In addition to the em-square ascent and descent values described above, fonts also have another set of
           ascent and descent values which describe line spacing. Actually, it's several sets of values which
           are each used by different operating systems in different circumstances. Luckily for us however, OpenSans
           uses a consistent set of values: 2189 for the ascender and 600 for the descender, as pictured below:
-        </p>
+        </NxP>
         <img src={openSansLineSpacingImg}/>
 
-        <p className="nx-p">
+        <NxP>
           As you can see these values are larger than those that defined the em-square, and they are once again
           unitless. So what do they do? They help define the line spacing: glyphs outside of the box defined
           by these values will be cut off, and more notably for web developers, they define the CSS content-height of
@@ -136,90 +138,90 @@ const FontSizePage = () =>
           would have a height of about 136px. Notwithstanding any padding or borders, an inline HTML element
           containing that text node would be that same height, as would the area colored by any background
           applied to said element. This exact scenario is demonstrated in the live example below:
-        </p>
+        </NxP>
 
         <FontLayoutExample/>
         <CodeExample content={FontLayoutExampleCode}/>
         <CodeExample language="scss" content={FontLayoutExampleStyles}/>
 
-        <p className="nx-p">
+        <NxP>
           Notice in this example that nothing you can visibly measure is actually 100px tall even though that is the
           font size. The glyphs aren't, because they aren't guaranteed to perfectly fill out the em-square. The
           background isn't, because it is based on the line spacing characteristics described above - and indeed
           it comes out to 136px as predicted.
-        </p>
+        </NxP>
       </section>
 
       <section>
         <h4 className="nx-h4">Line Boxes</h4>
-        <p className="nx-p">
+        <NxP>
           In HTML/CSS, inline elements are contained within block elements, in which the inline elements get laid
           out into a series of line boxes. The line boxes are a layout detail and not a manipulatable part of
           the DOM. Each one consists of (parts of) one or more inline elements and bare text nodes, and a given
           element/node may be split over multiple lines. The spacing between these lines is set using the familiar
-          {' '}<code className="nx-code">line-height</code> property. Extra space resulting from a
-          high <code className="nx-code">line-height</code> value is distributed equally above and below the content
+          {' '}<NxCode>line-height</NxCode> property. Extra space resulting from a
+          high <NxCode>line-height</NxCode> value is distributed equally above and below the content
           box, putting the content boxes in the middle of each line box. Note however that the visible glyphs are
           not necessarily in the middle of their content box. This extra space is known as the <q>leading</q>.
-        </p>
+        </NxP>
 
-        <p className="nx-p">
-          <code className="nx-code">line-height</code> can be set in a number of ways, some of which are more
+        <NxP>
+          <NxCode>line-height</NxCode> can be set in a number of ways, some of which are more
           problematic than others:
-        </p>
+        </NxP>
 
-        <h5 className="nx-h5">Absolute <code className="nx-code">line-height</code> values</h5>
-        <p className="nx-p">
-          <code className="nx-code">line-height</code> can be set using absolute units such
-          as <code className="nx-code">px</code>. This allows simple, fine-grained control, but is inflexible,
+        <h5 className="nx-h5">Absolute <NxCode>line-height</NxCode> values</h5>
+        <NxP>
+          <NxCode>line-height</NxCode> can be set using absolute units such
+          as <NxCode>px</NxCode>. This allows simple, fine-grained control, but is inflexible,
           especially when applied as a page-wide style.
-        </p>
+        </NxP>
 
-        <h5 className="nx-h5">Proportional <code className="nx-code">line-height</code> values</h5>
-        <p className="nx-p">
-          <code className="nx-code">line-height</code> can be also be set using proportional values such as
+        <h5 className="nx-h5">Proportional <NxCode>line-height</NxCode> values</h5>
+        <NxP>
+          <NxCode>line-height</NxCode> can be also be set using proportional values such as
           percentages and unitless values. Both of these are relative to the font-size, but there is an important
           difference. The unitless values compute a line-height relative to the actual font-size at which the text is
           displayed. In contrast, the percentage values compute a line-height relative to the
           font-size of the element on which the line-height is specified, which could be an ancestor with a
           different font size than the text is actually being displayed
           at. <strong>Prefer the unitless approach.</strong>
-        </p>
+        </NxP>
 
-        <h5 className="nx-h5">Automatic <code className="nx-code">line-height</code></h5>
-        <p className="nx-p">
-          The default value for <code className="nx-code">line-height</code> is
-          {' '}<code className="nx-code">normal</code>. The CSS spec is vague about what this means but in
+        <h5 className="nx-h5">Automatic <NxCode>line-height</NxCode></h5>
+        <NxP>
+          The default value for <NxCode>line-height</NxCode> is
+          {' '}<NxCode>normal</NxCode>. The CSS spec is vague about what this means but in
           practice it takes into account the font metrics described above plus one more: the Line Gap.
           The Line Gap is another value built into the font which tells renderers how much extra space to put
           between lines in addition to the line spacing ascender and descender values. Conveniently for us, in
           OpenSans the line gap is zero, as can be seen in the FontForge images above. This means that in our case the
-          default CSS <code className="nx-code">line-height</code> works out to the ratio between the em-square and the
+          default CSS <NxCode>line-height</NxCode> works out to the ratio between the em-square and the
           content-box, which once again is about 1.36. This also means that when
-          using <code className="nx-code">line-height: normal</code> with OpenSans, the content boxes of adjacent
+          using <NxCode>line-height: normal</NxCode> with OpenSans, the content boxes of adjacent
           lines of text will touch without overlapping. This is not necessarily the case with other fonts, where
           there may be a gap.
-        </p>
+        </NxP>
 
-        <p className="nx-p">
-          When setting an explicit <code className="nx-code">line-height</code>, even a proportional one, it should
+        <NxP>
+          When setting an explicit <NxCode>line-height</NxCode>, even a proportional one, it should
           be noted that the ideal/default value varies from one font to another based on the font metrics
-          described above. The only <code className="nx-code">line-height</code> setting that is really
-          future-proofed against changes to a different font-face is <code className="nx-code">normal</code>.
-        </p>
+          described above. The only <NxCode>line-height</NxCode> setting that is really
+          future-proofed against changes to a different font-face is <NxCode>normal</NxCode>.
+        </NxP>
       </section>
 
       <section>
         <h4 className="nx-h4">Block Elements</h4>
-        <p className="nx-p">
+        <NxP>
           Block Elements are more firmly within the realm of CSS itself and more directly controlled by CSS
-          properties such as <code className="nx-code">height</code> and <code className="nx-code">width</code>,
+          properties such as <NxCode>height</NxCode> and <NxCode>width</NxCode>,
           which won't be discussed here. A block elements can form a container for line boxes, the block's width
           determining the length of each line and thus, along with the text content, the number of lines. A block
           element's content area contains not only the content areas of its inline children but also any
           additional spacing applied to their line boxes. Notice the different in the height of the colored
           backgrounds below:
-        </p>
+        </NxP>
 
         <BlockLayoutExample/>
         <CodeExample content={BlockLayoutExampleCode}/>
@@ -229,14 +231,14 @@ const FontSizePage = () =>
 
     <section>
       <h3 className="nx-h3">Additional Nuances</h3>
-      <p className="nx-p">
+      <NxP>
         Here is an incomplete list of additional nuances to consider when dealing with inline formatting
-      </p>
+      </NxP>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">
           Inline elements do not respond to CSS width, height, margin-top, or margin-bottom properties. Their
-          size and vertical spacing only follows the <code className="nx-code">font-size</code>,
-          {' '}<code className="nx-code">line-height</code>, and font metrics as described above, as well as padding
+          size and vertical spacing only follows the <NxCode>font-size</NxCode>,
+          {' '}<NxCode>line-height</NxCode>, and font metrics as described above, as well as padding
           and borders.
         </li>
         <li className="nx-list__item">
@@ -244,15 +246,15 @@ const FontSizePage = () =>
         </li>
         <li className="nx-list__item">
           inline-block elements use the baseline of their last line box as their baseline, unless they have no text
-          content or have <code className="nx-code">overflow</code> set to something other
-          than <code className="nx-code">visible</code>. In these cases the baseline is the bottom margin
+          content or have <NxCode>overflow</NxCode> set to something other
+          than <NxCode>visible</NxCode>. In these cases the baseline is the bottom margin
           edge. <a href={css2SpecUrl}>[3]</a>
         </li>
         <li className="nx-list__item">
           Things get more complicated when a line box includes inline elements of multiple heights. In this
           scenario, the elements are sized individually,
-          including <code className="nx-code">line-height</code> spacing, lined up according to
-          the <code className="nx-code">vertical-align</code> property (by default: so their baselines
+          including <NxCode>line-height</NxCode> spacing, lined up according to
+          the <NxCode>vertical-align</NxCode> property (by default: so their baselines
           are aligned), and then the line box goes from the highest top to the lowest bottom.
         </li>
         <li className="nx-list__item">
@@ -266,17 +268,17 @@ const FontSizePage = () =>
           of <a href={firstReferenceUrl}>[1]</a>
         </li>
         <li className="nx-list__item">
-          <p className="nx-p">
-            It is possible to specify a <code className="nx-code">line-height</code> smaller than an element's content
+          <NxP>
+            It is possible to specify a <NxCode>line-height</NxCode> smaller than an element's content
             height, in which case the leading will be negative and text node content areas will have a height exceeding
             that of their line box. In this scenario, text nodes in adjacent line boxes will overlap one another.
-          </p>
-          <p className="nx-p">
+          </NxP>
+          <NxP>
             This is one reason why a global, absolute line-height is a poor choice - this line height will need to be
             adjusted explicitly for any element which has a larger font size in order to prevent visible crowding and
             overlap. The example below demonstrates what might happen with a large-font header in an app with a 18px
             "global" line-height and no element-specific line-height adjustments:
-          </p>
+          </NxP>
 
           <BadLineHeightExample />
           <CodeExample content={BadLineHeightExampleCode}/>
@@ -289,12 +291,12 @@ const FontSizePage = () =>
           Different fonts, of course, have different metrics, which means different heights. Experimentally, in this
           case the browser appears to take the metrics of the declared font, even if that font is not
           contributing <em>any</em> of the glyphs in the text node in question. As an example, observe
-          the <code className="nx-code">span</code>s containing the following emojis. The first inherits the page styles
+          the <NxCode>span</NxCode>s containing the following emojis. The first inherits the page styles
           setting OpenSans as the font family.  Despite not actually having any glyphs from OpenSans, it still has a
           content height derived from OpenSans metrics - that is, a content height that is roughly 1.36 times the font
-          size. The second <code className="nx-code">span</code> however is styled with the
-          generic <code className="nx-code">sans-serif</code> font family. You will likely observe that this
-          second <code className="nx-code">span</code> has a different height
+          size. The second <NxCode>span</NxCode> however is styled with the
+          generic <NxCode>sans-serif</NxCode> font family. You will likely observe that this
+          second <NxCode>span</NxCode> has a different height
           - one which will depend on the default sans-serif font installed on your operating system:
 
           <FallbackFontExample />
@@ -306,10 +308,10 @@ const FontSizePage = () =>
 
     <section>
       <h3 className="nx-h3">References, further reading</h3>
-      <p className="nx-p">
+      <NxP>
         The first reference here is particularly valuable, and is where the bulk of the knowledge on this page come
         from.
-      </p>
+      </NxP>
       <ol>
         <li>
           <a id="font-size-ref-1" href={firstReferenceUrl}>

--- a/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
+++ b/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
@@ -5,9 +5,10 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import FormValidationExample from './FormValidationExample';
 
 const FormValidationCode = require('./FormValidationExample?raw');

--- a/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
+++ b/gallery/src/guidelines/FormValidation/FormValidationPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 import FormValidationExample from './FormValidationExample';
 
 const FormValidationCode = require('./FormValidationExample?raw');
@@ -14,18 +15,18 @@ const FormValidationCode = require('./FormValidationExample?raw');
 const FormValidationPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         This page demonstrates the typical overall approach to communicating form validation matters to the user.
         There are several things to note here:
-      </p>
+      </NxP>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">
           Fields are not marked invalid while they are pristine. This is handled by
-          the <code className="nx-code">NxTextInput</code> state helpers.
+          the <NxCode>NxTextInput</NxCode> state helpers.
         </li>
         <li className="nx-list__item">
           Optional text fields are declared to the user using
-          the <code className="nx-code">nx-label--optional</code> class which adds the <q>- optional</q> text.
+          the <NxCode>nx-label--optional</NxCode> class which adds the <q>- optional</q> text.
           All fields not marked optional are required. This does not apply to checkbox groups where selecting
           nothing is generally just as valid as any other selection.
         </li>
@@ -36,7 +37,7 @@ const FormValidationPage = () =>
         <li className="nx-list__item">
           Non-pristine fields which are invalid get a red border and a red tooltip displaying the validation error.
           This tooltip is visible until the field becomes valid, as opposed to being hover-triggered. This behavior
-          is implemented by <code className="nx-code">NxTextInput</code>
+          is implemented by <NxCode>NxTextInput</NxCode>
         </li>
       </ul>
     </GalleryDescriptionTile>

--- a/gallery/src/jsUtilPages/IdUtil/IdUtilPage.tsx
+++ b/gallery/src/jsUtilPages/IdUtil/IdUtilPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import UseUniqueIdUniqueExample from './UseUniqueIdUniqueExample';

--- a/gallery/src/jsUtilPages/IdUtil/IdUtilPage.tsx
+++ b/gallery/src/jsUtilPages/IdUtil/IdUtilPage.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import UseUniqueIdUniqueExample from './UseUniqueIdUniqueExample';
 import UseUniqueIdExplicitExample from './UseUniqueIdExplicitExample';
@@ -17,12 +18,12 @@ const getUniqueIdExampleCode = require('./GetUniqueIdExample?raw'),
 const IdUtilPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         The ID Utils consist of two utility functions for managing unique, auto-generated strings for use
         as HTML IDs. This functionality is provided as both a simple
-        function: <code className="nx-code">getUniqueId</code>, and as a React
-        hook: <code className="nx-code">useUniqueId</code>.
-      </p>
+        function: <NxCode>getUniqueId</NxCode>, and as a React
+        hook: <NxCode>useUniqueId</NxCode>.
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="getUniqueId" codeExamples={getUniqueIdExampleCode}>
@@ -40,16 +41,16 @@ const IdUtilPage = () =>
     <GalleryExampleTile title="useUniqueId Non-Unique Override Example"
                         liveExample={UseUniqueIdExplicitExample}
                         codeExamples={useUniqueIdExplicitExampleCode}>
-      This example demonstrates how <code className="nx-code">useUniqueId</code> can be used in situations where an
+      This example demonstrates how <NxCode>useUniqueId</NxCode> can be used in situations where an
       explicit ID <em>may</em> be provided by an external source instead. This example features two components: a
       child which can optionally receive an ID as a prop, but which
-      uses <code className="nx-code">useUniqueId</code> to generate a unique ID in the event that it has not
+      uses <NxCode>useUniqueId</NxCode> to generate a unique ID in the event that it has not
       received an ID, and a parent component which renders two instances of the child, one with an
       explicit id passed and one without. Note that React hooks should never be called within a conditional
-      statement. For this reason, <code className="nx-code">useUniqueId</code> has special support for handling an
+      statement. For this reason, <NxCode>useUniqueId</NxCode> has special support for handling an
       explicit ID as its second parameter, allowing any component
-      which <em>might</em> need <code className="nx-code">useUniqueId</code> to <em>always</em>{' '}
-      call <code className="nx-code">useUniqueId</code>.
+      which <em>might</em> need <NxCode>useUniqueId</NxCode> to <em>always</em>{' '}
+      call <NxCode>useUniqueId</NxCode>.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/jsUtilPages/IdUtil/IdUtilPage.tsx
+++ b/gallery/src/jsUtilPages/IdUtil/IdUtilPage.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import UseUniqueIdUniqueExample from './UseUniqueIdUniqueExample';
 import UseUniqueIdExplicitExample from './UseUniqueIdExplicitExample';

--- a/gallery/src/jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage.tsx
+++ b/gallery/src/jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const threatLevelNumberExampleCode = require('./ThreatLevelNumberExample?raw'),

--- a/gallery/src/jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage.tsx
+++ b/gallery/src/jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const threatLevelNumberExampleCode = require('./ThreatLevelNumberExample?raw'),
     threatLevelCategoryExampleCode = require('./ThreatLevelCategoryExample?raw'),

--- a/gallery/src/jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage.tsx
+++ b/gallery/src/jsUtilPages/PolicyThreatLevelUtils/PolicyThreatLevelUtilsPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 const threatLevelNumberExampleCode = require('./ThreatLevelNumberExample?raw'),
     threatLevelCategoryExampleCode = require('./ThreatLevelCategoryExample?raw'),
@@ -15,11 +16,11 @@ const threatLevelNumberExampleCode = require('./ThreatLevelNumberExample?raw'),
 const PolicyThreatLevelUtilsPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Sonatype's Insight line of products have concepts of Policy Threat Levels and Policy Threat Level
         Categories, as described below. The React Shared Components library includes a few simple JavaScript
         objects and TypeScript types that provide code definitions and mappings between these two concepts.
-      </p>
+      </NxP>
 
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">
@@ -45,25 +46,25 @@ const PolicyThreatLevelUtilsPage = () =>
 
     <GalleryExampleTile title="ThreatLevelCategory & allThreatLevelCategories"
                         codeExamples={threatLevelCategoryExampleCode}>
-      <code className="nx-code">ThreatLevelCategory</code> is a TypeScript type consisting of
+      <NxCode>ThreatLevelCategory</NxCode> is a TypeScript type consisting of
       only the valid Threat Level Category strings.
-      {' '}<code className="nx-code">allThreatLevelCategories</code> is a read-only array
+      {' '}<NxCode>allThreatLevelCategories</NxCode> is a read-only array
       containing those same values
     </GalleryExampleTile>
 
     <GalleryExampleTile title="ThreatLevelNumber & allThreatLevelNumbers"
                         codeExamples={threatLevelNumberExampleCode}>
-      <code className="nx-code">ThreatLevelNumber</code> is a TypeScript type consisting of
+      <NxCode>ThreatLevelNumber</NxCode> is a TypeScript type consisting of
       only the valid Threat Level Numbers – i.e. the integers 0 through 10.
-      {' '}<code className="nx-code">allThreatLevelNumbers</code> is a read-only array
+      {' '}<NxCode>allThreatLevelNumbers</NxCode> is a read-only array
       containing those same values
     </GalleryExampleTile>
 
     <GalleryExampleTile title="categoryByPolicyThreatLevel"
                         codeExamples={categoryByPolicyThreatLevelExampleCode}>
-      <code className="nx-code">categoryByPolicyThreatLevel</code> is a read-only array that,
-      when indexed into using a <code className="nx-code">ThreatLevelNumber</code>, gives the
-      {' '}<code className="nx-code">ThreatLevelCategory</code> to which that number belongs
+      <NxCode>categoryByPolicyThreatLevel</NxCode> is a read-only array that,
+      when indexed into using a <NxCode>ThreatLevelNumber</NxCode>, gives the
+      {' '}<NxCode>ThreatLevelCategory</NxCode> to which that number belongs
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage.tsx
+++ b/gallery/src/jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import TooltipConfigPropsDropdownExample from './TooltipConfigPropsDropdownExample';
 

--- a/gallery/src/jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage.tsx
+++ b/gallery/src/jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import TooltipConfigPropsDropdownExample from './TooltipConfigPropsDropdownExample';
 
@@ -15,25 +16,25 @@ const tooltipConfigPropsDropdownExampleCode = require('./TooltipConfigPropsDropd
 const TooltipConfigPropsPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">TooltipConfigProps</code> is a TypeScript type that represents
-        all <code className="nx-code">NxTooltip</code> props except <code className="nx-code">children</code>.
+      <NxP>
+        <NxCode>TooltipConfigProps</NxCode> is a TypeScript type that represents
+        all <NxCode>NxTooltip</NxCode> props except <NxCode>children</NxCode>.
         This type is used for properties on some other components that can optionally contain a tooltip around
-        one of their elements. For example, <code className="nx-code">NxDropdown</code> has a prop
-        called <code className="nx-code">toggleTooltip</code> which can be used to specify configuration for
+        one of their elements. For example, <NxCode>NxDropdown</NxCode> has a prop
+        called <NxCode>toggleTooltip</NxCode> which can be used to specify configuration for
         a tooltip on the dropdown's toggle button. The omission of
-        the <code className="nx-code">children</code> prop is important here as
-        the <code className="nx-code">NxDropdown</code> itself fills in its own toggle button as the tooltip
+        the <NxCode>children</NxCode> prop is important here as
+        the <NxCode>NxDropdown</NxCode> itself fills in its own toggle button as the tooltip
         child.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Example with NxDropdown"
                         liveExample={TooltipConfigPropsDropdownExample}
                         codeExamples={tooltipConfigPropsDropdownExampleCode}>
-      A basic <code className="nx-code">NxDropdown</code> demonstrating usage of its
-      {' '}<code className="nx-code">toggleTooltip</code> prop, which is of type
-      {' '}<code className="nx-code">TooltipConfigProps</code>.
+      A basic <NxCode>NxDropdown</NxCode> demonstrating usage of its
+      {' '}<NxCode>toggleTooltip</NxCode> prop, which is of type
+      {' '}<NxCode>TooltipConfigProps</NxCode>.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage.tsx
+++ b/gallery/src/jsUtilPages/TooltipConfigProps/TooltipConfigPropsPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import TooltipConfigPropsDropdownExample from './TooltipConfigPropsDropdownExample';

--- a/gallery/src/jsUtilPages/UseToggle/UseTogglePage.tsx
+++ b/gallery/src/jsUtilPages/UseToggle/UseTogglePage.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import UseToggleExample from './UseToggleExample';
 import UseToggleThirdItemExample from './UseToggleThirdItemExample';

--- a/gallery/src/jsUtilPages/UseToggle/UseTogglePage.tsx
+++ b/gallery/src/jsUtilPages/UseToggle/UseTogglePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import UseToggleExample from './UseToggleExample';

--- a/gallery/src/jsUtilPages/UseToggle/UseTogglePage.tsx
+++ b/gallery/src/jsUtilPages/UseToggle/UseTogglePage.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import UseToggleExample from './UseToggleExample';
 import UseToggleThirdItemExample from './UseToggleThirdItemExample';
@@ -16,40 +17,40 @@ const useToggleExampleCode = require('./UseToggleExample?raw'),
 const UseTogglePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">useToggle</code> is a React hook which wraps React's
-        built-in <code className="nx-code">useState</code> hook, and provides a level of convenience for
+      <NxP>
+        <NxCode>useToggle</NxCode> is a React hook which wraps React's
+        built-in <NxCode>useState</NxCode> hook, and provides a level of convenience for
         boolean state values that are meant to be primarily interacted with via toggling (that is, setting
         the state to the opposite of its current value in reaction to some event).{' '}
-        <code className="nx-code">useToggle</code> is only usable with boolean state value.
-      </p>
+        <NxCode>useToggle</NxCode> is only usable with boolean state value.
+      </NxP>
 
-      <p className="nx-p">
-        Whereas <code className="nx-code">useState</code> returns a pair containing two items: the current state
+      <NxP>
+        Whereas <NxCode>useState</NxCode> returns a pair containing two items: the current state
         value and a setter function which receives the new value as a parameter,{' '}
-        <code className="nx-code">useToggle</code> returns a tuple of three items. The first item is still the
+        <NxCode>useToggle</NxCode> returns a tuple of three items. The first item is still the
         state value. The second however is a parameterless function that, when called, will update the state
         value to be the opposite of what it currently is. Then the third item is the manual update function
-        analogous to <code className="nx-code">useState</code>'s second item. In common usage, the third
+        analogous to <NxCode>useState</NxCode>'s second item. In common usage, the third
         item would often not be used, but it is provided in cases there are rare situations that call for it.
-      </p>
+      </NxP>
 
-      <p className="nx-p">
-        The toggle function provided by <code className="nx-code">useToggle</code> also provides the new state
+      <NxP>
+        The toggle function provided by <NxCode>useToggle</NxCode> also provides the new state
         value as its return value, which can be useful if that value is needed for passing to a callback prop
         on your own component.
-      </p>
+      </NxP>
 
-      <p className="nx-p">
-        Like <code className="nx-code">useState</code>, <code className="nx-code">useToggle</code> takes the
+      <NxP>
+        Like <NxCode>useState</NxCode>, <NxCode>useToggle</NxCode> takes the
         initial state value as its parameter.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Basic Example"
                         liveExample={UseToggleExample}
                         codeExamples={useToggleExampleCode}>
-      This example shows a React component which uses <code className="nx-code">useToggle</code> to manage the
+      This example shows a React component which uses <NxCode>useToggle</NxCode> to manage the
       state of a checkbox.
     </GalleryExampleTile>
 
@@ -57,7 +58,7 @@ const UseTogglePage = () =>
                         liveExample={UseToggleThirdItemExample}
                         codeExamples={useToggleThirdItemExampleCode}>
       This example demonstrates the usage of the third return item
-      from <code className="nx-code">useToggle</code> as a means to manually set the state value.
+      from <NxCode>useToggle</NxCode> as a means to manually set the state value.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
+++ b/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 const validationErrorsExampleCode = require('./ValidationErrorsExample?raw'),
     hasValidationErrorsExampleCode = require('./HasValidationErrorsExample?raw'),
@@ -15,44 +16,40 @@ const validationErrorsExampleCode = require('./ValidationErrorsExample?raw'),
 const ValidationUtilsPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        Some of the form-related components provided by RSC, such as <code className="nx-code">NxTextInput</code>,
+      <NxP>
+        Some of the form-related components provided by RSC, such as <NxCode>NxTextInput</NxCode>,
         have support for validation logic. Typically, when building a form using these components, it is desired to
         have certain form-level logic based around the validation status of the form's fields. For instance, the
         form's "Submit" button might be disabled when a field is invalid. To assist with this sort of pattern,
         RSC provides a few helper functions and types around the validation related data types that the form fields
         rely on. See the <a href="#/pages/Form%20Validation%20Guidelines">Form Validation Example</a> as a
         demonstration of some of these types and functions in use.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
-    <GalleryExampleTile title="ValidationErrors"
-                        codeExamples={validationErrorsExampleCode}>
-      The <code className="nx-code">ValidationErrors</code> data type is essentially zero or more
+    <GalleryExampleTile title="ValidationErrors" codeExamples={validationErrorsExampleCode}>
+      The <NxCode>ValidationErrors</NxCode> data type is essentially zero or more
       validation error message strings. More precisely, it is a union type which can be either
       a single string, an array of strings, or null. If it is null or an empty array, the
       intended semantics are that no error is represented and the validation was successful.
     </GalleryExampleTile>
 
-    <GalleryExampleTile title="hasValidationErrors"
-                        codeExamples={hasValidationErrorsExampleCode}>
-      <code className="nx-code">hasValidationErrors</code> is a function which returns whether
-      the specified <code className="nx-code">ValidationErrors</code> represents an error.
+    <GalleryExampleTile title="hasValidationErrors" codeExamples={hasValidationErrorsExampleCode}>
+      <NxCode>hasValidationErrors</NxCode> is a function which returns whether
+      the specified <NxCode>ValidationErrors</NxCode> represents an error.
     </GalleryExampleTile>
 
-    <GalleryExampleTile title="getFirstValidationError"
-                        codeExamples={getFirstValidationErrorExampleCode}>
-      <code className="nx-code">getFirstValidationError</code> returns the first message from
-      the given <code className="nx-code">ValidationErrors</code> or null if none are present.
-      This is the logic that <code className="nx-code">NxTextInput</code> follows internally to
+    <GalleryExampleTile title="getFirstValidationError" codeExamples={getFirstValidationErrorExampleCode}>
+      <NxCode>getFirstValidationError</NxCode> returns the first message from
+      the given <NxCode>ValidationErrors</NxCode> or null if none are present.
+      This is the logic that <NxCode>NxTextInput</NxCode> follows internally to
       select which validation error message to display.
     </GalleryExampleTile>
 
-    <GalleryExampleTile title="combineValidationErrors"
-                        codeExamples={combineValidationErrorsExampleCode}>
-      <code className="nx-code">combineValidationErrors</code> takes a series
-      of <code className="nx-code">ValidationErrors</code> objects as arguments and returns a
-      single <code className="nx-code">ValidationErrors</code> object containing all of the errors in those
+    <GalleryExampleTile title="combineValidationErrors" codeExamples={combineValidationErrorsExampleCode}>
+      <NxCode>combineValidationErrors</NxCode> takes a series
+      of <NxCode>ValidationErrors</NxCode> objects as arguments and returns a
+      single <NxCode>ValidationErrors</NxCode> object containing all of the errors in those
       arguments, in the same order.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
+++ b/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 const validationErrorsExampleCode = require('./ValidationErrorsExample?raw'),

--- a/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
+++ b/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+
 import { NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 const validationErrorsExampleCode = require('./ValidationErrorsExample?raw'),
     hasValidationErrorsExampleCode = require('./HasValidationErrorsExample?raw'),

--- a/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
+++ b/gallery/src/jsUtilPages/ValidationUtils/ValidationUtilsPage.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
-import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
 
 const validationErrorsExampleCode = require('./ValidationErrorsExample?raw'),
     hasValidationErrorsExampleCode = require('./HasValidationErrorsExample?raw'),
@@ -20,10 +20,10 @@ const ValidationUtilsPage = () =>
         Some of the form-related components provided by RSC, such as <NxCode>NxTextInput</NxCode>,
         have support for validation logic. Typically, when building a form using these components, it is desired to
         have certain form-level logic based around the validation status of the form's fields. For instance, the
-        form's "Submit" button might be disabled when a field is invalid. To assist with this sort of pattern,
-        RSC provides a few helper functions and types around the validation related data types that the form fields
-        rely on. See the <a href="#/pages/Form%20Validation%20Guidelines">Form Validation Example</a> as a
-        demonstration of some of these types and functions in use.
+        form's "Submit" button might be disabled when a field is invalid. To assist with this sort of pattern, RSC
+        provides a few helper functions and types around the validation related data types that the form fields rely
+        on. See the <NxTextLink href="#/pages/Form%20Validation%20Guidelines">Form Validation Example</NxTextLink> as
+        a demonstration of some of these types and functions in use.
       </NxP>
     </GalleryDescriptionTile>
 

--- a/gallery/src/jsUtilPages/WithClass/WithClassPage.tsx
+++ b/gallery/src/jsUtilPages/WithClass/WithClassPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import WithClassExample from './WithClassExample';

--- a/gallery/src/jsUtilPages/WithClass/WithClassPage.tsx
+++ b/gallery/src/jsUtilPages/WithClass/WithClassPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxP, NxCode } from '@sonatype/react-shared-components';
 
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 import { GalleryExampleTile, GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import WithClassExample from './WithClassExample';

--- a/gallery/src/pages/AdditionalResources.tsx
+++ b/gallery/src/pages/AdditionalResources.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import {GalleryTile} from '../gallery-components/GalleryTiles';
+
 import { NxP, NxTile, NxH3, NxTextLink } from '@sonatype/react-shared-components';
+import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 const AdditionalResources = () =>
   <GalleryTile title="Additional Resources">

--- a/gallery/src/pages/AdditionalResources.tsx
+++ b/gallery/src/pages/AdditionalResources.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxTile, NxH3, NxTextLink } from '@sonatype/react-shared-components';
+
 import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 const AdditionalResources = () =>

--- a/gallery/src/pages/AdditionalResources.tsx
+++ b/gallery/src/pages/AdditionalResources.tsx
@@ -6,104 +6,103 @@
  */
 import React from 'react';
 import {GalleryTile} from '../gallery-components/GalleryTiles';
+import { NxP, NxTile, NxH3, NxTextLink } from '@sonatype/react-shared-components';
 
 const AdditionalResources = () =>
   <GalleryTile title="Additional Resources">
-    <p className="nx-p">
+    <NxP>
       We have curated a list of additional resources you can use to increase your understanding of react and redux.
-    </p>
+    </NxP>
 
-    <h3 className="nx-h3 nx-tile__section-header">Classes / Tutorials</h3>
-    <ul className="nx-list nx-list--bulleted">
-      <li className="nx-list__item">
-        <a rel="noreferrer" href="https://reactjs.org/tutorial/tutorial.html" target="_blank">
-          Official ReactJS Tutorial
-        </a>
-        {' '}(Beginner Level)
-      </li>
-      <li className="nx-list__item">
-        <a rel="noreferrer"
-           href="https://redux.js.org/basics/basic-tutorial"
-           target="_blank">Official Redux Getting Started
-        </a>
-        {' '}(Beginner Level)
-      </li>
-      <li className="nx-list__item">
-        <a rel="noreferrer"
-           href="https://egghead.io/courses/getting-started-with-redux"
-           target="_blank">
-          Getting started with Redux
-        </a>
-        {' '}(egghead.io beginner course)
-      </li>
-      <li className="nx-list__item">
-        <a rel="noreferrer"
-           href="https://www.pluralsight.com/paths/react"
-           target="_blank">
-          Pluralsight React Path
-        </a>
-        {' '}(beginner to advanced)
-      </li>
-      <li className="nx-list__item">
-        <a rel="noreferrer"
-           href="https://reactforbeginners.com/"
-           target="_blank">
-          React for beginners
-        </a>
-      </li>
-    </ul>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>Classes / Tutorials</NxH3>
+      </NxTile.SubsectionHeader>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
+          <NxTextLink external href="https://reactjs.org/tutorial/tutorial.html">
+            Official ReactJS Tutorial
+          </NxTextLink>
+          {' '}(Beginner Level)
+        </li>
+        <li className="nx-list__item">
+          <NxTextLink external href="https://redux.js.org/basics/basic-tutorial">
+            Official Redux Getting Started
+          </NxTextLink>
+          {' '}(Beginner Level)
+        </li>
+        <li className="nx-list__item">
+          <NxTextLink external href="https://egghead.io/courses/getting-started-with-redux">
+            Getting started with Redux
+          </NxTextLink>
+          {' '}(egghead.io beginner course)
+        </li>
+        <li className="nx-list__item">
+          <NxTextLink external href="https://www.pluralsight.com/paths/react">
+            Pluralsight React Path
+          </NxTextLink>
+          {' '}(beginner to advanced)
+        </li>
+        <li className="nx-list__item">
+          <NxTextLink external href="https://reactforbeginners.com/">
+            React for beginners
+          </NxTextLink>
+        </li>
+      </ul>
+    </NxTile.Subsection>
 
-    <h3 className="nx-h3 nx-tile__section-header">Good Reads</h3>
-    <ul className="nx-list nx-list--bulleted">
-      <li className="nx-list__item">
-        <a rel="noreferrer" href="https://reactjs.org/docs/hello-world.html" target="_blank">
-          Main Concepts in React
-        </a>
-      </li>
-      <li className="nx-list__item">
-        <a rel="noreferrer" href="https://reactjs.org/docs/thinking-in-react.html" target="_blank">Thinking in React</a>
-      </li>
-      <li className="nx-list__item">
-        Many apps utilizing React and Redux together utilize the official{' '}
-        <a rel="noreferrer" href="https://react-redux.js.org/using-react-redux/connect-mapstate" target="_blank">
-          react-redux
-        </a>
-        {' '}connectors, as well as the{' '}
-        <a rel="noreferrer" href="https://redux-toolkit.js.org/introduction/quick-start" target="_blank">
-          Redux toolkit
-        </a>
-        , which is a set of patterns to reduce boilerplate in “vanilla Redux”.
-      </li>
-      <li className="nx-list__item">
-        <a rel="noreferrer"
-           href="https://www.youtube.com/watch?v=nYkdrAPrdcw&time_continue=781"
-           target="_blank">
-          Video about Flux
-        </a>
-        , which is a precursor to redux. Uses some real-world problems to motivate the concept of one-way dataflow for
-        state management, which is what Redux is all about.
-      </li>
-    </ul>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>Good Reads</NxH3>
+      </NxTile.SubsectionHeader>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
+          <NxTextLink external href="https://reactjs.org/docs/hello-world.html">
+            Main Concepts in React
+          </NxTextLink>
+        </li>
+        <li className="nx-list__item">
+          <NxTextLink external href="https://reactjs.org/docs/thinking-in-react.html">Thinking in React</NxTextLink>
+        </li>
+        <li className="nx-list__item">
+          Many apps utilizing React and Redux together utilize the official{' '}
+          <NxTextLink external href="https://react-redux.js.org/using-react-redux/connect-mapstate">
+            react-redux
+          </NxTextLink>
+          {' '}connectors, as well as the{' '}
+          <NxTextLink external href="https://redux-toolkit.js.org/introduction/quick-start">
+            Redux toolkit
+          </NxTextLink>
+          , which is a set of patterns to reduce boilerplate in “vanilla Redux”.
+        </li>
+        <li className="nx-list__item">
+          <NxTextLink external href="https://www.youtube.com/watch?v=nYkdrAPrdcw&time_continue=781">
+            Video about Flux
+          </NxTextLink>
+          , which is a precursor to redux. Uses some real-world problems to motivate the concept of one-way dataflow for
+          state management, which is what Redux is all about.
+        </li>
+      </ul>
+    </NxTile.Subsection>
 
-    <h3 className="nx-h3 nx-tile__section-header">Getting your hands dirty</h3>
-    <ul className="nx-list nx-list--bulleted">
-      <li className="nx-list__item">
-        <a rel="noreferrer"
-           href="https://github.com/sonatype/sonatype-application-builder"
-           target="_blank">
-          Internal Sonatype Application Builder (SAB) Template
-        </a>
-        {' - '}A great place to start for new projects and a fun place to poke around.
-        It is also setup as a GitHub Template, just click the "use this template" button (or click{' '}
-        <a rel="noreferrer"
-           href="https://github.com/sonatype/sonatype-application-builder/generate"
-           target="_blank">
-          here
-        </a>
-        ) in GitHub to get started. Note that, at this time, this is an internal to Sonatype template.
-      </li>
-    </ul>
-
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>Getting your hands dirty</NxH3>
+      </NxTile.SubsectionHeader>
+      <ul className="nx-list nx-list--bulleted">
+        <li className="nx-list__item">
+          <NxTextLink external href="https://github.com/sonatype/sonatype-application-builder">
+            Internal Sonatype Application Builder (SAB) Template
+          </NxTextLink>
+          {' - '}A great place to start for new projects and a fun place to poke around.
+          It is also setup as a GitHub Template, just click the "use this template" button (or click{' '}
+          <NxTextLink external href="https://github.com/sonatype/sonatype-application-builder/generate">
+            here
+          </NxTextLink>
+          ) in GitHub to get started. Note that, at this time, this is an internal to Sonatype template.
+        </li>
+      </ul>
+    </NxTile.Subsection>
   </GalleryTile>;
 
 export default AdditionalResources;

--- a/gallery/src/pages/Contributing.tsx
+++ b/gallery/src/pages/Contributing.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import {GalleryTile} from '../gallery-components/GalleryTiles';
+
 import { NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 import CodeExample from '../CodeExample';
 

--- a/gallery/src/pages/Contributing.tsx
+++ b/gallery/src/pages/Contributing.tsx
@@ -6,6 +6,8 @@
  */
 import React from 'react';
 import {GalleryTile} from '../gallery-components/GalleryTiles';
+import { NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import CodeExample from '../CodeExample';
 
 const pageConfigExample = `import Foo from './pages/Foo';
@@ -27,56 +29,60 @@ const pageConfig: PageConfig = {
 const Contributing = () =>
   <>
     <GalleryTile title="How to add a new component to the Gallery" >
-      <h3 className="nx-h3">Create a page describing the component</h3>
+      <NxH3>Create a page describing the component</NxH3>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">
           For each component or style that you want to add to the Gallery, create a subdirectory
-          underneath <code className="nx-code">src/components</code> or <code className="nx-code">src/styles</code>
+          underneath <NxCode>src/components</NxCode> or <NxCode>src/styles</NxCode>
           with the name of the component or style
         </li>
         <li className="nx-list__item">
           Under the subdirectory, create 2 Typescript files to describe the behavior of your component or style. One
-          file will be <code className="nx-code">[ComponentName]Example.tsx</code>, which has a working example of the
+          file will be <NxCode>[ComponentName]Example.tsx</NxCode>, which has a working example of the
           component with how different parameters are handled. The second file will
-          be <code className="nx-code">[ComponentName]Page.tsx</code>, which should contain 3 things:
+          be <NxCode>[ComponentName]Page.tsx</NxCode>, which should contain 3 things:
           <ul className="nx-list nx-list--bulleted">
             <li className="nx-list__item">
               A description of the component and its parameters, as well as an example of how to use the component.
-              See also the <code className="nx-code">GalleryDescriptionTile</code> component
+              See also the <NxCode>GalleryDescriptionTile</NxCode> component
             </li>
             <li className="nx-list__item">
               Code that demonstrates the component (import the example component and invoke it)
             </li>
             <li className="nx-list__item">
-              Code snippet of the example component (use the <code className="nx-code">CodeExample</code> component)
+              Code snippet of the example component (use the <NxCode>CodeExample</NxCode> component)
             </li>
           </ul>
         </li>
         <li className="nx-list__item">
-          See also <code className="nx-code">NxCheckboxPage.tsx</code>
-          and <code className="nx-code">NxCheckboxExample.tsx</code> as an example of how to create a
+          See also <NxCode>NxCheckboxPage.tsx</NxCode>
+          and <NxCode>NxCheckboxExample.tsx</NxCode> as an example of how to create a
           component example.
         </li>
       </ul>
-      <h3 className="nx-h3">Add the new page to Gallery navigation</h3>
-      <p className="nx-p">
-        After you've created the description page, in order to add the component to the Gallery Navigation, you
-        will need to add it to the <code className="nx-code">pageConfig</code> object inside of
-        the <code className="nx-code">pageConfig.ts</code> file
-      </p>
-      <CodeExample content={pageConfigExample}/>
-      <ul className="nx-list nx-list--bulleted">
-        <li className="nx-list__item">
-          Import the description page you created earlier
-        </li>
-        <li className="nx-list__item">
-          Place the entry in the proper category (creating a new category if necessary)
-        </li>
-        <li className="nx-list__item">
-          It is important to note that the key that you use for your entry will be used by
-          <code className="nx-code">react-router</code> to auto-populate the left-hand navigation, page title and URL
-        </li>
-      </ul>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
+          <NxH3>Add the new page to Gallery navigation</NxH3>
+        </NxTile.SubsectionHeader>
+        <NxP>
+          After you've created the description page, in order to add the component to the Gallery Navigation, you
+          will need to add it to the <NxCode>pageConfig</NxCode> object inside of
+          the <NxCode>pageConfig.ts</NxCode> file
+        </NxP>
+        <CodeExample content={pageConfigExample}/>
+        <ul className="nx-list nx-list--bulleted">
+          <li className="nx-list__item">
+            Import the description page you created earlier
+          </li>
+          <li className="nx-list__item">
+            Place the entry in the proper category (creating a new category if necessary)
+          </li>
+          <li className="nx-list__item">
+            It is important to note that the key that you use for your entry will be used by
+            <NxCode>react-router</NxCode> to auto-populate the left-hand navigation, page title and URL
+          </li>
+        </ul>
+      </NxTile.Subsection>
     </GalleryTile>
   </>;
 

--- a/gallery/src/pages/Contributing.tsx
+++ b/gallery/src/pages/Contributing.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 import CodeExample from '../CodeExample';

--- a/gallery/src/pages/Home.tsx
+++ b/gallery/src/pages/Home.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxP, NxH3, NxH4, NxCode } from '@sonatype/react-shared-components';
+import { NxP, NxH3, NxH4, NxCode, NxTile, NxTextLink } from '@sonatype/react-shared-components';
 
 import {GalleryTile} from '../gallery-components/GalleryTiles';
 
@@ -19,10 +19,10 @@ const Home = () =>
       component, live examples are provided along with displays of the code snippets used for generate those live
       examples.
     </NxP>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
         <NxH3>Navigating the Gallery</NxH3>
-      </header>
+      </NxTile.SubsectionHeader>
       <NxP>
         The sidebar at left can be used to navigate to the various examples, which are organized into groups
         as follows:
@@ -53,24 +53,24 @@ const Home = () =>
       </NxP>
       <NxH4>JavaScript &amp; TypeScript Utilities</NxH4>
       <NxP>Utility function and datatypes available to users of RSC.</NxP>
-    </section>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
+    </NxTile.Subsection>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
         <NxH3>Consuming the React Shared Components</NxH3>
-      </header>
+      </NxTile.SubsectionHeader>
       <NxP>
         The RSC library is available as an open-source npm module on{' '}
-        <a rel="noreferrer" target="_blank" href="https://www.npmjs.com/package/@sonatype/react-shared-components">
+        <NxTextLink external href="https://www.npmjs.com/package/@sonatype/react-shared-components">
           npmjs.com
-        </a>
+        </NxTextLink>
         {' '} under the name <NxCode>@sonatype/react-shared-components</NxCode>. It is packaged as
         ECMAScript modules, and is intended to be consumed by project using webpack or a similar module bundler.
       </NxP>
-    </section>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
+    </NxTile.Subsection>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
         <NxH3>Component Architecture Philosophy</NxH3>
-      </header>
+      </NxTile.SubsectionHeader>
       <NxP>
         Most if not all components in RSC come in stateless forms by default. That is, they rely on the consuming
         code to manage their state. This approach was taken in order to be as flexible as possible in regards to the
@@ -82,7 +82,7 @@ const Home = () =>
         stateless <NxCode>NxTextInput</NxCode> that keeps track of basic state such as text box
         contents. A non-redux application would likely use this wrapper, which a redux application would not.
       </NxP>
-    </section>
+    </NxTile.Subsection>
   </GalleryTile>;
 
 export default Home;

--- a/gallery/src/pages/Home.tsx
+++ b/gallery/src/pages/Home.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxH3, NxH4, NxCode, NxTile, NxTextLink } from '@sonatype/react-shared-components';
+
 import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 const Home = () =>

--- a/gallery/src/pages/Home.tsx
+++ b/gallery/src/pages/Home.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxP, NxH3, NxH4, NxCode, NxTile, NxTextLink } from '@sonatype/react-shared-components';
 
+import { NxP, NxH3, NxH4, NxCode, NxTile, NxTextLink } from '@sonatype/react-shared-components';
 import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 const Home = () =>

--- a/gallery/src/pages/StylingComponents.tsx
+++ b/gallery/src/pages/StylingComponents.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import {GalleryTile} from '../gallery-components/GalleryTiles';
+
 import { NxP, NxH3, NxH4, NxCode, NxTile, NxTextLink } from '@sonatype/react-shared-components';
+import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 const StylingRSCPage = () =>
   <GalleryTile title="How to style your app when using RSC">

--- a/gallery/src/pages/StylingComponents.tsx
+++ b/gallery/src/pages/StylingComponents.tsx
@@ -6,135 +6,130 @@
  */
 import React from 'react';
 import {GalleryTile} from '../gallery-components/GalleryTiles';
+import { NxP, NxH3, NxH4, NxCode, NxTile, NxTextLink } from '@sonatype/react-shared-components';
 
 const StylingRSCPage = () =>
   <GalleryTile title="How to style your app when using RSC">
-    <p className="nx-p">
+    <NxP>
       If you have styling needs that aren't covered by the styles included in React Shared Components (RSC),
       then you're going to have to create your own styles.
-    </p>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
-        <h3 className="nx-h3">Page &amp; component specific stylesheets</h3>
-      </header>
-      <p className="nx-p">
+    </NxP>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>Page &amp; component specific stylesheets</NxH3>
+      </NxTile.SubsectionHeader>
+      <NxP>
         Why have page and component specific stylesheets? By grouping our styles together by use and (ideally) locating
         the SCSS next to the HTML that it modifies we decrease clutter/noise in our main stylesheet, keep our styles
         focused on what they modify, and also help maintain a clear separation between code, layout, and styling.
-      </p>
-      <h4 className="nx-h4">Modifying component styles</h4>
-      <p className="nx-p">
+      </NxP>
+      <NxH4>Modifying component styles</NxH4>
+      <NxP>
         If you need to modify any of the stock RSC styles for use within your project you should create either a single
         file to contain your modifications or keep them within a page specific stylesheet if the changes are localised
-        to a page. For example in IQ has an SCSS file named <code className="nx-code">_nx-overrides.scss</code> in
+        to a page. For example in IQ has an SCSS file named <NxCode>_nx-overrides.scss</NxCode> in
         which all IQ specific modifications to RSC styles are stored. If you are starting a brand new project you
         probably won't need to do this but for existing projects where RSC styles will be mixing with legacy styles it
         can be invaluable.
-      </p>
-    </section>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
-        <h3 className="nx-h3">B.E.M.</h3>
-      </header>
-      <p className="nx-p">
+      </NxP>
+    </NxTile.Subsection>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>B.E.M.</NxH3>
+      </NxTile.SubsectionHeader>
+      <NxP>
         You might have noticed lots of dashes and underscores in our class names. That's because we use BEM naming
         by default. BEM stands for "Block", "Element", and "Modifier".{' '}
-        <a href="https://www.toptal.com/css/introduction-to-bem-methodology" target="_blank">Learn more about BEM</a>.
+        <NxTextLink external href="https://www.toptal.com/css/introduction-to-bem-methodology">
+          Learn more about BEM
+        </NxTextLink>.
         We use a slightly modified version of BEM in the RSC; we have added namespaces and utility classes.
-      </p>
-    </section>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
-        <h3 className="nx-h3">Namespaces</h3>
-      </header>
-      <p className="nx-p">
+      </NxP>
+    </NxTile.Subsection>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>Namespaces</NxH3>
+      </NxTile.SubsectionHeader>
+      <NxP>
         Because the RSC styles are used by multiple apps we wanted to clearly distinguish between RSC styles and
         custom app styles. To that end we use a namespace prefix in our class names. In RSC that prefix
-        is <code className="nx-code">nx-</code>. In IQ they use <code className="nx-code">iq-</code> as
+        is <NxCode>nx-</NxCode>. In IQ they use <NxCode>iq-</NxCode> as
         a prefix in order to differentiate between classes in IQ and classes from RSC. When you
         create custom CSS in your app you should create a simple unique prefix for your app.
-      </p>
-    </section>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
-        <h3 className="nx-h3">Utility classes</h3>
-      </header>
-      <p className="nx-p">
+      </NxP>
+    </NxTile.Subsection>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>Utility classes</NxH3>
+      </NxTile.SubsectionHeader>
+      <NxP>
         You may notice as you work with the various RSC that some components have CSS classes that don't follow
         normal BEM naming conventions. Classes like:
-      </p>
+      </NxP>
       <div className="nx-list nx-list--bulleted">
         <ul>
           <li className="nx-list__item">
-            <code className="nx-code">open</code> &amp; <code className="nx-code">closed</code>
+            <NxCode>open</NxCode> &amp; <NxCode>closed</NxCode>
           </li>
           <li className="nx-list__item">
-            <code className="nx-code">disabled</code>
+            <NxCode>disabled</NxCode>
           </li>
           <li className="nx-list__item">
-            <code className="nx-code">pristine</code>, <code className="nx-code">valid</code>,
-            {' '}<code className="nx-code">invalid</code>
+            <NxCode>pristine</NxCode>, <NxCode>valid</NxCode>,
+            {' '}<NxCode>invalid</NxCode>
           </li>
           <li className="nx-list__item">
-            <code className="nx-code">selected</code> &amp; <code className="nx-code">unselected</code>
+            <NxCode>selected</NxCode> &amp; <NxCode>unselected</NxCode>
           </li>
         </ul>
       </div>
-      <p className="nx-p">
+      <NxP>
         These are commonly refered to as "utility classes". Utility classes usually describe a change in a components'
         visual state. These classes are common across all components that might need them, especially in the case of the
         validation utility classes.
-      </p>
-    </section>
-    <section className="nx-tile-subsection">
-      <header className="nx-tile-subsection__header">
-        <h3 className="nx-h3">CSS Resources</h3>
-      </header>
-      <p className="nx-p">
+      </NxP>
+    </NxTile.Subsection>
+    <NxTile.Subsection>
+      <NxTile.SubsectionHeader>
+        <NxH3>CSS Resources</NxH3>
+      </NxTile.SubsectionHeader>
+      <NxP>
         Many components in the RSC are laid out using CSS Flexbox or CSS Grid. Flexbox is well
         established, but Grid is quite new. The syntax for both can be a little confusing for those who aren't used to
         them. There are many resources available on the web to help new users, the ones linked below are used by the RSC
         team for reference.
-      </p>
-      <h4 className="nx-h4">Flexbox</h4>
+      </NxP>
+      <NxH4>Flexbox</NxH4>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">
-          <a rel="noreferrer"
-             href="https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox"
-             target="_blank">
+          <NxTextLink external href="https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox">
             MDN Layout Guide: Flexbox
-          </a>
+          </NxTextLink>
         </li>
         <li className="nx-list__item">
-          <a rel="noreferrer"
-             href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/"
-             target="_blank">
+          <NxTextLink external href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">
             CSS Tricks Guide to CSS Flexbox
-          </a>
+          </NxTextLink>
         </li>
       </ul>
       <h4 className="nx-h4">CSS Grid</h4>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">
-          <a rel="noreferrer"
-             href="https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Grids"
-             target="_blank">
+          <NxTextLink external href="https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Grids">
             MDN Layout Guide: CSS Grid
-          </a>
+          </NxTextLink>
         </li>
         <li className="nx-list__item">
-          <a rel="noreferrer"
-             href="https://css-tricks.com/snippets/css/complete-guide-grid/"
-             target="_blank">
+          <NxTextLink external href="https://css-tricks.com/snippets/css/complete-guide-grid/">
             CSS Tricks Guide to CSS Grid
-          </a>
+          </NxTextLink>
         </li>
       </ul>
-      <p className="nx-p">
+      <NxP>
         If you have questions about how to use RSC's styles in your app, or how to create customs style for your app
         #react-components on Slack is a good place to ask.
-      </p>
-    </section>
+      </NxP>
+    </NxTile.Subsection>
   </GalleryTile>;
 
 export default StylingRSCPage;

--- a/gallery/src/pages/StylingComponents.tsx
+++ b/gallery/src/pages/StylingComponents.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxH3, NxH4, NxCode, NxTile, NxTextLink } from '@sonatype/react-shared-components';
+
 import {GalleryTile} from '../gallery-components/GalleryTiles';
 
 const StylingRSCPage = () =>

--- a/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
+++ b/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxWarningAlert, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import ColorPaletteExample from './ColorPaletteExample';

--- a/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
+++ b/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import ColorPaletteExample from './ColorPaletteExample';
-import { NxWarningAlert, NxP, NxCode } from '@sonatype/react-shared-components';
+import { NxWarningAlert, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
 
 const ColorPalettePage = () =>
   <>
@@ -25,17 +25,17 @@ const ColorPalettePage = () =>
       <NxWarningAlert>
         The lime palette is deprecated and is currently an alias for the green palette.
       </NxWarningAlert>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__header">
-          <h3 className="nx-h3">Using Colors</h3>
-        </header>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
+          <NxH3>Using Colors</NxH3>
+        </NxTile.SubsectionHeader>
         <NxP>
           It is expected that designers and consumers of the RSC will limit themselves to using the colors that have
           been made available in the swatch custom CSS properties. It is preferable to use the
           {' '}custom property rather than hardcoding the color value. Doing so makes it easier
           to replace colors in the future if the palette changes.
         </NxP>
-      </section>
+      </NxTile.Subsection>
     </GalleryDescriptionTile>
 
     <ColorPaletteExample/>

--- a/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
+++ b/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
@@ -8,21 +8,20 @@ import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import ColorPaletteExample from './ColorPaletteExample';
-import { NxWarningAlert } from '@sonatype/react-shared-components';
+import { NxWarningAlert, NxP, NxCode } from '@sonatype/react-shared-components';
 
 const ColorPalettePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         The design group has created a palette of colors for use in RSC. The colors are organized into swatches
         which each have a consistent hue (red, green, blue, etc) and saturation. Within a swatch the various colors vary
         by lightness, and are named based on their lightness value in the HSL color scheme. Thus darker colors
         have lower values, and lighter colors have higher values. For example the darkest red is
-        {' '}<code className="nx-code">--nx-swatch-red-10</code> and the lightest is
-        {' '}<code className="nx-code">--nx-swatch-red-95</code>. All of the color swatch values are available as
-        CSS custom properties declared within the RSC base styles. The swatches below show all of the colors
-        available in RSC along with their hex value and corresponding RSC variable.
-      </p>
+        {' '}<NxCode>--nx-swatch-red-10</NxCode> and the lightest is <NxCode>--nx-swatch-red-95</NxCode>. All of the
+        color swatch values are available as CSS custom properties declared within the RSC base styles. The swatches
+        below show all of the colors available in RSC along with their hex value and corresponding RSC variable.
+      </NxP>
       <NxWarningAlert>
         The lime palette is deprecated and is currently an alias for the green palette.
       </NxWarningAlert>
@@ -30,12 +29,12 @@ const ColorPalettePage = () =>
         <header className="nx-tile-subsection__header">
           <h3 className="nx-h3">Using Colors</h3>
         </header>
-        <p className="nx-p">
+        <NxP>
           It is expected that designers and consumers of the RSC will limit themselves to using the colors that have
           been made available in the swatch custom CSS properties. It is preferable to use the
           {' '}custom property rather than hardcoding the color value. Doing so makes it easier
           to replace colors in the future if the palette changes.
-        </p>
+        </NxP>
       </section>
     </GalleryDescriptionTile>
 

--- a/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
+++ b/gallery/src/styles/ColorPalette/ColorPalettePage.tsx
@@ -6,9 +6,10 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
-import ColorPaletteExample from './ColorPaletteExample';
 import { NxWarningAlert, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+
+import ColorPaletteExample from './ColorPaletteExample';
 
 const ColorPalettePage = () =>
   <>

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React, { ReactNode, useEffect, useState } from 'react';
-
 import { NxTextLink, NxP, NxCode, NxList, NxWarningAlert, NxTable } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryTile } from '../../gallery-components/GalleryTiles';
 
 import './CssVariablesPage.scss';

--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -6,8 +6,8 @@
  */
 import React, { ReactNode, useEffect, useState } from 'react';
 
-import { GalleryDescriptionTile, GalleryTile } from '../../gallery-components/GalleryTiles';
 import { NxTextLink, NxP, NxCode, NxList, NxWarningAlert, NxTable } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryTile } from '../../gallery-components/GalleryTiles';
 
 import './CssVariablesPage.scss';
 

--- a/gallery/src/styles/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxAlertInfoExample from './NxAlertInfoExample';

--- a/gallery/src/styles/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxAlertInfoExample from './NxAlertInfoExample';
 import NxAlertSuccessExample from './NxAlertSuccessExample';

--- a/gallery/src/styles/NxAlert/NxAlertPage.tsx
+++ b/gallery/src/styles/NxAlert/NxAlertPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxAlertInfoExample from './NxAlertInfoExample';
 import NxAlertSuccessExample from './NxAlertSuccessExample';
@@ -21,38 +22,38 @@ const nxAlertInfoCode = require('./NxAlertInfoExample?raw'),
 const NxAlertPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Standard name spaced alert styles. Note that these examples are shown in react as each style includes
-        specific icons. When working in React, <code className="nx-code">NxFontAwesomeIcon</code> should be used
-        as shown to get these icons (or preferably the <code className="nx-code">NxAlert</code> React component and
+        specific icons. When working in React, <NxCode>NxFontAwesomeIcon</NxCode> should be used
+        as shown to get these icons (or preferably the <NxCode>NxAlert</NxCode> React component and
         its variations should be used). When not working in react, check the FontAwesome 5 documentation for alternative
         ways to include the icons. Alerts should generally include Close buttons or another way to dismiss themselves.
-        In this example standard Close button styling is provided by <code className="nx-code">NxCloseButton</code>.
-      </p>
+        In this example standard Close button styling is provided by <NxCode>NxCloseButton</NxCode>.
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Information alert"
                         liveExample={NxAlertInfoExample}
                         codeExamples={nxAlertInfoCode}>
-      An <code className="nx-code">nx-alert</code> demonstrating information styles.
+      An <NxCode>nx-alert</NxCode> demonstrating information styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Success alert"
                         liveExample={NxAlertSuccessExample}
                         codeExamples={nxAlertSuccessCode}>
-      An <code className="nx-code">nx-alert</code> demonstrating success styles.
+      An <NxCode>nx-alert</NxCode> demonstrating success styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Warning alert"
                         liveExample={NxAlertWarningExample}
                         codeExamples={nxAlertWarningCode}>
-      An <code className="nx-code">nx-alert</code> demonstrating warning styles.
+      An <NxCode>nx-alert</NxCode> demonstrating warning styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Error alert"
                         liveExample={NxAlertErrorExample}
                         codeExamples={nxAlertErrorCode}>
-      An <code className="nx-code">nx-alert</code> demonstrating error styles.
+      An <NxCode>nx-alert</NxCode> demonstrating error styles.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/styles/NxBlockquote/NxBlockquotePage.tsx
+++ b/gallery/src/styles/NxBlockquote/NxBlockquotePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxBlockquoteExampleCode = require('./NxBlockquoteExample.html');
 

--- a/gallery/src/styles/NxBlockquote/NxBlockquotePage.tsx
+++ b/gallery/src/styles/NxBlockquote/NxBlockquotePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxBlockquoteExampleCode = require('./NxBlockquoteExample.html');

--- a/gallery/src/styles/NxBlockquote/NxBlockquotePage.tsx
+++ b/gallery/src/styles/NxBlockquote/NxBlockquotePage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxCode } from '@sonatype/react-shared-components';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 const nxBlockquoteExampleCode = require('./NxBlockquoteExample.html');
 
@@ -15,13 +15,13 @@ const NxBlockquotePage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          The <code className="nx-code">.nx-blockquote</code> CSS class provides standard RSC styling
-          for <code className="nx-code">&lt;blockquote&gt;</code> elements.
-        </p>
-        <p className="nx-p">
+        <NxP>
+          The <NxCode>.nx-blockquote</NxCode> CSS class provides standard RSC styling
+          for <NxCode>&lt;blockquote&gt;</NxCode> elements.
+        </NxP>
+        <NxP>
           These styles are also available via the <NxCode>NxBlockquote</NxCode> convenience React component.
-        </p>
+        </NxP>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="Basic Example"
                           codeExamples={nxBlockquoteExampleCode}

--- a/gallery/src/styles/NxBtn/NxBtnPage.tsx
+++ b/gallery/src/styles/NxBtn/NxBtnPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
-import { NxCode, NxTable, NxTile, NxH3 } from '@sonatype/react-shared-components';
+import { NxCode, NxTable, NxTile, NxH3, NxP } from '@sonatype/react-shared-components';
 
 const nxBtnPrimaryCode = require('./NxBtnPrimaryExample.html'),
     nxBtnDefaultCode = require('./NxBtnDefaultExample.html'),
@@ -18,16 +18,16 @@ const nxBtnPrimaryCode = require('./NxBtnPrimaryExample.html'),
 const NxBtnPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p"><code className="nx-code">.nx-btn</code> is the standard class for all buttons.</p>
-      <p className="nx-p">
+      <NxP><NxCode>.nx-btn</NxCode> is the standard class for all buttons.</NxP>
+      <NxP>
         Buttons are typically encapsulated within "button bars" implemented using the <NxCode>nx-btn-bar</NxCode> class.
         This class mediates the layout of groups of buttons within various containers such as footers, table cells, etc.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         When working in React, it is recommended to use the <NxCode>NxButton</NxCode> component which provides a more
         convenient way to use these styles. For the button bar, there is an <NxCode>NxButtonBar</NxCode> convenience
         component.
-      </p>
+      </NxP>
       <NxTile.Subsection>
         <NxTile.SubsectionHeader>
           <NxH3>Classes</NxH3>
@@ -93,37 +93,37 @@ const NxBtnPage = () =>
     <GalleryExampleTile title="Default"
                         htmlExample={nxBtnDefaultCode}
                         codeExamples={nxBtnDefaultCode}>
-      A series of <code className="nx-code">nx-btn</code>s within a <code className="nx-code">nx-btn-bar</code>
+      A series of <NxCode>nx-btn</NxCode>s within a <NxCode>nx-btn-bar</NxCode>
       alongside other block content and inline content. Some of the buttons demonstrate disabled styling, applied
-      both by the <code className="nx-code">disabled</code> HTML attribute and by
-      the <code className="nx-code">.disabled</code> class.
+      both by the <NxCode>disabled</NxCode> HTML attribute and by
+      the <NxCode>.disabled</NxCode> class.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Primary"
                         htmlExample={nxBtnPrimaryCode}
                         codeExamples={nxBtnPrimaryCode}>
-      A demonstration of an <code className="nx-code">nx-btn</code> using "primary" styles, along with disabled
+      A demonstration of an <NxCode>nx-btn</NxCode> using "primary" styles, along with disabled
       primary buttons. Note that the standard disabled styles override the primary styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Tertiary"
                         htmlExample={nxBtnTertiaryCode}
                         codeExamples={nxBtnTertiaryCode}>
-      A demonstration of an <code className="nx-code">nx-btn</code> using "tertiary" styles, along with disabled
+      A demonstration of an <NxCode>nx-btn</NxCode> using "tertiary" styles, along with disabled
       tertiary buttons. Note that the standard disabled styles override the tertiary styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Error"
                         htmlExample={nxBtnErrorCode}
                         codeExamples={nxBtnErrorCode}>
-      A demonstration of an <code className="nx-code">nx-btn</code> using "error" styles, along with a disabled
+      A demonstration of an <NxCode>nx-btn</NxCode> using "error" styles, along with a disabled
       error buttons. Note that the standard disabled styles override the error styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Buttons with Icons"
                         htmlExample={nxBtnIconCode}
                         codeExamples={nxBtnIconCode}>
-      A demonstration of <code className="nx-code">nx-btn</code>s containing icons. One contains only an icon while
+      A demonstration of <NxCode>nx-btn</NxCode>s containing icons. One contains only an icon while
       the other contains both an icon and text.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/styles/NxBtn/NxBtnPage.tsx
+++ b/gallery/src/styles/NxBtn/NxBtnPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 import { NxCode, NxTable, NxTile, NxH3, NxP } from '@sonatype/react-shared-components';
+import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 const nxBtnPrimaryCode = require('./NxBtnPrimaryExample.html'),
     nxBtnDefaultCode = require('./NxBtnDefaultExample.html'),

--- a/gallery/src/styles/NxBtn/NxBtnPage.tsx
+++ b/gallery/src/styles/NxBtn/NxBtnPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxTable, NxTile, NxH3, NxP } from '@sonatype/react-shared-components';
+
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 const nxBtnPrimaryCode = require('./NxBtnPrimaryExample.html'),

--- a/gallery/src/styles/NxCard/NxCardPage.tsx
+++ b/gallery/src/styles/NxCard/NxCardPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import './NxCardPageExamples.scss';
 

--- a/gallery/src/styles/NxCard/NxCardPage.tsx
+++ b/gallery/src/styles/NxCard/NxCardPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import './NxCardPageExamples.scss';
 
@@ -18,134 +19,134 @@ const nxCardLayoutCode = require('./NxCardLayoutExample?raw'),
 const NxCardPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         At its most basic a card is simply a container like a smaller version of
-        {' '}<code className="nx-code">nx-tile</code> with header, content, and footer content areas. Because it's
+        {' '}<NxCode>nx-tile</NxCode> with header, content, and footer content areas. Because it's
         expected that cards will have many uses the examples below do not represent an exhaustive list, instead the
         intent is to display some common patterns that we have seen to date, and provide a starting off point for
         future implementations.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Convenience Component</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card-container</code></td>
-            <td className="nx-cell"><code className="nx-code">NxCard.Container</code></td>
-            <td className="nx-cell">Top-Level</td>
-            <td className="nx-cell">
-              Container for <code className="nx-code">.nx-card</code>s
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card-container--no-wrap</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-card-container</code></td>
-            <td className="nx-cell">
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Convenience Component</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card-container</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxCard.Container</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top-Level</NxTable.Cell>
+            <NxTable.Cell>
+              Container for <NxCode>.nx-card</NxCode>s
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card-container--no-wrap</NxCode></NxTable.Cell>
+            <NxTable.Row/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-card-container</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               By default if you put more cards into a container than can fit horizontally the cards will wrap into a
               new row. This modifier is used when you do not want the cards to wrap. Use with care as this can break
               layouts.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card</code></td>
-            <td className="nx-cell"><code className="nx-code">NxCard</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxCard</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               Basic card element.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card--equal</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-card</code></td>
-            <td className="nx-cell">
-              <code className="nx-code">.nx-card</code>s have a default <code className="nx-code">max-width</code>.
-              This modifer will override the <code className="nx-code">max-width</code> and force all cards to share
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card--equal</NxCode></NxTable.Cell>
+            <NxTable.Row/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-card</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>.nx-card</NxCode>s have a default <NxCode>max-width</NxCode>.
+              This modifer will override the <NxCode>max-width</NxCode> and force all cards to share
               the available space equally. It should be applied to all cards within an
-              <code className="nx-code">.nx-card-container</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card__header</code></td>
-            <td className="nx-cell"><code className="nx-code">NxCard.Header</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Card header element, typically wraps an <code className="nx-code">&lt;h3&gt;</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card__footer</code></td>
-            <td className="nx-cell"><code className="nx-code">NxCard.Footer</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+              <NxCode>.nx-card-container</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card__header</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxCard.Header</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Card header element, typically wraps an <NxCode>&lt;h3&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card__footer</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxCard.Footer</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               Card footer, typically provides a link to more information or an action button.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card__content</code></td>
-            <td className="nx-cell"><code className="nx-code">NxCard.Content</code></td>
-            <td className="nx-cell">Wrapping element</td>
-            <td className="nx-cell">
-              <code className="nx-code">.nx-card__content</code> applied to a
-              {' '}<code className="nx-code">&lt;div&gt;</code> wraps card contents. In the layouts below it wraps
-              {' '}<code className="nx-code">.nx-card__call-out</code> and
-              {' '}<code className="nx-code">.nx-card__text</code> as well as other card content.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card__content--columns</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-card__content</code></td>
-            <td className="nx-cell">
-              <code className="nx-code">.nx-card__content--columns</code> applied to
-              {' '}<code className="nx-code">.nx-card__content</code> creates a two column layout within
-              {' '}<code className="nx-code">.nx-card__content</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card__call-out</code></td>
-            <td className="nx-cell"><code className="nx-code">NxCard.CallOut</code></td>
-            <td className="nx-cell">
-              Element, typically a child of <code className="nx-code">.nx-card__content</code>
-            </td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card__content</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxCard.Content</NxCode></NxTable.Cell>
+            <NxTable.Cell>Wrapping element</NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>.nx-card__content</NxCode> applied to a
+              {' '}<NxCode>&lt;div&gt;</NxCode> wraps card contents. In the layouts below it wraps
+              {' '}<NxCode>.nx-card__call-out</NxCode> and
+              {' '}<NxCode>.nx-card__text</NxCode> as well as other card content.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card__content--columns</NxCode></NxTable.Cell>
+            <NxTable.Row/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-card__content</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>.nx-card__content--columns</NxCode> applied to
+              {' '}<NxCode>.nx-card__content</NxCode> creates a two column layout within
+              {' '}<NxCode>.nx-card__content</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card__call-out</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxCard.CallOut</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Element, typically a child of <NxCode>.nx-card__content</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>
               Wraps the card call out (if any). The call out typically consists of a number, sparkline, icon, or
               other small graphic. It should not be free form text.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-card__text</code></td>
-            <td className="nx-cell"><code className="nx-code">NxCard.Text</code></td>
-            <td className="nx-cell">
-              Element, typically a child of <code className="nx-code">.nx-card__content</code>
-            </td>
-            <td className="nx-cell">Free-form text. Should be concise.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">nx-card__call-out-icon</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-icon</code></td>
-            <td className="nx-cell">
-              Changes the size of <code className="nx-code">.nx-icon</code> to <code className="nx-code">48px</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">nx-card__call-out-icon--xl</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-icon</code></td>
-            <td className="nx-cell">
-              Changes the size of <code className="nx-code">.nx-icon</code> to <code className="nx-code">64px</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-card__text</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxCard.Text</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Element, typically a child of <NxCode>.nx-card__content</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>Free-form text. Should be concise.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-card__call-out-icon</NxCode></NxTable.Cell>
+            <NxTable.Row/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-icon</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Changes the size of <NxCode>.nx-icon</NxCode> to <NxCode>48px</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-card__call-out-icon--xl</NxCode></NxTable.Cell>
+            <NxTable.Row/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-icon</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Changes the size of <NxCode>.nx-icon</NxCode> to <NxCode>64px</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Card Row Layout"

--- a/gallery/src/styles/NxCard/NxCardPage.tsx
+++ b/gallery/src/styles/NxCard/NxCardPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import './NxCardPageExamples.scss';

--- a/gallery/src/styles/NxClickable/NxClickablePage.tsx
+++ b/gallery/src/styles/NxClickable/NxClickablePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxClickableExample from './NxClickableExample';

--- a/gallery/src/styles/NxClickable/NxClickablePage.tsx
+++ b/gallery/src/styles/NxClickable/NxClickablePage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxClickableExample from './NxClickableExample';
 
@@ -16,13 +17,13 @@ const NxClickablePage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          The <code className="nx-code">.nx-clickable</code> helper class allows you to quickly and easily
+        <NxP>
+          The <NxCode>.nx-clickable</NxCode> helper class allows you to quickly and easily
           indicate when a part of the UI is clickable when it might not be obvious to the user. It does this by
           simply changing the cursor to a pointer. It's intended to be used on UI elements like table rows.
-          It is recommended that <code className="nx-code">.nx-clickable</code> be just one of the
+          It is recommended that <NxCode>.nx-clickable</NxCode> be just one of the
           visual cues provided in the UI.
-        </p>
+        </NxP>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="General Example"
                           codeExamples={nxClickableExampleCode}

--- a/gallery/src/styles/NxClickable/NxClickablePage.tsx
+++ b/gallery/src/styles/NxClickable/NxClickablePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxClickableExample from './NxClickableExample';
 

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxCodeExampleCode = require('./NxCodeExample.html');

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxCodeExampleCode = require('./NxCodeExample.html');
 

--- a/gallery/src/styles/NxCode/NxCodePage.tsx
+++ b/gallery/src/styles/NxCode/NxCodePage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxCode } from '@sonatype/react-shared-components';
+import { NxCode, NxP } from '@sonatype/react-shared-components';
 
 const nxCodeExampleCode = require('./NxCodeExample.html');
 
@@ -15,15 +15,15 @@ const NxCodePage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          Using the <code className="nx-code">&lt;code&gt;</code> HTML tag with the
-          <code className="nx-code">.nx-code</code> className applies a monospace font and other styling to make your
+        <NxP>
+          Using the <NxCode>&lt;code&gt;</NxCode> HTML tag with the
+          <NxCode>.nx-code</NxCode> className applies a monospace font and other styling to make your
           code snippets stand out. When working in React, the <NxCode>NxCode</NxCode> component is available for
           a more convenient way to apply these styles.
-        </p>
-        <p className="nx-p">
-          <code className="nx-code">.nx-code</code> is used extensively throughout the RSC Gallery.
-        </p>
+        </NxP>
+        <NxP>
+          <NxCode>.nx-code</NxCode> is used extensively throughout the RSC Gallery.
+        </NxP>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="Styling code snippets"
                           codeExamples={nxCodeExampleCode}

--- a/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
+++ b/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxContainerHelpersExample from './NxContainerHelpersExample';

--- a/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
+++ b/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxContainerHelpersExample from './NxContainerHelpersExample';
 import './NxContainerHelpersExample.scss';
@@ -20,11 +21,11 @@ const NxContainerHelpersPage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
+        <NxP>
           The following general guidelines are recommended for the usage of padding and margin.
-          The <code className="nx-code">container-vertical</code> and
-          <code className="nx-code">container-horizontal</code> SCSS mixins are provided to facilitate these patterns.
-        </p>
+          The <NxCode>container-vertical</NxCode> and
+          <NxCode>container-horizontal</NxCode> SCSS mixins are provided to facilitate these patterns.
+        </NxP>
         <ul className="nx-list nx-list--bulleted">
           <li className="nx-list__item">
             Elements should specify margin as desired in the directions in which they may have siblings, i.e. top
@@ -44,32 +45,32 @@ const NxContainerHelpersPage = () => {
             sticking to margin here, we remain compatible with #2 above and also with margin collapsing rules.
           </li>
         </ul>
-        <p className="nx-p">
-          The mixins facilitate point #2 above. The <code className="nx-code">container-vertical</code> mixin removes
+        <NxP>
+          The mixins facilitate point #2 above. The <NxCode>container-vertical</NxCode> mixin removes
           top margin from the first child and bottom margin from the last child, while the{' '}
-          <code className="nx-code">container-horizontal</code> mixin removes the left margin from the first child and
+          <NxCode>container-horizontal</NxCode> mixin removes the left margin from the first child and
           right margin from the last child.
-        </p>
-        <p className="nx-p">
+        </NxP>
+        <NxP>
           These guidelines do have a few caveats that developers must be aware of:
-        </p>
+        </NxP>
         <ul className="nx-list nx-list--bulleted">
           <li className="nx-list__item">
-            Bare text nodes don't count in the <code className="nx-code">:first-child</code> and
-            <code className="nx-code">:last-child</code> selectors that are used to implement
+            Bare text nodes don't count in the <NxCode>:first-child</NxCode> and
+            <NxCode>:last-child</NxCode> selectors that are used to implement
             guideline #2. Therefore they can cause those selectors to select the wrong thing. As a result, bare
             text nodes as siblings of actual elements should be used with caution. This is particularly awkward with
             react components that take children but which support those children being a mix of inline and block
-            elements, such as <code className="nx-code">NxAlert</code>.
+            elements, such as <NxCode>NxAlert</NxCode>.
           </li>
           <li className="nx-list__item">
             Any CSS styles that cause the visual order of elements to not follow the document order of elements
-            can similarly cause <code className="nx-code">:first-child</code> and
-            <code className="nx-code">:last-child</code> problems. Floats are the most obvious offender here.
+            can similarly cause <NxCode>:first-child</NxCode> and
+            <NxCode>:last-child</NxCode> problems. Floats are the most obvious offender here.
             Again, use with caution.
           </li>
           <li className="nx-list__item">
-            The specificity on the <code className="nx-code">{'>'} :first-child</code> selector isn't that high as it
+            The specificity on the <NxCode>{'>'} :first-child</NxCode> selector isn't that high as it
             turns out, and component style can sometimes inadvertently override it.
           </li>
         </ul>

--- a/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
+++ b/gallery/src/styles/NxContainerHelpers/NxContainerHelpersPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxContainerHelpersExample from './NxContainerHelpersExample';
 import './NxContainerHelpersExample.scss';

--- a/gallery/src/styles/NxCounter/NxCounterPage.tsx
+++ b/gallery/src/styles/NxCounter/NxCounterPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxCounterCode = require('./NxCounterExample.html');
 

--- a/gallery/src/styles/NxCounter/NxCounterPage.tsx
+++ b/gallery/src/styles/NxCounter/NxCounterPage.tsx
@@ -7,53 +7,53 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxCode } from '@sonatype/react-shared-components';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 const nxCounterCode = require('./NxCounterExample.html');
 
 const NxCounterPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Basic style for small indicator token which typically displays a single #, a '# of #' string, or a short text
         string. When working in React, the <NxCode>NxCounter</NxCode> component is available for a more convenient way
         to create these elements.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         Some basic positioning CSS examples have been provided. To right justify the counter within its container use
-        <code className="nx-code">nx-pull-right</code>.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-counter</code></td>
-            <td className="nx-cell">Top level</td>
-            <td className="nx-cell">Basic counter styling. Supports # of # and text string.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-counter--active</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-counter</code></td>
-            <td className="nx-cell">
+        <NxCode>nx-pull-right</NxCode>.
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-counter</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top level</NxTable.Cell>
+            <NxTable.Cell>Basic counter styling. Supports # of # and text string.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-counter--active</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-counter</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               An active state, used in lists or tree-views when the parent also has an active state.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="nx-counter Examples"
                         htmlExample={nxCounterCode}
                         codeExamples={nxCounterCode}>
-      Examples of <code className="nx-code">nx-counter</code>s with variations. The first is a basic example. The
+      Examples of <NxCode>nx-counter</NxCode>s with variations. The first is a basic example. The
       second is an example of the active style. The third and fourth examples demonstrate the addition of the
-      <code className="nx-code">nx-pull-right</code> class to put the counter on the right side of the container.
+      <NxCode>nx-pull-right</NxCode> class to put the counter on the right side of the container.
       The fourth example demonstrates this in conjunction with text that is long enough to overflow.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/styles/NxCounter/NxCounterPage.tsx
+++ b/gallery/src/styles/NxCounter/NxCounterPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxCounterCode = require('./NxCounterExample.html');

--- a/gallery/src/styles/NxFieldset/NxFieldsetStylePage.tsx
+++ b/gallery/src/styles/NxFieldset/NxFieldsetStylePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFieldsetExample from './NxFieldsetExample';

--- a/gallery/src/styles/NxFieldset/NxFieldsetStylePage.tsx
+++ b/gallery/src/styles/NxFieldset/NxFieldsetStylePage.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFieldsetExample from './NxFieldsetExample';
 import NxFieldsetComplexExample from './NxFieldsetComplexExample';

--- a/gallery/src/styles/NxFieldset/NxFieldsetStylePage.tsx
+++ b/gallery/src/styles/NxFieldset/NxFieldsetStylePage.tsx
@@ -6,8 +6,7 @@
  */
 import React from 'react';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTableHead, NxTableRow, NxTableCell, NxTable, NxTableBody }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxCode, NxP } from '@sonatype/react-shared-components';
 
 import NxFieldsetExample from './NxFieldsetExample';
 import NxFieldsetComplexExample from './NxFieldsetComplexExample';
@@ -20,87 +19,87 @@ const nxFormGroupExampleCode = require('./NxFieldsetExample?raw'),
 const NxFieldsetPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">.nx-fieldset</code> is a wrapper around a collection of checkboxes, radios, or
+      <NxP>
+        <NxCode>.nx-fieldset</NxCode> is a wrapper around a collection of checkboxes, radios, or
         similar form elements which should be displayed to the user as a group with an overall label. When used
-        with <code className="nx-code">NxCheckbox</code> or <code className="nx-code">NxRadio</code>, all inputs
+        with <NxCode>NxCheckbox</NxCode> or <NxCode>NxRadio</NxCode>, all inputs
         contained within a single NxFieldset should represent different options/values of the same field.
-      </p>
-      <p className="nx-p">
-        Form fields which have their own individual label styled using <code className="nx-code">.nx-label</code>{' '}
-        (including those wrapped in <code className="nx-code">.nx-form-group</code>) should not be wrapped
-        in <code className="nx-code">.nx-fieldset</code> as the label styles between the two are intended to be
+      </NxP>
+      <NxP>
+        Form fields which have their own individual label styled using <NxCode>.nx-label</NxCode>{' '}
+        (including those wrapped in <NxCode>.nx-form-group</NxCode>) should not be wrapped
+        in <NxCode>.nx-fieldset</NxCode> as the label styles between the two are intended to be
         identical and not hierarchical.
-      </p>
+      </NxP>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Class</NxTableCell>
-            <NxTableCell>Location</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-fieldset</code></NxTableCell>
-            <NxTableCell>
-              A <code className="nx-code">&lt;fieldset&gt;</code> within
-              an <code className="nx-code">.nx-form</code>
-            </NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-fieldset</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              A <NxCode>&lt;fieldset&gt;</NxCode> within
+              an <NxCode>.nx-form</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>
               Wraps a collection of checkboxes or radios that represent different selections within the same
               category.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-legend</code></NxTableCell>
-            <NxTableCell>
-              A <code className="nx-code">&lt;legend&gt;</code> element within
-              the <code className="nx-code">.nx-fieldset</code>.
-            </NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-legend</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              A <NxCode>&lt;legend&gt;</NxCode> element within
+              the <NxCode>.nx-fieldset</NxCode>.
+            </NxTable.Cell>
+            <NxTable.Cell>
               The label for the fieldset.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-legend--optional</code></NxTableCell>
-            <NxTableCell>Modifier on <code className="nx-code">.nx-legend</code></NxTableCell>
-            <NxTableCell>
-              This class should be present on the <code className="nx-code">.nx-legend</code> of any form
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-legend--optional</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier on <NxCode>.nx-legend</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              This class should be present on the <NxCode>.nx-legend</NxCode> of any form
               field which does not require a value to be entered before the form can be submitted. It adds a
               small "Optional" tag to the legend UI.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-legend__text</code></NxTableCell>
-            <NxTableCell>Wrapping text content within the <code className="nx-code">.nx-legend</code></NxTableCell>
-            <NxTableCell>
-              The text content within the <code className="nx-code">.nx-label</code> should be wrapped in a span
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-legend__text</NxCode></NxTable.Cell>
+            <NxTable.Cell>Wrapping text content within the <NxCode>.nx-legend</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              The text content within the <NxCode>.nx-label</NxCode> should be wrapped in a span
               with this class. This exists to maintain compatibility with the deprecated way of laying
-              out <code className="nx-code">.nx-fieldset</code>s.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-sub-label</code></NxTableCell>
-            <NxTableCell>Following the <code className="nx-code">.nx-legend</code></NxTableCell>
-            <NxTableCell>
+              out <NxCode>.nx-fieldset</NxCode>s.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-sub-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>Following the <NxCode>.nx-legend</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               The optional sublabel content should be displayed in this element.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"
                         liveExample={NxFieldsetExample}
                         codeExamples={nxFormGroupExampleCode}>
-      A simple example of an <code className="nx-code">nx-form-group</code>.
+      A simple example of an <NxCode>nx-form-group</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Complex Example"
                         liveExample={NxFieldsetComplexExample}
                         codeExamples={nxFormGroupComplexExampleCode}>
-      An example of an <code className="nx-code">nx-form-group</code> containing a sublabel and the "Optional"
+      An example of an <NxCode>nx-form-group</NxCode> containing a sublabel and the "Optional"
       modifier
     </GalleryExampleTile>
 
@@ -108,11 +107,11 @@ const NxFieldsetPage = () =>
                         id="nx-fieldset-deprecated-example"
                         liveExample={NxFieldsetDeprecatedExample}
                         codeExamples={nxFormGroupDeprecatedExampleCode}>
-      This example show an alternative layout of the <code className="nx-code">nx-fieldset</code> internals. In this
-      layout, the <code className="nx-code">nx-sub-label</code> is inside of
-      the <code className="nx-code">.nx-legend</code>. This layout is deprecated since it is inconsistent with
-      the way that <code className="nx-code">.nx-sub-labels</code> are used
-      within <code className="nx-code">.nx-form-group</code>.
+      This example show an alternative layout of the <NxCode>nx-fieldset</NxCode> internals. In this
+      layout, the <NxCode>nx-sub-label</NxCode> is inside of
+      the <NxCode>.nx-legend</NxCode>. This layout is deprecated since it is inconsistent with
+      the way that <NxCode>.nx-sub-labels</NxCode> are used
+      within <NxCode>.nx-form-group</NxCode>.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import './NxFontSizeScssExample.scss';

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -6,8 +6,9 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import './NxFontSizeScssExample.scss';
 
 const nxFontSizeHtmlExampleCode = require('./NxFontSizeHtmlExample.html');

--- a/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
+++ b/gallery/src/styles/NxFontSize/NxFontSizePage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 import './NxFontSizeScssExample.scss';
 
 const nxFontSizeHtmlExampleCode = require('./NxFontSizeHtmlExample.html');
@@ -15,25 +16,24 @@ const nxFontSizeScssExampleCode = require('./NxFontSizeScssExample.scss?raw');
 const NxFontSizePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">font-size()</code> is a mixin that can be applied to the
-        {' '}<code className="nx-code">&lt;body&gt;</code> tag of your project to adjust the default RSC font size to
-        better match your project. The default font size in RSC is 16px.
-      </p>
-      <p className="nx-p">
+      <NxP>
+        <NxCode>font-size()</NxCode> is a mixin that can be applied to the <NxCode>&lt;body&gt;</NxCode> tag of
+        your project to adjust the default RSC font size to better match your project. The default font size in RSC
+        is 16px.
+      </NxP>
+      <NxP>
         The mixin takes a single variable which is the desired font-size with unit. For example:
-        {' '}<code className="nx-code">@include font-size(14px);</code> or
-        {' '}<code className="nx-code">@include font-size(1.1em);</code>.
-      </p>
-      <p className="nx-p">
+        {' '}<NxCode>@include font-size(14px);</NxCode> or <NxCode>@include font-size(1.1em);</NxCode>.
+      </NxP>
+      <NxP>
         The mixin adjusts the default text size as well as several form elements which have default font size values
         set by the browser.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         This mixin is primarily intended for use when RSC is incorporated into existing/legacy projects. If you're
         using it on a new project then you should confirm with your designer, or the design group that custom font
         sizes are a design requirement.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
     <GalleryExampleTile title="Sample HTML"
                         codeExamples={[{ content: nxFontSizeHtmlExampleCode, language: 'html' },

--- a/gallery/src/styles/NxFormGroup/NxFormGroupStylePage.tsx
+++ b/gallery/src/styles/NxFormGroup/NxFormGroupStylePage.tsx
@@ -5,8 +5,9 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+
 import { NxTable, NxP, NxCode, NxWarningAlert } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormGroupExample from './NxFormGroupExample';
 import NxFormGroupComplexExample from './NxFormGroupComplexExample';

--- a/gallery/src/styles/NxFormGroup/NxFormGroupStylePage.tsx
+++ b/gallery/src/styles/NxFormGroup/NxFormGroupStylePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode, NxWarningAlert } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormGroupExample from './NxFormGroupExample';

--- a/gallery/src/styles/NxFormGroup/NxFormGroupStylePage.tsx
+++ b/gallery/src/styles/NxFormGroup/NxFormGroupStylePage.tsx
@@ -6,8 +6,7 @@
  */
 import React from 'react';
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTableHead, NxTableRow, NxTableCell, NxTable, NxTableBody, NxWarningAlert }
-  from '@sonatype/react-shared-components';
+import { NxTable, NxP, NxCode, NxWarningAlert } from '@sonatype/react-shared-components';
 
 import NxFormGroupExample from './NxFormGroupExample';
 import NxFormGroupComplexExample from './NxFormGroupComplexExample';
@@ -20,87 +19,87 @@ const nxFormGroupExampleCode = require('./NxFormGroupExample?raw'),
 const NxFormGroupPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">.nx-form-group</code> is a wrapper around a form field which provides the labels
-        and overall spacing for the field. Most commonly, <code className="nx-code">.nx-form-group</code> wraps
-        an <code className="nx-code">NxTextInput</code>, but it may wrap other content such as
-        a <code className="nx-code">&lt;select&gt;</code>. It <em>should not</em> be used to wrap radio
+      <NxP>
+        <NxCode>.nx-form-group</NxCode> is a wrapper around a form field which provides the labels
+        and overall spacing for the field. Most commonly, <NxCode>.nx-form-group</NxCode> wraps
+        an <NxCode>NxTextInput</NxCode>, but it may wrap other content such as
+        a <NxCode>&lt;select&gt;</NxCode>. It <em>should not</em> be used to wrap radio
         and checkbox groups, as those are best encapsulated
-        in <code className="nx-code">&lt;fieldset&gt;</code> elements.
-      </p>
+        in <NxCode>&lt;fieldset&gt;</NxCode> elements.
+      </NxP>
       <NxWarningAlert>
         Using these styles manually is not recommended, due to the complexity of setting up the proper attributes
-        for screenreader support. Use the <code className="nx-code">NxFormGroup</code> react component instead
+        for screenreader support. Use the <NxCode>NxFormGroup</NxCode> react component instead
         where possible.
       </NxWarningAlert>
       <NxTable>
-        <NxTableHead>
-          <NxTableRow>
-            <NxTableCell>Class</NxTableCell>
-            <NxTableCell>Location</NxTableCell>
-            <NxTableCell>Details</NxTableCell>
-          </NxTableRow>
-        </NxTableHead>
-        <NxTableBody>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-form-group</code></NxTableCell>
-            <NxTableCell>Typically within an <code className="nx-code">.nx-form</code></NxTableCell>
-            <NxTableCell>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-form-group</NxCode></NxTable.Cell>
+            <NxTable.Cell>Typically within an <NxCode>.nx-form</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Wraps a form field along with its label and sublabel. Also manages the layout of the form field
               relative to its surroundings.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-label</code></NxTableCell>
-            <NxTableCell>
-              A <code className="nx-code">&lt;label&gt;</code> element within
-              the <code className="nx-code">.nx-form-group</code>.
-            </NxTableCell>
-            <NxTableCell>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              A <NxCode>&lt;label&gt;</NxCode> element within
+              the <NxCode>.nx-form-group</NxCode>.
+            </NxTable.Cell>
+            <NxTable.Cell>
               The label for the form field. The label must be associated with the form field itself, this should
-              be accomplished using the <code className="nx-code">for</code> attribute.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-label--optional</code></NxTableCell>
-            <NxTableCell>Modifier on <code className="nx-code">.nx-label</code></NxTableCell>
-            <NxTableCell>
-              This class should be present on the <code className="nx-code">.nx-label</code> of any form
+              be accomplished using the <NxCode>for</NxCode> attribute.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-label--optional</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier on <NxCode>.nx-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              This class should be present on the <NxCode>.nx-label</NxCode> of any form
               field which does not require a value to be entered before the form can be submitted. It adds a
               small "Optional" tag to the label UI.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-label__text</code></NxTableCell>
-            <NxTableCell>Wrapping text content within the <code className="nx-code">.nx-label</code></NxTableCell>
-            <NxTableCell>
-              The text content within the <code className="nx-code">.nx-label</code> should be wrapped in a span
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-label__text</NxCode></NxTable.Cell>
+            <NxTable.Cell>Wrapping text content within the <NxCode>.nx-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              The text content within the <NxCode>.nx-label</NxCode> should be wrapped in a span
               with this class. This exists to maintain compatibility with the deprecated way of laying
-              out <code className="nx-code">.nx-form-group</code>s.
-            </NxTableCell>
-          </NxTableRow>
-          <NxTableRow>
-            <NxTableCell><code className="nx-code">nx-sub-label</code></NxTableCell>
-            <NxTableCell>Following the <code className="nx-code">.nx-label</code></NxTableCell>
-            <NxTableCell>
+              out <NxCode>.nx-form-group</NxCode>s.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-sub-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>Following the <NxCode>.nx-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               The optional sublabel content should be displayed in this element. It should have an id which is
-              referenced using <code className="nx-code">aria-describedby</code> on the form field.
-            </NxTableCell>
-          </NxTableRow>
-        </NxTableBody>
+              referenced using <NxCode>aria-describedby</NxCode> on the form field.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
       </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"
                         liveExample={NxFormGroupExample}
                         codeExamples={nxFormGroupExampleCode}>
-      A simple example of an <code className="nx-code">nx-form-group</code>.
+      A simple example of an <NxCode>nx-form-group</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Complex Example"
                         liveExample={NxFormGroupComplexExample}
                         codeExamples={nxFormGroupComplexExampleCode}>
-      An example of an <code className="nx-code">nx-form-group</code> containing a sublabel and the "Optional"
+      An example of an <NxCode>nx-form-group</NxCode> containing a sublabel and the "Optional"
       modifier
     </GalleryExampleTile>
 
@@ -108,7 +107,7 @@ const NxFormGroupPage = () =>
                         id="nx-form-group-deprecated-example"
                         liveExample={NxFormGroupDeprecatedExample}
                         codeExamples={nxFormGroupDeprecatedExampleCode}>
-      This example show an alternative layout of the <code className="nx-code">nx-form-group</code> internals. This
+      This example show an alternative layout of the <NxCode>nx-form-group</NxCode> internals. This
       layout does not require ids on any elements but at the same time does not properly support screenreaders,
       which is why it is deprecated.
     </GalleryExampleTile>

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTextLink, NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormLayoutExample from './NxFormLayoutExample';

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTextLink, NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormLayoutExample from './NxFormLayoutExample';
 import NxFormHorizontalLayoutExample from './NxFormHorizontalLayoutExample';

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { NxTextLink, NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
 
 import NxFormLayoutExample from './NxFormLayoutExample';
 import NxFormHorizontalLayoutExample from './NxFormHorizontalLayoutExample';
@@ -129,8 +129,10 @@ const NxFormLayoutPage = () =>
           </NxTable.Row>
         </NxTable.Body>
       </NxTable>
-      <section className="nx-tile__subsection">
-        <h2 className="nx-h2">&lt;form&gt; Accessibility</h2>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
+          <NxH3>&lt;form&gt; Accessibility</NxH3>
+        </NxTile.SubsectionHeader>
         <NxP>
           Larger forms should be identified using either the <NxCode>aria-label</NxCode>
           {' '}attribute to provide a descriptive title, or the <NxCode>aria-labelledby</NxCode>
@@ -141,7 +143,7 @@ const NxFormLayoutPage = () =>
           </NxTextLink>
           {' '}structure, and will be identified by screen readers.
         </NxP>
-      </section>
+      </NxTile.Subsection>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxTextLink } from '@sonatype/react-shared-components';
+import { NxTextLink, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxFormLayoutExample from './NxFormLayoutExample';
 import NxFormHorizontalLayoutExample from './NxFormHorizontalLayoutExample';
@@ -20,127 +20,127 @@ const NxFormInlineLayoutCode = require('./NxFormInlineLayoutExample?raw');
 const NxFormLayoutPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         This page demonstrates the HTML and SCSS required for displaying form and form elements in an application.
         Note that all standard HTML elements in a form have corresponding SCSS classes. It's important that these
         classes are used correctly as they reset browser default form styles.
-      </p>
-      <p className="nx-p">
+      </NxP>
+      <NxP>
         This page does not demonstrate validation which is a part of the form element components which can be found
         in the menu to the left.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-form</code></td>
-            <td className="nx-cell">Top-Level</td>
-            <td className="nx-cell">
-              Default form class. Resets browser <code className="nx-code">&lt;form&gt;</code> attributes and applies
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-form</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top-Level</NxTable.Cell>
+            <NxTable.Cell>
+              Default form class. Resets browser <NxCode>&lt;form&gt;</NxCode> attributes and applies
               NX styles.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-form-group</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-form-group</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               Basic container for form elements. Typically it is best to use
-              the <code className="nx-code">NxFormGroup</code> react component instead of using this class directly.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-form-row</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Used as a parent when you want <code className="nx-code">.nx-form-group</code> blocks to display
+              the <NxCode>NxFormGroup</NxCode> react component instead of using this class directly.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-form-row</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Used as a parent when you want <NxCode>.nx-form-group</NxCode> blocks to display
               horizontally rather than stack vertically.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-label</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Standard class for <code className="nx-code">&lt;label&gt;</code> elements. This element may either be
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Standard class for <NxCode>&lt;label&gt;</NxCode> elements. This element may either be
               wrapped around the form field and sublabel, or precede them and use
-              the <code className="nx-code">for</code> attribute (<code className="nx-code">htmlFor</code> is react).
+              the <NxCode>for</NxCode> attribute (<NxCode>htmlFor</NxCode> is react).
               When the sublabel is present, the label <em>should</em> be set up as a
-              preceding element for accessibility reasons. Using the <code className="nx-code">NxFormGroup</code>
+              preceding element for accessibility reasons. Using the <NxCode>NxFormGroup</NxCode>
               react component handles all of this for you and is recommended.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-label--optional</code></td>
-            <td className="nx-cell">Modifier</td>
-            <td className="nx-cell">
-              Used when you want "Optional" text to appear after a <code className="nx-code">&lt;label&gt;</code>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-label--optional</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier</NxTable.Cell>
+            <NxTable.Cell>
+              Used when you want "Optional" text to appear after a <NxCode>&lt;label&gt;</NxCode>
               element.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-sub-label</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Used when you want text below the standard <code className="nx-code">&lt;label&gt;</code> text.
-              <code className="nx-code">.nx-sub-label</code> is meant to be applied to a{' '}
-              <code className="nx-code">&lt;span&gt;</code> located after the{' '}
-              <code className="nx-code">&lt;label&gt;</code>, though for backwards compatibility placing it within
-              the <code className="nx-code">&lt;label&gt;</code> is also supported. The sublabel <em>should</em> be
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-sub-label</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Used when you want text below the standard <NxCode>&lt;label&gt;</NxCode> text.
+              <NxCode>.nx-sub-label</NxCode> is meant to be applied to a{' '}
+              <NxCode>&lt;span&gt;</NxCode> located after the{' '}
+              <NxCode>&lt;label&gt;</NxCode>, though for backwards compatibility placing it within
+              the <NxCode>&lt;label&gt;</NxCode> is also supported. The sublabel <em>should</em> be
               referenced as the accessibility description (i.e.
-              using <code className="nx-code">aria-describedby</code>) on the form field.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-fieldset</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Applied to a <code className="nx-code">&lt;fieldset&gt;</code> element that wraps checkboxes or
+              using <NxCode>aria-describedby</NxCode>) on the form field.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-fieldset</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Applied to a <NxCode>&lt;fieldset&gt;</NxCode> element that wraps checkboxes or
               radio buttons.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-footer</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-footer</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               Applied to a footer which contains the form action buttons (e.g. Submit, Cancel, etc).
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-legend</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Standard class for <code className="nx-code">&lt;legend&gt;</code> elements. A legend is used inside of a
-              <code className="nx-code">&lt;fieldset&gt;</code> in the place of a
-              <code className="nx-code">&lt;label&gt;</code>
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-legend--optional</code></td>
-            <td className="nx-cell">Modifier</td>
-            <td className="nx-cell">
-              Used when you want "Optional" text to appear after a <code className="nx-code">&lt;legend&gt;</code>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-legend</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Standard class for <NxCode>&lt;legend&gt;</NxCode> elements. A legend is used inside of a
+              <NxCode>&lt;fieldset&gt;</NxCode> in the place of a
+              <NxCode>&lt;label&gt;</NxCode>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-legend--optional</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier</NxTable.Cell>
+            <NxTable.Cell>
+              Used when you want "Optional" text to appear after a <NxCode>&lt;legend&gt;</NxCode>
               element.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
       <section className="nx-tile__subsection">
         <h2 className="nx-h2">&lt;form&gt; Accessibility</h2>
-        <p className="nx-p">
-          Larger forms should be identified using either the <code className="nx-code">aria-label</code>
-          {' '}attribute to provide a descriptive title, or the <code className="nx-code">aria-labelledby</code>
+        <NxP>
+          Larger forms should be identified using either the <NxCode>aria-label</NxCode>
+          {' '}attribute to provide a descriptive title, or the <NxCode>aria-labelledby</NxCode>
           {' '}attribute when existing text is available. Doing so will include the
-          {' '}<code className="nx-code">&lt;form&gt;</code> element in the{' '}
+          {' '}<NxCode>&lt;form&gt;</NxCode> element in the{' '}
           <NxTextLink href="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html" external>
             landmark
           </NxTextLink>
           {' '}structure, and will be identified by screen readers.
-        </p>
+        </NxP>
       </section>
     </GalleryDescriptionTile>
 
@@ -157,7 +157,7 @@ const NxFormLayoutPage = () =>
                         codeExamples={NxFormHorizontalLayoutCode}>
       This example demonstrates a form layout with horizontally placed text input fields. Note that the checkbox and
       radio fieldsets remain vertically separated, they should not be placed side-by-side. This example also
-      demonstrates the use of an <code className="nx-code">NxErrorAlert</code> in the footer.
+      demonstrates the use of an <NxCode>NxErrorAlert</NxCode> in the footer.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Inline form layout"

--- a/gallery/src/styles/NxFormSelect/NxFormSelectPage.tsx
+++ b/gallery/src/styles/NxFormSelect/NxFormSelectPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode, NxTable } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormSelectExample from './NxFormSelectExample';

--- a/gallery/src/styles/NxFormSelect/NxFormSelectPage.tsx
+++ b/gallery/src/styles/NxFormSelect/NxFormSelectPage.tsx
@@ -7,10 +7,10 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode, NxTable } from '@sonatype/react-shared-components';
 
 import NxFormSelectExample from './NxFormSelectExample';
 import NxFormSelectDisabledExample from './NxFormSelectDisabledExample';
-import { NxCode } from '@sonatype/react-shared-components';
 
 const sourceCode = require('./NxFormSelectExample?raw'),
     disabledSourceCode = require('./NxFormSelectDisabledExample?raw');
@@ -18,45 +18,45 @@ const sourceCode = require('./NxFormSelectExample?raw'),
 const NxFormSelectPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Basic styles for Sonatype form select inputs. There isn't very much styling available for the
-        <code className="nx-code">&lt;select&gt;</code> tag. As such we've just implemented the basic borders, font,
+        <NxCode>&lt;select&gt;</NxCode> tag. As such we've just implemented the basic borders, font,
         and padding as well as disabled and focus styles. An <NxCode>NxFormSelect</NxCode> convenience component is
         also available.
-      </p>
-      <p className="nx-p">Classes:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-form-select</code></td>
-            <td className="nx-cell">
+      </NxP>
+      <NxP>Classes:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-form-select</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Base class
-            </td>
-            <td className="nx-cell">
-              Base class for a form <code className="nx-code">&lt;select&gt;</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+            <NxTable.Cell>
+              Base class for a form <NxCode>&lt;select&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Form Select Example"
                         codeExamples={sourceCode}
                         liveExample={NxFormSelectExample}>
-      Demonstrates a form <code className="nx-code">&lt;select&gt;</code> active state.
+      Demonstrates a form <NxCode>&lt;select&gt;</NxCode> active state.
     </GalleryExampleTile>
     <GalleryExampleTile title="Form Select Disabled Example"
                         id="nx-form-select-disabled-example"
                         codeExamples={disabledSourceCode}
                         liveExample={NxFormSelectDisabledExample}>
-      Demonstrates a form <code className="nx-code">&lt;select&gt;</code> disabled state. Note that disabling
+      Demonstrates a form <NxCode>&lt;select&gt;</NxCode> disabled state. Note that disabling
       is only supported via attribute, not class name.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/styles/NxFormSelect/NxFormSelectPage.tsx
+++ b/gallery/src/styles/NxFormSelect/NxFormSelectPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode, NxTable } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxFormSelectExample from './NxFormSelectExample';
 import NxFormSelectDisabledExample from './NxFormSelectDisabledExample';

--- a/gallery/src/styles/NxGlobalHeader/NxGlobalHeaderPage.tsx
+++ b/gallery/src/styles/NxGlobalHeader/NxGlobalHeaderPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxP, NxCode, NxTile, NxH2, NxTextLink } from '@sonatype/react-shared-components';
 
+import { NxTable, NxP, NxCode, NxTile, NxH2, NxTextLink } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import CodeExample from '../../CodeExample';

--- a/gallery/src/styles/NxGlobalHeader/NxGlobalHeaderPage.tsx
+++ b/gallery/src/styles/NxGlobalHeader/NxGlobalHeaderPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode, NxTile, NxH2, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import CodeExample from '../../CodeExample';

--- a/gallery/src/styles/NxGrid/NxGridExamples.tsx
+++ b/gallery/src/styles/NxGrid/NxGridExamples.tsx
@@ -5,10 +5,11 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+
 import { GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxCode } from '@sonatype/react-shared-components';
 
 import './CustomWidthExample.scss';
-import { NxCode } from '@sonatype/react-shared-components';
 
 const NxGridCode = require('./NxGridExample.html'),
     NxGridScrollingCode = require('./NxGridScrollingExample.html'),
@@ -19,8 +20,8 @@ const NxGridExamples = () =>
     <GalleryExampleTile title="NX Grid Example"
                         htmlExample={NxGridCode}
                         codeExamples={[NxGridCode, { content: NxGridMixinUsageCode, language: 'scss' }]}>
-      An example of an <code className="nx-code">nx-grid</code> demonstrating a variety of column layouts in different
-      rows. Particularly note the custom <code className="nx-code">nx-grid-col--200px</code> class defined for this
+      An example of an <NxCode>nx-grid</NxCode> demonstrating a variety of column layouts in different
+      rows. Particularly note the custom <NxCode>nx-grid-col--200px</NxCode> class defined for this
       example using a SCSS mixin.
     </GalleryExampleTile>
 

--- a/gallery/src/styles/NxGrid/NxGridPage.tsx
+++ b/gallery/src/styles/NxGrid/NxGridPage.tsx
@@ -7,8 +7,9 @@
 import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxInfoAlert, NxCode, NxTable } from '@sonatype/react-shared-components';
+
 import NxGridExamples from './NxGridExamples';
-import { NxP, NxInfoAlert, NxCode } from '@sonatype/react-shared-components';
 
 const NxGridPage = () =>
   <>
@@ -28,83 +29,83 @@ const NxGridPage = () =>
         For creating a class for a custom-sized grid cell with a static width,
         the <NxCode>nx-grid-col-width</NxCode> mixin is provided which sets the necessary width and flexbox properties.
       </NxP>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Convenience Component</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-grid-row</code></td>
-            <td className="nx-cell"><code className="nx-code">NxGrid.Row</code></td>
-            <td className="nx-cell">Top-Level</td>
-            <td className="nx-cell">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Convenience Component</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-grid-row</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxGrid.Row</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top-Level</NxTable.Cell>
+            <NxTable.Cell>
               Basic row class. These can be nested inside other rows or within grid cells to allow
               further subdivision of elements.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-grid-col</code></td>
-            <td className="nx-cell"><code className="nx-code">NxGrid.Column</code></td>
-            <td className="nx-cell">Element (<NxCode>&lt;div&gt;</NxCode> or <NxCode>&lt;section&gt;</NxCode>)</td>
-            <td className="nx-cell">
-              A simple container, always placed inside <code className="nx-code">.nx-grid-row</code>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-grid-col</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxGrid.Column</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element (<NxCode>&lt;div&gt;</NxCode> or <NxCode>&lt;section&gt;</NxCode>)</NxTable.Cell>
+            <NxTable.Cell>
+              A simple container, always placed inside <NxCode>.nx-grid-row</NxCode>.
               If this cell has a single header, it should be a <NxCode>&lt;section&gt;</NxCode>. Otherwise, it may
               be a <NxCode>&lt;div&gt;</NxCode> or a <NxCode>&lt;section&gt;</NxCode>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-grid-col--##</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-grid-col</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-grid-col--##</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-grid-col</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used when you want to give a column cell a specific width. Modifiers are provided for
               25%, 50%, 75%, 33%, and 66% widths.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-grid-header</code></td>
-            <td className="nx-cell"><code className="nx-code">NxGrid.Header</code></td>
-            <td className="nx-cell">Element (<NxCode>&lt;header&gt;</NxCode>)</td>
-            <td className="nx-cell">Container for title text and icons.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-grid-header__title</code></td>
-            <td className="nx-cell"><code className="nx-code">NxGrid.Title</code></td>
-            <td className="nx-cell">Element (<NxCode>&lt;h3&gt;</NxCode>)</td>
-            <td className="nx-cell">
-              Applied to any <code className="nx-code">h3</code> element used as a header for a grid cell. Note that
-              it's expected that the corresponding <code className="nx-code">.nx-h3</code> class will also be applied.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-grid-header</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxGrid.Header</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element (<NxCode>&lt;header&gt;</NxCode>)</NxTable.Cell>
+            <NxTable.Cell>Container for title text and icons.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-grid-header__title</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxGrid.Title</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element (<NxCode>&lt;h3&gt;</NxCode>)</NxTable.Cell>
+            <NxTable.Cell>
+              Applied to any <NxCode>h3</NxCode> element used as a header for a grid cell. Note that
+              it's expected that the corresponding <NxCode>.nx-h3</NxCode> class will also be applied.
               Headers of higher rank are no longer explicitly supported.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-grid-h-keyline</code></td>
-            <td className="nx-cell"><code className="nx-code">NxGrid.HorizontalKeyline</code></td>
-            <td className="nx-cell">Element (<NxCode>&lt;hr&gt;</NxCode>)</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-grid-h-keyline</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxGrid.HorizontalKeyline</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element (<NxCode>&lt;hr&gt;</NxCode>)</NxTable.Cell>
+            <NxTable.Cell>
               Horizontal keyline used between grid rows. Keylines should be placed between each row within the grid,
               but generally not before the first row or after the last. There may be cases however where it is
               desirable to place them before the first row or after the last, for instance when the grid cells are
               scroll containers.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-grid-col__section</code></td>
-            <td className="nx-cell"><code className="nx-code">NxGrid.ColumnSection</code></td>
-            <td className="nx-cell">Element within <NxCode>.nx-grid-col</NxCode> (<NxCode>&lt;section&gt;</NxCode>)</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-grid-col__section</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxGrid.ColumnSection</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element within <NxCode>.nx-grid-col</NxCode> (<NxCode>&lt;section&gt;</NxCode>)</NxTable.Cell>
+            <NxTable.Cell>
               When a single cell contains multiple groups of headers and content, each such group should be wrapped
               in a <NxCode>&lt;section&gt;</NxCode> with this class. The <NxCode>.nx-grid-col</NxCode> itself
               may be a <NxCode>&lt;div&gt;</NxCode> in this case.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
     <NxGridExamples/>
   </>;

--- a/gallery/src/styles/NxGrid/NxGridPage.tsx
+++ b/gallery/src/styles/NxGrid/NxGridPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxInfoAlert, NxCode, NxTable } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import NxGridExamples from './NxGridExamples';

--- a/gallery/src/styles/NxGrid/NxGridPage.tsx
+++ b/gallery/src/styles/NxGrid/NxGridPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxInfoAlert, NxCode, NxTable } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import NxGridExamples from './NxGridExamples';
 

--- a/gallery/src/styles/NxH/NxHPage.tsx
+++ b/gallery/src/styles/NxH/NxHPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxH1ExampleCode = require('./NxH1Example.html'),

--- a/gallery/src/styles/NxH/NxHPage.tsx
+++ b/gallery/src/styles/NxH/NxHPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxH1ExampleCode = require('./NxH1Example.html'),
     nxH2ExampleCode = require('./NxH2Example.html'),

--- a/gallery/src/styles/NxIcon/NxIconPage.tsx
+++ b/gallery/src/styles/NxIcon/NxIconPage.tsx
@@ -7,22 +7,23 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 const nxIconExampleCode = require('./NxIconExample.html');
 
 const NxIconPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">.nx-icon</code> is a class that gives standard layout, namely left and right margin,
-        to icons in a way that is compatible with the <code className="nx-code">nx-container-helpers</code>.
-      </p>
-      <p className="nx-p">
-        When using <code className="nx-code">.nx-icon</code> manually, be careful to set up heights and widths in
+      <NxP>
+        <NxCode>.nx-icon</NxCode> is a class that gives standard layout, namely left and right margin,
+        to icons in a way that is compatible with the <NxCode>nx-container-helpers</NxCode>.
+      </NxP>
+      <NxP>
+        When using <NxCode>.nx-icon</NxCode> manually, be careful to set up heights and widths in
         ways that work in all supported browsers. For instance, note that in the example below, only the height OR the
         width need to be specified for Chrome and Firefox due to the instrinsic aspect ratio from
-        the <code className="nx-code">viewBox</code>, while for IE, both the width and the height are necessary.
-      </p>
+        the <NxCode>viewBox</NxCode>, while for IE, both the width and the height are necessary.
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/styles/NxIcon/NxIconPage.tsx
+++ b/gallery/src/styles/NxIcon/NxIconPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxIconExampleCode = require('./NxIconExample.html');
 

--- a/gallery/src/styles/NxList/NxListExamples.tsx
+++ b/gallery/src/styles/NxList/NxListExamples.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxCode } from '@sonatype/react-shared-components';
 
 import NxListClickableExample from './NxListClickableExample';
 import NxListClickableLinksExample from './NxListClickableLinksExample';
@@ -32,37 +33,37 @@ const NxListsExamples = () =>
                         id="nx-list-simple-example"
                         htmlExample={NxListSimpleCode}
                         codeExamples={NxListSimpleCode}>
-      Basic <code className="nx-code">nx-list</code> with a heading.
+      Basic <NxCode>nx-list</NxCode> with a heading.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Clickable List Example"
                         id="nx-list-clickable-example"
                         liveExample={NxListClickableExample}
                         codeExamples={NxListClickableCode}>
-      An <code className="nx-code">nx-list</code> demonstrating clickable, selection, and disabled styles.
+      An <NxCode>nx-list</NxCode> demonstrating clickable, selection, and disabled styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Clickable List Links Example"
                         id="nx-list-clickable-links-example"
                         liveExample={NxListClickableLinksExample}
                         codeExamples={NxListClickableLinksCode}>
-      An <code className="nx-code">nx-list</code> demonstrating clickable and selection styles where the
-      clickable aspects of the list items are defined using <code className="nx-code">&lt;a&gt;</code> tags.
+      An <NxCode>nx-list</NxCode> demonstrating clickable and selection styles where the
+      clickable aspects of the list items are defined using <NxCode>&lt;a&gt;</NxCode> tags.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Bulleted List Example"
                         id="nx-list-bulleted-example"
                         htmlExample={NxListBulletedCode}
                         codeExamples={NxListBulletedCode}>
-      An <code className="nx-code">nx-list</code> demonstrating bulleted list styles more typical of
-      default <code className="nx-code">&lt;ul&gt;</code> styling. These can be nested.
+      An <NxCode>nx-list</NxCode> demonstrating bulleted list styles more typical of
+      default <NxCode>&lt;ul&gt;</NxCode> styling. These can be nested.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX List with Actions Example"
                         id="nx-list-actions-example"
                         liveExample={NxListWithActionsExample}
                         codeExamples={NxListWithActionsCode}>
-      An <code className="nx-code">nx-list</code> with icon buttons for initiation actions.
+      An <NxCode>nx-list</NxCode> with icon buttons for initiation actions.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Multi-line Example"
@@ -70,21 +71,21 @@ const NxListsExamples = () =>
                         htmlExample={NxListMultiLineCode}
                         codeExamples={NxListMultiLineCode}>
       Examples of list items that wrap and truncate, some examples demonstrating wrapping and truncation
-      on <code className="nx-code">nx-list-item__subtext</code>.
+      on <NxCode>nx-list-item__subtext</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX List Empty Example"
                         id="nx-list-empty-example"
                         htmlExample={NxListEmptyCode}
                         codeExamples={NxListEmptyCode}>
-      A demonstration of the expected styling and content for an empty <code className="nx-code">nx-list</code>.
+      A demonstration of the expected styling and content for an empty <NxCode>nx-list</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX List with Error Message Example"
                         id="nx-list-error-example"
                         liveExample={NxListErrorExample}
                         codeExamples={NxListErrorStateCode}>
-      A demonstration of the expected styling and content for an <code className="nx-code">nx-list</code> whose content
+      A demonstration of the expected styling and content for an <NxCode>nx-list</NxCode> whose content
       failed to load.
     </GalleryExampleTile>
 
@@ -93,14 +94,14 @@ const NxListsExamples = () =>
                         liveExample={NxListLoadingExample}
                         codeExamples={NxListLoadingCode}>
       A demonstration of the expected styling and placement for a loading indicator
-      within <code className="nx-code">nx-list</code>.
+      within <NxCode>nx-list</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NxList description list example"
                         id="nx-list-description-example"
                         htmlExample={NxListDescriptionCode}
                         codeExamples={NxListDescriptionCode}>
-      Basic <code className="nx-code">nx-list--description</code> with a heading. Wrapping is demonstrated in both
+      Basic <NxCode>nx-list--description</NxCode> with a heading. Wrapping is demonstrated in both
       the terms and the descriptions.
     </GalleryExampleTile>
 
@@ -109,7 +110,7 @@ const NxListsExamples = () =>
                         liveExample={NxListDeprecatedClickableExample}
                         codeExamples={NxListDeprecatedClickableCode}>
       This method of creating clickable lists is deprecated. It is strongly recommended that one of the above clickable
-      lists using <code className="nx-code">&lt;button&gt;</code> or <code className="nx-code">&lt;a&gt;</code> be
+      lists using <NxCode>&lt;button&gt;</NxCode> or <NxCode>&lt;a&gt;</NxCode> be
       used for accessibility reasons.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { NxInfoAlert, NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import NxListExamples from './NxListExamples';
@@ -153,10 +153,10 @@ const NxListPage = () =>
           </NxTable.Row>
         </NxTable.Body>
       </NxTable>
-      <section className="nx-tile-subsection">
-        <header className="nx-tile-subsection__title">
-          <h3 className="nx-h3">Description Lists</h3>
-        </header>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
+          <NxH3>Description Lists</NxH3>
+        </NxTile.SubsectionHeader>
         <NxP>
           In addition to ordered and unordered lists, <NxCode>nx-list</NxCode> also supports the
           styling of description lists using the following classes. Terms and descriptions are laid out side-by-side
@@ -207,7 +207,7 @@ const NxListPage = () =>
             </NxTable.Row>
           </NxTable.Body>
         </NxTable>
-      </section>
+      </NxTile.Subsection>
       <NxInfoAlert>
         Note that some of these examples are shown in React as they includes specific icons. When working in
         React, <NxCode>NxFontAwesomeIcon</NxCode> should be used as shown to get these icons.

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -5,9 +5,10 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
 
+import { NxInfoAlert, NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+
 import NxListExamples from './NxListExamples';
 
 const NxListPage = () =>

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxInfoAlert, NxTable, NxP, NxCode, NxTile, NxH3 } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import NxListExamples from './NxListExamples';

--- a/gallery/src/styles/NxList/NxListPage.tsx
+++ b/gallery/src/styles/NxList/NxListPage.tsx
@@ -5,8 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxTable, NxTableHead, NxTableRow, NxTableCell, NxTableBody }
-  from '@sonatype/react-shared-components';
+import { NxInfoAlert, NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import NxListExamples from './NxListExamples';
@@ -14,7 +13,7 @@ import NxListExamples from './NxListExamples';
 const NxListPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">Lists take many forms:</p>
+      <NxP>Lists take many forms:</NxP>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">Simple data lists</li>
         <li className="nx-list__item">Lists with clickable list items</li>
@@ -22,196 +21,196 @@ const NxListPage = () =>
         <li className="nx-list__item">Lists with actions</li>
         <li className="nx-list__item">Lists with items that have multiple lines of text</li>
       </ul>
-      <p className="nx-p">Lists can also have modified states depending on their content:</p>
+      <NxP>Lists can also have modified states depending on their content:</NxP>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">Lists with no data</li>
         <li className="nx-list__item">Error states</li>
       </ul>
-      <p className="nx-p">
-        The basic layout is a <code className="nx-code">&lt;ul&gt;</code>. If the list has a title a simple heading
-        such as <code className="nx-code">&lt;h3 className="nx-h3"&gt;</code> should be used before the &lt;ul&gt;.
-      </p>
-      <p className="nx-p">
+      <NxP>
+        The basic layout is a <NxCode>&lt;ul&gt;</NxCode>. If the list has a title a simple heading
+        such as <NxCode>&lt;h3 className="nx-h3"&gt;</NxCode> should be used before the &lt;ul&gt;.
+      </NxP>
+      <NxP>
         There are also lists that are "clickable", the list items in these lists indicate hover and click states and
         when clicked an event occurs - usually navigation. Clickable lists have hover and disabled states. They share
         error and empty states with default lists.
-      </p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Convenience Component</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list</code></td>
-            <td className="nx-cell"><code className="nx-code">NxList</code></td>
-            <td className="nx-cell">Top-Level <code className="nx-code">&lt;ul&gt;</code></td>
-            <td className="nx-cell">The parent list class. It has no bullets.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list--clickable</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list</code></td>
-            <td className="nx-cell">
+      </NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Convenience Component</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxList</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top-Level <NxCode>&lt;ul&gt;</NxCode></NxTable.Cell>
+            <NxTable.Cell>The parent list class. It has no bullets.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list--clickable</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-list</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               This modifier causes list items to respond to hover events. There is normally a chevron icon on the
               right to make it clear to the user that clicking will navigate away from the page.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list--bulleted</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list</code></td>
-            <td className="nx-cell">If you need a list with bullets.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__item</code></td>
-            <td className="nx-cell"><code className="nx-code">NxList.Item</code></td>
-            <td className="nx-cell">The <code className="nx-code">&lt;li&gt;</code> elements within the list</td>
-            <td className="nx-cell">
-              This class should be present on all list items within an <code className="nx-code">nx-list</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.selected</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">
-              Utility class that goes along with <code className="nx-code">.nx-list__item</code>
-            </td>
-            <td className="nx-cell">
-              Use the <code className="nx-code">selected</code> class alongside
-              <code className="nx-code">.nx-list__item</code> when a clickable list item is selected
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__text</code></td>
-            <td className="nx-cell"><code className="nx-code">NxList.Text</code></td>
-            <td className="nx-cell">Element within <code className="nx-code">&lt;li&gt;</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list--bulleted</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-list</NxCode></NxTable.Cell>
+            <NxTable.Cell>If you need a list with bullets.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__item</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxList.Item</NxCode></NxTable.Cell>
+            <NxTable.Cell>The <NxCode>&lt;li&gt;</NxCode> elements within the list</NxTable.Cell>
+            <NxTable.Cell>
+              This class should be present on all list items within an <NxCode>nx-list</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.selected</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>
+              Utility class that goes along with <NxCode>.nx-list__item</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>
+              Use the <NxCode>selected</NxCode> class alongside
+              <NxCode>.nx-list__item</NxCode> when a clickable list item is selected
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__text</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxList.Text</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element within <NxCode>&lt;li&gt;</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               The primary text content of the list item, displayed in a heavier font weight.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__subtext</code></td>
-            <td className="nx-cell"><code className="nx-code">NxList.Subtext</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__subtext</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxList.Subtext</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               When you want a separate section of non-bolded text below the main list item text use
-              a <code className="nx-code">&lt;span&gt;</code> with <code className="nx-code">.nx-list__subtext</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__actions</code></td>
-            <td className="nx-cell"><code className="nx-code">NxList.Actions</code></td>
-            <td className="nx-cell">A container for buttons inside list items</td>
-            <td className="nx-cell">Use this when you want to have a button on the far right.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__item--empty</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list__item</code></td>
-            <td className="nx-cell">Used when there are no list items returned.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">nx-list__item--error</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list__item</code></td>
-            <td className="nx-cell">
+              a <NxCode>&lt;span&gt;</NxCode> with <NxCode>.nx-list__subtext</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__actions</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxList.Actions</NxCode></NxTable.Cell>
+            <NxTable.Cell>A container for buttons inside list items</NxTable.Cell>
+            <NxTable.Cell>Use this when you want to have a button on the far right.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__item--empty</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-list__item</NxCode></NxTable.Cell>
+            <NxTable.Cell>Used when there are no list items returned.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>nx-list__item--error</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-list__item</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               This is added to a list item when the list is in an error state. In this case it's expected that there
               would only be a single list item which contains the error alert.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__item--clickable</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-list__item</code></td>
-            <td className="nx-cell">
-              Applied to <code className="nx-code">.nx-list__item</code> this allows for the correct styling of
-              clickable lists. Ensure that the <code className="nx-code">.nx-list</code> modifier
-              {' '}<code className="nx-code">.nx-list--clickable</code> is also used.
-              {' '}<code className="nx-code">.nx-list__item--clickable</code> should contain a single button or link as
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__item--clickable</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-list__item</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Applied to <NxCode>.nx-list__item</NxCode> this allows for the correct styling of
+              clickable lists. Ensure that the <NxCode>.nx-list</NxCode> modifier
+              {' '}<NxCode>.nx-list--clickable</NxCode> is also used.
+              {' '}<NxCode>.nx-list__item--clickable</NxCode> should contain a single button or link as
               children, see below for classes and convenience components.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__btn</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Applied to an <code className="nx-code">&lt;button&gt;</code> used in a clickable list.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-list__link</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Applied to an <code className="nx-code">&lt;a&gt;</code> used in a clickable link list.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__btn</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Applied to an <NxCode>&lt;button&gt;</NxCode> used in a clickable list.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-list__link</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Applied to an <NxCode>&lt;a&gt;</NxCode> used in a clickable link list.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
       <section className="nx-tile-subsection">
         <header className="nx-tile-subsection__title">
           <h3 className="nx-h3">Description Lists</h3>
         </header>
-        <p className="nx-p">
-          In addition to ordered and unordered lists, <code className="nx-code">nx-list</code> also supports the
+        <NxP>
+          In addition to ordered and unordered lists, <NxCode>nx-list</NxCode> also supports the
           styling of description lists using the following classes. Terms and descriptions are laid out side-by-side
           in rows. Currently only one description per term, and one term per description, are supported – not multiple.
-        </p>
+        </NxP>
         <NxTable>
-          <NxTableHead>
-            <NxTableRow>
-              <NxTableCell>Class</NxTableCell>
-              <NxTableCell>Convenience Component</NxTableCell>
-              <NxTableCell>Location</NxTableCell>
-              <NxTableCell>Details</NxTableCell>
-            </NxTableRow>
-          </NxTableHead>
-          <NxTableBody>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">.nx-list--description-list</code></NxTableCell>
-              <NxTableCell/>
-              <NxTableCell>
-                <code className="nx-code">&lt;dl&gt;</code> which also
-                has <code className="nx-code">.nx-list</code>.
-              </NxTableCell>
-              <NxTableCell>Root class to apply RSC description list styles</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">.nx-list__item</code></NxTableCell>
-              <NxTableCell><code className="nx-code">NxList.Item</code></NxTableCell>
-              <NxTableCell>
-                <code className="nx-code">&lt;div&gt;</code> wrapping <code className="nx-code">&lt;dt&gt;</code>{' '}
-                and <code className="nx-code">&lt;dd&gt;</code> elements
-              </NxTableCell>
-              <NxTableCell>
-                Each <code className="nx-code">&lt;dt&gt;</code>/<code className="nx-code">&lt;dd&gt;</code> pairing
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Class</NxTable.Cell>
+              <NxTable.Cell>Convenience Component</NxTable.Cell>
+              <NxTable.Cell>Location</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-list--description-list</NxCode></NxTable.Cell>
+              <NxTable.Cell/>
+              <NxTable.Cell>
+                <NxCode>&lt;dl&gt;</NxCode> which also
+                has <NxCode>.nx-list</NxCode>.
+              </NxTable.Cell>
+              <NxTable.Cell>Root class to apply RSC description list styles</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-list__item</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>NxList.Item</NxCode></NxTable.Cell>
+              <NxTable.Cell>
+                <NxCode>&lt;div&gt;</NxCode> wrapping <NxCode>&lt;dt&gt;</NxCode>{' '}
+                and <NxCode>&lt;dd&gt;</NxCode> elements
+              </NxTable.Cell>
+              <NxTable.Cell>
+                Each <NxCode>&lt;dt&gt;</NxCode>/<NxCode>&lt;dd&gt;</NxCode> pairing
                 should be wrapped in a div which is styled similarly to an item row in a normal nx-list.
-              </NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">.nx-list__term</code></NxTableCell>
-              <NxTableCell><code className="nx-code">NxList.Term</code></NxTableCell>
-              <NxTableCell><code className="nx-code">&lt;dt&gt;</code></NxTableCell>
-              <NxTableCell>Styles the description term elements</NxTableCell>
-            </NxTableRow>
-            <NxTableRow>
-              <NxTableCell><code className="nx-code">.nx-list__description</code></NxTableCell>
-              <NxTableCell><code className="nx-code">NxList.Description</code></NxTableCell>
-              <NxTableCell><code className="nx-code">&lt;dd&gt;</code></NxTableCell>
-              <NxTableCell>Styles the description elements</NxTableCell>
-            </NxTableRow>
-          </NxTableBody>
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-list__term</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>NxList.Term</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>&lt;dt&gt;</NxCode></NxTable.Cell>
+              <NxTable.Cell>Styles the description term elements</NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-list__description</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>NxList.Description</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>&lt;dd&gt;</NxCode></NxTable.Cell>
+              <NxTable.Cell>Styles the description elements</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
         </NxTable>
       </section>
       <NxInfoAlert>
         Note that some of these examples are shown in React as they includes specific icons. When working in
-        React, <code className="nx-code">NxFontAwesomeIcon</code> should be used as shown to get these icons.
+        React, <NxCode>NxFontAwesomeIcon</NxCode> should be used as shown to get these icons.
         When not working in React, check the FontAwesome 5 documentation for alternative ways to include the icons.
       </NxInfoAlert>
     </GalleryDescriptionTile>

--- a/gallery/src/styles/NxP/NxPPage.tsx
+++ b/gallery/src/styles/NxP/NxPPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxPExampleCode = require('./NxPExample.html');
 

--- a/gallery/src/styles/NxP/NxPPage.tsx
+++ b/gallery/src/styles/NxP/NxPPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxPExampleCode = require('./NxPExample.html');

--- a/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
+++ b/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
@@ -5,9 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
-import { GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxPageTitlePolicyViolationIndicatorExample from './NxPageTitlePolicyViolationIndicatorExample';
 import NxPageTitleEverythingExample from './NxPageTitleEverythingExample';

--- a/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
+++ b/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxPageTitlePolicyViolationIndicatorExample from './NxPageTitlePolicyViolationIndicatorExample';

--- a/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
+++ b/gallery/src/styles/NxPageTitle/NxPageTitlePage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import { GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxPageTitlePolicyViolationIndicatorExample from './NxPageTitlePolicyViolationIndicatorExample';
 import NxPageTitleEverythingExample from './NxPageTitleEverythingExample';
@@ -23,83 +23,83 @@ const NxPageTitlePage = () =>
   <>
     <GalleryDescriptionTile>
       <NxP>
-        <code className="nx-code">nx-page-title</code> is used at the top of a page, it always has a title, and can also
+        <NxCode>nx-page-title</NxCode> is used at the top of a page, it always has a title, and can also
         have a sub-title, descriptive text, and space for tags or other indicators.
       </NxP>
       <NxP>
-        In addition <code className="nx-code">.nx-page-title</code> can have buttons inline with the title.
+        In addition <NxCode>.nx-page-title</NxCode> can have buttons inline with the title.
       </NxP>
       <NxP>
-        Note: <code className="nx-code">.nx-page-title</code> replaces
-        <code className="nx-code">.nx-tile--top-tile</code> and <code className="nx-code">.nx-tile--title-only</code>.
+        Note: <NxCode>.nx-page-title</NxCode> replaces
+        <NxCode>.nx-tile--top-tile</NxCode> and <NxCode>.nx-tile--title-only</NxCode>.
       </NxP>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Convenience Component</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-page-title</code></td>
-            <td className="nx-cell"><code className="nx-code">NxPageTitle</code></td>
-            <td className="nx-cell">Top level</td>
-            <td className="nx-cell">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Convenience Component</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-page-title</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxPageTitle</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top level</NxTable.Cell>
+            <NxTable.Cell>
               This is the basic wrapper class. The title text is almost always contained in an
-              <code className="nx-code">&lt;h1&gt;</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-page-title__headings</code></td>
-            <td className="nx-cell"><code className="nx-code">NxPageTitle.Headings</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+              <NxCode>&lt;h1&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-page-title__headings</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxPageTitle.Headings</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               If there is a sub-title then the <NxCode>&lt;h1&gt;</NxCode> &amp; <NxCode>&lt;h2&gt;</NxCode> should
-              both be wrapped in a containing <code className="nx-code">&lt;hgroup&gt;</code> with this class. If there
+              both be wrapped in a containing <NxCode>&lt;hgroup&gt;</NxCode> with this class. If there
               is only an <NxCode>&lt;h1&gt;</NxCode> then this element and its class are optional.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-page-title__sub-title</code></td>
-            <td className="nx-cell"><code className="nx-code">NxPageTitle.Subtitle</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-page-title__sub-title</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxPageTitle.Subtitle</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               If there is sub-title text it should be wrapped in a containing
-              <code className="nx-code">&lt;H2&gt;</code> with this class.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-btn-bar</code></td>
-            <td className="nx-cell"><code className="nx-code">NxBtnBar</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              <code className="nx-code">.nx-page-title</code> supports the inclusion of buttons on its right-hand side.
-              This is accomplished by adding an <code className="nx-code">.nx-btn-bar</code> after the heading elements.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-page-title__description</code></td>
-            <td className="nx-cell"><code className="nx-code">NxPageTitle.Description</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+              <NxCode>&lt;H2&gt;</NxCode> with this class.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-btn-bar</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxBtnBar</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              <NxCode>.nx-page-title</NxCode> supports the inclusion of buttons on its right-hand side.
+              This is accomplished by adding an <NxCode>.nx-btn-bar</NxCode> after the heading elements.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-page-title__description</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxPageTitle.Description</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               If there is page level descriptive text it should be wrapped in a containing
-              <code className="nx-code">&lt;div&gt;</code> with this class.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-page-title__tags</code></td>
-            <td className="nx-cell"><code className="nx-code">NxPageTitle.Tags</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
+              <NxCode>&lt;div&gt;</NxCode> with this class.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-page-title__tags</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxPageTitle.Tags</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
               Any "tags" to place in the page header, such as <NxCode>NxTag</NxCode> or
               <NxCode>NxPolicyViolationIndicator</NxCode>, should be wrapped by this element.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Basic page title"
@@ -107,7 +107,7 @@ const NxPageTitlePage = () =>
                         defaultCheckeredBackground={true}
                         htmlExample={nxPageTitleCode}
                         codeExamples={nxPageTitleCode}>
-      A simple example of an <code className="nx-code">nx-page-title</code>.
+      A simple example of an <NxCode>nx-page-title</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Page title with actions"
@@ -115,7 +115,7 @@ const NxPageTitlePage = () =>
                         defaultCheckeredBackground={true}
                         htmlExample={nxPageTitleActionsCode}
                         codeExamples={nxPageTitleActionsCode}>
-      An example of <code className="nx-code">nx-page-title</code> with action buttons.
+      An example of <NxCode>nx-page-title</NxCode> with action buttons.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Page title with sub-title and page description"
@@ -123,7 +123,7 @@ const NxPageTitlePage = () =>
                         defaultCheckeredBackground={true}
                         htmlExample={nxPageTitleSubtitleCode}
                         codeExamples={nxPageTitleSubtitleCode}>
-      A simple example of an <code className="nx-code">nx-page-title</code> with a sub-title.
+      A simple example of an <NxCode>nx-page-title</NxCode> with a sub-title.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Page title with NxPolicyViolationIndicator"
@@ -131,7 +131,7 @@ const NxPageTitlePage = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxPageTitlePolicyViolationIndicatorExample}
                         codeExamples={nxPageTitlePolicyViolationIndicatorCode}>
-      An example of a page title with an <code className="nx-code">NxPolicyViolationIndicator</code>.
+      An example of a page title with an <NxCode>NxPolicyViolationIndicator</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="Page title with everything"
@@ -139,7 +139,7 @@ const NxPageTitlePage = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxPageTitleEverythingExample}
                         codeExamples={nxPageTitleEverythingCode}>
-      A simple example of an <code className="nx-code">nx-page-title</code> with a sub-title, actions, tags, and a page
+      A simple example of an <NxCode>nx-page-title</NxCode> with a sub-title, actions, tags, and a page
       description.
     </GalleryExampleTile>
   </>;

--- a/gallery/src/styles/NxPre/NxPrePage.tsx
+++ b/gallery/src/styles/NxPre/NxPrePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxPreExampleCode = require('./NxPreExample.html');
 

--- a/gallery/src/styles/NxPre/NxPrePage.tsx
+++ b/gallery/src/styles/NxPre/NxPrePage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxCode } from '@sonatype/react-shared-components';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 const nxPreExampleCode = require('./NxPreExample.html');
 
@@ -15,11 +15,11 @@ const NxPrePage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          The <code className="nx-code">.nx-pre</code> CSS class provides standard RSC styling
-          for <code className="nx-code">&lt;pre&gt;</code> elements such as code blocks.
+        <NxP>
+          The <NxCode>.nx-pre</NxCode> CSS class provides standard RSC styling
+          for <NxCode>&lt;pre&gt;</NxCode> elements such as code blocks.
           An <NxCode>NxPre</NxCode> convenience component is also provided.
-        </p>
+        </NxP>
       </GalleryDescriptionTile>
 
       <GalleryExampleTile title="Basic Example"

--- a/gallery/src/styles/NxPre/NxPrePage.tsx
+++ b/gallery/src/styles/NxPre/NxPrePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxPreExampleCode = require('./NxPreExample.html');

--- a/gallery/src/styles/NxReadOnly/NxReadOnlyPage.tsx
+++ b/gallery/src/styles/NxReadOnly/NxReadOnlyPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxP, NxTextLink, NxTable } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import './NxReadOnlyGridExample.scss';

--- a/gallery/src/styles/NxReadOnly/NxReadOnlyPage.tsx
+++ b/gallery/src/styles/NxReadOnly/NxReadOnlyPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxCode, NxP, NxTextLink } from '@sonatype/react-shared-components';
+import { NxCode, NxP, NxTextLink, NxTable } from '@sonatype/react-shared-components';
 
 import './NxReadOnlyGridExample.scss';
 
@@ -34,74 +34,74 @@ const NxReadOnlyPage = () => {
           by vertical dividers. For an example of that combination, see the{' '}
           <NxTextLink href="#/pages/Read-Only%20Grid%20Tile%20Layout">Read-Only Grid Tile Layout</NxTextLink> page.
         </NxP>
-        <table className="nx-table">
-          <thead>
-            <tr className="nx-table-row">
-              <th className="nx-cell nx-cell--header">Class</th>
-              <th className="nx-cell nx-cell--header">Convenience Component</th>
-              <th className="nx-cell nx-cell--header">Location</th>
-              <th className="nx-cell nx-cell--header">Details</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-read-only</code></td>
-              <td className="nx-cell"><code className="nx-code">NxReadOnly</code></td>
-              <td className="nx-cell">Top level</td>
-              <td className="nx-cell">
-                This is the basic wrapper class. It is applied to the <code className="nx-code">&lt;dl&gt;</code>.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-read-only--grid</code></td>
-              <td className="nx-cell"></td>
-              <td className="nx-cell">Modifier of <NxCode>.nx-read-only</NxCode></td>
-              <td className="nx-cell">
+        <NxTable>
+          <NxTable.Head>
+            <NxTable.Row>
+              <NxTable.Cell>Class</NxTable.Cell>
+              <NxTable.Cell>Convenience Component</NxTable.Cell>
+              <NxTable.Cell>Location</NxTable.Cell>
+              <NxTable.Cell>Details</NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Head>
+          <NxTable.Body>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-read-only</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>NxReadOnly</NxCode></NxTable.Cell>
+              <NxTable.Cell>Top level</NxTable.Cell>
+              <NxTable.Cell>
+                This is the basic wrapper class. It is applied to the <NxCode>&lt;dl&gt;</NxCode>.
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-read-only--grid</NxCode></NxTable.Cell>
+              <NxTable.Cell></NxTable.Cell>
+              <NxTable.Cell>Modifier of <NxCode>.nx-read-only</NxCode></NxTable.Cell>
+              <NxTable.Cell>
                 This class preps the <NxCode>nx-read-only</NxCode> to display its entries in a grid. While this class
                 adds the basic grid properties (<NxCode>display</NxCode>, <NxCode>gap</NxCode>, etc) it is up to
                 the caller to specify additional CSS to define their desired grid layout in terms of the number
                 and arrangement of the grid cells.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-read-only__label</code></td>
-              <td className="nx-cell"><code className="nx-code">NxReadOnly.Label</code></td>
-              <td className="nx-cell">Element</td>
-              <td className="nx-cell">
-                This class is applied to the <code className="nx-code">&lt;dt&gt;</code>, it represents the label for
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-read-only__label</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>NxReadOnly.Label</NxCode></NxTable.Cell>
+              <NxTable.Cell>Element</NxTable.Cell>
+              <NxTable.Cell>
+                This class is applied to the <NxCode>&lt;dt&gt;</NxCode>, it represents the label for
                 the data below.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-read-only__data</code></td>
-              <td className="nx-cell"><code className="nx-code">NxReadOnly.Data</code></td>
-              <td className="nx-cell">Element</td>
-              <td className="nx-cell">
-                This class is applied to any <code className="nx-code">&lt;dd&gt;</code>'s that appear. The data
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-read-only__data</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>NxReadOnly.Data</NxCode></NxTable.Cell>
+              <NxTable.Cell>Element</NxTable.Cell>
+              <NxTable.Cell>
+                This class is applied to any <NxCode>&lt;dd&gt;</NxCode>'s that appear. The data
                 displayed can be any string or HTML markup.
-              </td>
-            </tr>
-            <tr className="nx-table-row">
-              <td className="nx-cell"><code className="nx-code">.nx-read-only__item</code></td>
-              <td className="nx-cell"><code className="nx-code">NxReadOnly.Item</code></td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+            </NxTable.Row>
+            <NxTable.Row>
+              <NxTable.Cell><NxCode>.nx-read-only__item</NxCode></NxTable.Cell>
+              <NxTable.Cell><NxCode>NxReadOnly.Item</NxCode></NxTable.Cell>
+              <NxTable.Cell>
                 Child of <NxCode>.nx-read-only--grid</NxCode>, parent of <NxCode>.nx-read-only__label</NxCode> and
                 {' '}<NxCode>.nx-read-only__data</NxCode>.
-              </td>
-              <td className="nx-cell">
+              </NxTable.Cell>
+              <NxTable.Cell>
                 When creating an <NxCode>.nx-read-only</NxCode> with a grid layout,
                 each <NxCode>&lt;dt&gt;</NxCode>/<NxCode>&lt;dd&gt;</NxCode> group must be wrapped
                 in a div with this class. This class/element should not be used in non-grid layouts.
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              </NxTable.Cell>
+            </NxTable.Row>
+          </NxTable.Body>
+        </NxTable>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="Simple Example"
                           id="nx-read-only-simple-example"
                           codeExamples={nxReadOnlyDlExampleCode}
                           htmlExample={nxReadOnlyDlExampleCode}>
-        Standard <code className="nx-code">nx-read-only</code> layouts, by default all text wraps.
+        Standard <NxCode>nx-read-only</NxCode> layouts, by default all text wraps.
       </GalleryExampleTile>
 
       <GalleryExampleTile title="Grid Example"

--- a/gallery/src/styles/NxReadOnly/NxReadOnlyPage.tsx
+++ b/gallery/src/styles/NxReadOnly/NxReadOnlyPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxCode, NxP, NxTextLink, NxTable } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import './NxReadOnlyGridExample.scss';
 

--- a/gallery/src/styles/NxReadOnlyGridTile/NxReadOnlyGridTilePage.tsx
+++ b/gallery/src/styles/NxReadOnlyGridTile/NxReadOnlyGridTilePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxCode, NxP } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import './NxReadOnlyGridTileExample.scss';

--- a/gallery/src/styles/NxReadOnlyGridTile/NxReadOnlyGridTilePage.tsx
+++ b/gallery/src/styles/NxReadOnlyGridTile/NxReadOnlyGridTilePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxCode, NxP } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import './NxReadOnlyGridTileExample.scss';
 

--- a/gallery/src/styles/NxScrollable/NxScrollablePage.tsx
+++ b/gallery/src/styles/NxScrollable/NxScrollablePage.tsx
@@ -7,25 +7,26 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
 
 const nxScrollableExampleCode = require('./NxScrollableExample.html');
 
 const NxScrollablePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        <code className="nx-code">.nx-scrollable</code> is a class that turns any block level element into a scrolling
+      <NxP>
+        <NxCode>.nx-scrollable</NxCode> is a class that turns any block level element into a scrolling
         container. It has a default max-height of 400px so in most instances you're going to want to create a modifier
-        class (e.g. <code className="nx-code">.nx-scrollable--my-box</code>) to adjust the height to suit your needs.
-      </p>
-      <p className="nx-p">
-        Generally <code className="nx-code">.nx-scrollable</code> is applied to blocks
-        like <code className="nx-code">.nx-tile-content</code>.
-      </p>
-      <p className="nx-p">
-        <code className="nx-code">.nx-scrollable</code> should <strong>not</strong> be used to replicate page or browser
-        scrolling, refer instead to the <a href="#Pages/Page Layout/">page layout templates</a>.
-      </p>
+        class (e.g. <NxCode>.nx-scrollable--my-box</NxCode>) to adjust the height to suit your needs.
+      </NxP>
+      <NxP>
+        Generally <NxCode>.nx-scrollable</NxCode> is applied to blocks
+        like <NxCode>.nx-tile-content</NxCode>.
+      </NxP>
+      <NxP>
+        <NxCode>.nx-scrollable</NxCode> should <strong>not</strong> be used to replicate page or browser
+        scrolling, refer instead to the <NxTextLink href="#Pages/Page Layout/">page layout templates</NxTextLink>.
+      </NxP>
     </GalleryDescriptionTile>
     <GalleryExampleTile title="General Example"
                         id="nx-scrollable-simple-example"

--- a/gallery/src/styles/NxScrollable/NxScrollablePage.tsx
+++ b/gallery/src/styles/NxScrollable/NxScrollablePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxScrollableExampleCode = require('./NxScrollableExample.html');

--- a/gallery/src/styles/NxScrollable/NxScrollablePage.tsx
+++ b/gallery/src/styles/NxScrollable/NxScrollablePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 const nxScrollableExampleCode = require('./NxScrollableExample.html');
 

--- a/gallery/src/styles/NxSystemNotice/NxSystemNoticePage.tsx
+++ b/gallery/src/styles/NxSystemNotice/NxSystemNoticePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxP, NxCode, NxTile, NxH2, NxTextLink } from '@sonatype/react-shared-components';
 
+import { NxTable, NxP, NxCode, NxTile, NxH2, NxTextLink } from '@sonatype/react-shared-components';
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import CodeExample from '../../CodeExample';

--- a/gallery/src/styles/NxSystemNotice/NxSystemNoticePage.tsx
+++ b/gallery/src/styles/NxSystemNotice/NxSystemNoticePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode, NxTile, NxH2, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import CodeExample from '../../CodeExample';

--- a/gallery/src/styles/NxSystemNotice/NxSystemNoticeTraditionalPageExample.tsx
+++ b/gallery/src/styles/NxSystemNotice/NxSystemNoticeTraditionalPageExample.tsx
@@ -5,6 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+
 import { NxPageMain, NxPageHeader, NxTile, NxH2 } from '@sonatype/react-shared-components';
 
 export default function NxSystemNoticeGlobalSidebarExample() {

--- a/gallery/src/styles/NxTable/NxTableContainerPage.tsx
+++ b/gallery/src/styles/NxTable/NxTableContainerPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxWarningAlert, NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTableScrollingExample from './NxTableScrollingExample';

--- a/gallery/src/styles/NxTable/NxTableContainerPage.tsx
+++ b/gallery/src/styles/NxTable/NxTableContainerPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
-import { NxWarningAlert } from '@sonatype/react-shared-components';
+import { NxWarningAlert, NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxTableScrollingExample from './NxTableScrollingExample';
 
@@ -19,72 +19,72 @@ const NxTableFooterCode = require('./NxTableFooterExample.html'),
 const NxTableContainerPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Some table layouts require an extra wrapper element around
-        the <code className="nx-code">&lt;table&gt;</code> proper, that appears visually as part of the table.
-        For these situations, a wrapper element using the <code className="nx-code">.nx-table-container</code> class
+        the <NxCode>&lt;table&gt;</NxCode> proper, that appears visually as part of the table.
+        For these situations, a wrapper element using the <NxCode>.nx-table-container</NxCode> class
         can be constructed around the table. This setup is needed for the following functionality:
-      </p>
+      </NxP>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">Scrolling tables</li>
         <li className="nx-list__item">Tables with pagination</li>
       </ul>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Convenience Component</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table-container</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTableContainer</code></td>
-            <td className="nx-cell">Element wrapping an <code className="nx-code">.nx-table</code></td>
-            <td className="nx-cell">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Convenience Component</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table-container</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTableContainer</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element wrapping an <NxCode>.nx-table</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Removes the border from the table itself and instead replicates it on the container element. This allows
               layout patterns within the visually-apparent table that aren't supported
-              on <code className="nx-code">&lt;table&gt;</code> itself.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-scrollable--table-container</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Element wrapping an <code className="nx-code">.nx-table</code></td>
-            <td className="nx-cell">
+              on <NxCode>&lt;table&gt;</NxCode> itself.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-scrollable--table-container</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Element wrapping an <NxCode>.nx-table</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               <NxWarningAlert>
-                Deprecated. Replaced by <code className="nx-code">.nx-table-container</code>.
+                Deprecated. Replaced by <NxCode>.nx-table-container</NxCode>.
               </NxWarningAlert>
               This class was originally supposed to be used in conjunction
-              with <code className="nx-code">.nx-table--scrollable</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-scrollable</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Same element as <code className="nx-code">.nx-table-container</code></td>
-            <td className="nx-cell">
-              The container element should also have the <code className="nx-code">.nx-scrollable</code> class
+              with <NxCode>.nx-table--scrollable</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-scrollable</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Same element as <NxCode>.nx-table-container</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              The container element should also have the <NxCode>.nx-scrollable</NxCode> class
               when table scrolling is desired.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table-container__footer</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTableContainer<br/>.Footer</code></td>
-            <td className="nx-cell">
-              Child of <code className="nx-code">.nx-table-container</code>, after
-              the <code className="nx-code">.nx-table</code>.
-            </td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table-container__footer</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTableContainer<br/>.Footer</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Child of <NxCode>.nx-table-container</NxCode>, after
+              the <NxCode>.nx-table</NxCode>.
+            </NxTable.Cell>
+            <NxTable.Cell>
               Container for elements which should be displayed as if they are a table footer, but affixed to the
               bottom of the container, regardless of the size of the
-              actual <code className="nx-code">&lt;table&gt;</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              actual <NxCode>&lt;table&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="NX Table Footer Example"
@@ -92,7 +92,7 @@ const NxTableContainerPage = () =>
                         codeExamples={NxTableFooterCode}>
       A demonstration of a table with a footer element which for the sake of example just contains a button.
       The most common real-world use-case for a footer is a pagination bar, which can be seen in
-      the <a className="nx-text-link" href="#/pages/NxTable"><code className="nx-code">NxTable</code></a> react
+      the <NxTextLink href="#/pages/NxTable"><NxCode>NxTable</NxCode></NxTextLink> react
       component examples.
     </GalleryExampleTile>
 

--- a/gallery/src/styles/NxTable/NxTableContainerPage.tsx
+++ b/gallery/src/styles/NxTable/NxTableContainerPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxWarningAlert, NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTableScrollingExample from './NxTableScrollingExample';
 

--- a/gallery/src/styles/NxTable/NxTableExamples.tsx
+++ b/gallery/src/styles/NxTable/NxTableExamples.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxCode } from '@sonatype/react-shared-components';
 
+import { NxCode } from '@sonatype/react-shared-components';
 import { GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTableClickableExample from './NxTableClickableExample';
@@ -45,7 +45,7 @@ const NxTablesExamples = () =>
     <GalleryExampleTile title="NX Table Simple Example"
                         htmlExample={NxTableSimpleCode}
                         codeExamples={NxTableSimpleCode}>
-      A simple, static demonstration of <code className="nx-code">nx-table</code> styles.
+      A simple, static demonstration of <NxCode>nx-table</NxCode> styles.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Table Truncation and Wrapping Example"
@@ -60,7 +60,7 @@ const NxTablesExamples = () =>
     <GalleryExampleTile title="NX Table with Clickable Rows Example"
                         liveExample={NxTableClickableExample}
                         codeExamples={NxTableClickableCode}>
-      A demonstration of an <code className="nx-code">nx-table</code> with rows that receive clickable styling and
+      A demonstration of an <NxCode>nx-table</NxCode> with rows that receive clickable styling and
       a chevron column.
     </GalleryExampleTile>
 
@@ -70,27 +70,27 @@ const NxTablesExamples = () =>
                         codeExamples={fixedLayoutCodeExamples}>
       This example demonstrates the nx-table--fixed-layout class which is typically used in conjunction with
       a custom class to explicitly set the widths of table rows. Notice here that the implementation of a
-      truncated column is simpler: the inner <code className="nx-code">div</code> is not necessary and instead
-      the <code className="nx-code">.nx-truncate-ellipsis</code> class can be applied directly to the table cell.
+      truncated column is simpler: the inner <NxCode>div</NxCode> is not necessary and instead
+      the <NxCode>.nx-truncate-ellipsis</NxCode> class can be applied directly to the table cell.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Table Empty Example"
                         htmlExample={NxTableEmptyCode}
                         codeExamples={NxTableEmptyCode}>
-      A demonstration of the expected styling and content of an empty <code className="nx-code">nx-table</code>.
+      A demonstration of the expected styling and content of an empty <NxCode>nx-table</NxCode>.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Table with Error Message Example"
                         liveExample={NxTableErrorExample}
                         codeExamples={NxTableErrorStateCode}>
-      A demonstration of the expected styling and content and an <code className="nx-code">nx-table</code> whose
+      A demonstration of the expected styling and content and an <NxCode>nx-table</NxCode> whose
       contents failed to load.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Table with Sortable Rows Example"
                         liveExample={NxTableSortableExample}
                         codeExamples={NxTableSortableCode}>
-      A demonstration of a <code className="nx-code">nx-table</code> used for columns that can be sorted.
+      A demonstration of a <NxCode>nx-table</NxCode> used for columns that can be sorted.
       In this example the interactivity to sort columns is not wired up. Note
       the <NxCode>&lt;button&gt;</NxCode> surrounding the sort header contents.
     </GalleryExampleTile>
@@ -98,7 +98,7 @@ const NxTablesExamples = () =>
     <GalleryExampleTile title="NX Table with Filter Rows Example"
                         liveExample={NxTableFilterExample}
                         codeExamples={NxTableFilterCode}>
-      A demonstration of a <code className="nx-code">nx-table</code> with a header
+      A demonstration of a <NxCode>nx-table</NxCode> with a header
       cell that contains a filter. Rows can be filtered depending on the text provided in the input.
       In this example the interactivity to filter content is not wired up. Note
       the <NxCode>&lt;button&gt;</NxCode> surrounding the chevron cell contents.

--- a/gallery/src/styles/NxTable/NxTableStylePage.tsx
+++ b/gallery/src/styles/NxTable/NxTableStylePage.tsx
@@ -5,7 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxFontAwesomeIcon, NxWarningAlert } from '@sonatype/react-shared-components';
+import { NxInfoAlert, NxFontAwesomeIcon, NxWarningAlert, NxTable, NxP, NxCode, NxTextLink }
+  from '@sonatype/react-shared-components';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
@@ -14,183 +15,180 @@ import NxTableExamples from './NxTableExamples';
 const NxTableStylePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         This is the styling and layout for a basic table. There are few variations demonstrated here:
-      </p>
+      </NxP>
       <ul className="nx-list nx-list--bulleted">
         <li className="nx-list__item">Basic table layout</li>
         <li className="nx-list__item">Tables with clickable rows</li>
         <li className="nx-list__item">Empty tables</li>
         <li className="nx-list__item">A table with an error.</li>
       </ul>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row nx-table-row--header">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table</code></td>
-            <td className="nx-cell">Top-Level</td>
-            <td className="nx-cell">
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top-Level</NxTable.Cell>
+            <NxTable.Cell>
               Default table class. Note that a properly configured table require
-              <code className="nx-code">&lt;thead&gt;</code>, <code className="nx-code">&lt;tbody&gt;</code>
+              <NxCode>&lt;thead&gt;</NxCode>, <NxCode>&lt;tbody&gt;</NxCode>
               and correct classes on rows and cells.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table--clickable</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-table</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table--clickable</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-table</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               A "clickable" table is one where the table rows accept a click event and (usually) navigate to another
               view.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table--scrollable</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-table</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table--scrollable</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-table</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               <NxWarningAlert>
-                Deprecated. Use an <code className="nx-code">.nx-table-container.nx-scrollable</code> wrapper
-                around a plain <code className="nx-code">.nx-table</code> instead.
+                Deprecated. Use an <NxCode>.nx-table-container.nx-scrollable</NxCode> wrapper
+                around a plain <NxCode>.nx-table</NxCode> instead.
               </NxWarningAlert>
               When a table which scrolls in of itself is desired, wrap the table in
-              an <code className="nx-code">.nx-scrollable</code> wrapper and give it a class
-              of <code className="nx-code">.nx-table--scrollable</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table--fixed-layout</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-table</code></td>
-            <td className="nx-cell">
+              an <NxCode>.nx-scrollable</NxCode> wrapper and give it a class
+              of <NxCode>.nx-table--scrollable</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table--fixed-layout</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-table</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used to apply{' '}
-              <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout"
-                 className="nx-text-link"
-                 target="_blank"
-                 rel="noreferrer">
-                <code className="nx-code">table-layout: fixed</code>
+              <NxTextLink external href="https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout">
+                <NxCode>table-layout: fixed</NxCode>
                 <NxFontAwesomeIcon icon={faExternalLinkAlt} />
-              </a>
-              {' '}to <code className="nx-code">nx-table</code>s. This class should be used in lieu of setting
-              <code className="nx-code">table-layout</code> manually, as it also makes some adjustments to the
+              </NxTextLink>
+              {' '}to <NxCode>nx-table</NxCode>s. This class should be used in lieu of setting
+              <NxCode>table-layout</NxCode> manually, as it also makes some adjustments to the
               behavior of other table classes in order to make them compatible with a fixed layout.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table-row</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">Basic table row class.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-table-row--header</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-table-row</code></td>
-            <td className="nx-cell">Used for table rows within a <code className="nx-code">&lt;thead&gt;</code>.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">Element</td>
-            <td className="nx-cell">
-              Standard tabel cell class, applied to both <code className="nx-code">&lt;td&gt;</code> and
-              <code className="nx-code">&lt;th&gt;</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-cell--header</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">Used for style table header cells.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-cell--num</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table-row</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>Basic table row class.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-table-row--header</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-table-row</NxCode></NxTable.Cell>
+            <NxTable.Cell>Used for table rows within a <NxCode>&lt;thead&gt;</NxCode>.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>Element</NxTable.Cell>
+            <NxTable.Cell>
+              Standard tabel cell class, applied to both <NxCode>&lt;td&gt;</NxCode> and
+              <NxCode>&lt;th&gt;</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-cell--header</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>Used for style table header cells.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-cell--num</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used to style header and body cells whose content is numerical. Centers the header and content.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-cell--meta-info</code></td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-cell--meta-info</NxCode></NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Applied to table cells that provide meta-information about the table data. There are three known use
               cases for this: loading states, error states, and empty states. In each of these cases, the table body
               should contain a single row with a single cell. That cell should use the `colspan` attribute to
               stretch all the way across the table, and should use this class.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              <code className="nx-code">.nx-cell--icon</code>
-            </td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              <NxCode>.nx-cell--icon</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               This class should be used when the only contents of a cell one or more icons.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              <code className="nx-code">.nx-cell--chevron</code>
-            </td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              <NxCode>.nx-cell--chevron</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               This class is intended for the cells holding the Chevron icons that should be placed on the right
               side of clickable table rows. It creates a column of the appropriate width for the icon. It
-              is <em>not</em> necessary to additional use <code className="nx-code">.nx-cell--icon</code> on these
+              is <em>not</em> necessary to additional use <NxCode>.nx-cell--icon</NxCode> on these
               cells.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              <code className="nx-code">.nx-cell--filter-header</code>
-            </td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              <NxCode>.nx-cell--filter-header</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used for style table header cells with a filter
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              <code className="nx-code">.nx-cell__sort-btn</code>
-            </td>
-            <td className="nx-cell">
-              Child of <code className="nx-code">.nx-cell--header</code> wrapping all other content
-            </td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              <NxCode>.nx-cell__sort-btn</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>
+              Child of <NxCode>.nx-cell--header</NxCode> wrapping all other content
+            </NxTable.Cell>
+            <NxTable.Cell>
               For a header cell that contains sort icons, the cell should contain a button with this class
               which then contains the actual cell header text and sort icons. This improves accessibility of the
               sorting feature. The button should have an accessible name which describes the header name and the
               current sort direction of this column.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              <code className="nx-code">.nx-cell__chevron-btn</code>
-            </td>
-            <td className="nx-cell">
-              Child of <code className="nx-code">.nx-cell--chevron</code> which then wraps the actual chevron icon
-            </td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              <NxCode>.nx-cell__chevron-btn</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>
+              Child of <NxCode>.nx-cell--chevron</NxCode> which then wraps the actual chevron icon
+            </NxTable.Cell>
+            <NxTable.Cell>
               In order to make clickable rows accessible, the chevron icon should be contained within a button
               bearing this class. The button should additionally have an accessible name which describes the row,
               typically by including its full text content.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell">
-              <code className="nx-code">.nx-cell--filter-header</code>
-            </td>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-cell</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell>
+              <NxCode>.nx-cell--filter-header</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>Modifier of <NxCode>.nx-cell</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used for style table header cells with a filter
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
 
       <NxInfoAlert>
         Note that some of these examples are shown in react as they includes specific icons. When working in
-        React, <code className="nx-code">NxFontAwesomeIcon</code> should be used as shown to get these icons.
+        React, <NxCode>NxFontAwesomeIcon</NxCode> should be used as shown to get these icons.
         When not working in react, check the FontAwesome 5 documentation for alternative ways to include the icons.
       </NxInfoAlert>
     </GalleryDescriptionTile>

--- a/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
+++ b/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTextInputStylesExample from './NxTextInputStylesExample';

--- a/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
+++ b/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTextInputStylesExample from './NxTextInputStylesExample';
 

--- a/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
+++ b/gallery/src/styles/NxTextInputStyles/NxTextInputStylesPage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
 
 import NxTextInputStylesExample from './NxTextInputStylesExample';
 
@@ -15,41 +16,41 @@ const sourceCode = require('./NxTextInputStylesExample?raw');
 const NxTextInputStylesPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
+      <NxP>
         Base styles for Sonatype text inputs.  Only the styles intended for "static" usage are shown
         here. For styles that involve business logic, such as validation, see
-        the <a href="#pages/NxTextInput">NxTextInput React Component</a>.
-      </p>
-      <p className="nx-p">Classes:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-text-input</code></td>
-            <td className="nx-cell">
-              Any text-oriented <code className="nx-code">{'<input>'}</code> type or
-              <code className="nx-code">{'<textarea>'}</code>
-            </td>
-            <td className="nx-cell">
+        the <NxTextLink href="#pages/NxTextInput">NxTextInput React Component</NxTextLink>.
+      </NxP>
+      <NxP>Classes:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-text-input</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Any text-oriented <NxCode>{'<input>'}</NxCode> type or
+              <NxCode>{'<textarea>'}</NxCode>
+            </NxTable.Cell>
+            <NxTable.Cell>
               Gives the input typical Sonatype input styling with 1px grey borders on the top, right, and bottom,
               and a 3px grey border on the left
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-text-input--long</code></td>
-            <td className="nx-cell">Any <code className="nx-code">.nx-text-input</code> element</td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-text-input--long</NxCode></NxTable.Cell>
+            <NxTable.Cell>Any <NxCode>.nx-text-input</NxCode> element</NxTable.Cell>
+            <NxTable.Cell>
               Use this class to make the text input particularly wide (395px vs the default 219px)
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="General Example"

--- a/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
+++ b/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxThreatNumberBasicExample from './NxThreatNumberBasicExample';
 import NxThreatNumberListExample from './NxThreatNumberListExample';

--- a/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
+++ b/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
@@ -7,11 +7,11 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxThreatNumberBasicExample from './NxThreatNumberBasicExample';
 import NxThreatNumberListExample from './NxThreatNumberListExample';
 import NxThreatNumberTableExample from './NxThreatNumberTableExample';
-import { NxCode } from '@sonatype/react-shared-components';
 
 const nxThreatNumberBasicExampleCode = require('./NxThreatNumberBasicExample?raw'),
     nxThreatNumberListExampleCode = require('./NxThreatNumberListExample?raw'),
@@ -20,28 +20,28 @@ const nxThreatNumberBasicExampleCode = require('./NxThreatNumberBasicExample?raw
 const NxThreatNumberPage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">
-        When an IQ Policy Threat Number is displayed adjacent to an <code className="nx-code">NxThreatIndicator</code>,
-        style the number with <code className="nx-code">.nx-threat-number</code>.
+      <NxP>
+        When an IQ Policy Threat Number is displayed adjacent to an <NxCode>NxThreatIndicator</NxCode>,
+        style the number with <NxCode>.nx-threat-number</NxCode>.
         An <NxCode>NxThreatNumber</NxCode> convenience component is also available.
-      </p>
+      </NxP>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Basic Example"
                         id="nx-threat-number-basic-example"
                         liveExample={NxThreatNumberBasicExample}
                         codeExamples={nxThreatNumberBasicExampleCode}>
-      An example of <code className="nx-code">.nx-threat-number</code> used
-      adjacent to an <code className="nx-code">NxThreatIndicator</code> in a simple inline layout.
+      An example of <NxCode>.nx-threat-number</NxCode> used
+      adjacent to an <NxCode>NxThreatIndicator</NxCode> in a simple inline layout.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="List Example"
                         id="nx-threat-number-list-example"
                         liveExample={NxThreatNumberListExample}
                         codeExamples={nxThreatNumberListExampleCode}>
-      An example of <code className="nx-code">.nx-threat-number</code> used
-      along with <code className="nx-code">NxThreatIndicator</code> in an <code className="nx-code">.nx-list</code>.
-      The layout expectations of <code className="nx-code">.nx-list</code> require a slight customization
+      An example of <NxCode>.nx-threat-number</NxCode> used
+      along with <NxCode>NxThreatIndicator</NxCode> in an <NxCode>.nx-list</NxCode>.
+      The layout expectations of <NxCode>.nx-list</NxCode> require a slight customization
       to the way the elements are arranged.
     </GalleryExampleTile>
 
@@ -49,9 +49,9 @@ const NxThreatNumberPage = () =>
                         id="nx-threat-number-table-example"
                         liveExample={NxThreatNumberTableExample}
                         codeExamples={nxThreatNumberTableExampleCode}>
-      Since <code className="nx-code">nx-table</code> is one of the primary places
-      that <code className="nx-code">NxThreatIndicator</code> is intended to be used, this example demonstrates a
-      typical usage of indicators and <code className="nx-code">nx-threat-number</code>s in that context.
+      Since <NxCode>nx-table</NxCode> is one of the primary places
+      that <NxCode>NxThreatIndicator</NxCode> is intended to be used, this example demonstrates a
+      typical usage of indicators and <NxCode>nx-threat-number</NxCode>s in that context.
       Note that no special classes or placements are needed here, it is essentially just the
       usual inline layout of the threat indicator and adjacent content, within a table cell.
     </GalleryExampleTile>

--- a/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
+++ b/gallery/src/styles/NxThreatNumber/NxThreatNumberPage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxThreatNumberBasicExample from './NxThreatNumberBasicExample';

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import NxTilesExamples from './NxTilesExamples';

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -7,115 +7,117 @@
 import React from 'react';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
+import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+
 import NxTilesExamples from './NxTilesExamples';
 
 const NxTilePage = () =>
   <>
     <GalleryDescriptionTile>
-      <p className="nx-p">The base building block of our pages.</p>
-      <p className="nx-p">
-        There are three default classes that can be used within an <code className="nx-code">.nx-tile</code>.
-        It can also be paired with <code className="nx-code">.nx-alert</code> to create tiles with alert coloring.
-      </p>
-      <p className="nx-p">They're all showcased in the table below:</p>
-      <table className="nx-table nx-table--gallery-props">
-        <thead>
-          <tr className="nx-table-row">
-            <th className="nx-cell nx-cell--header">Class</th>
-            <th className="nx-cell nx-cell--header">Convenience Component</th>
-            <th className="nx-cell nx-cell--header">Location</th>
-            <th className="nx-cell nx-cell--header">Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile</code></td>
-            <td className="nx-cell">Top-Level</td>
-            <td className="nx-cell">The parent tile class.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile__actions</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.HeaderActions</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">Used for actions (buttons or dropdowns) that appear in a tile header.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.Header</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">Used for tile titles, it has title and optional sub-title elements.</td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-header__title</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.HeaderTitle</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell">
-              Used for the main title inside an <code className="nx-code">.nx-tile-header</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-header__subtitle</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.HeaderSubtitle</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile-header</code></td>
-            <td className="nx-cell">
-              Used for the subtitle inside an <code className="nx-code">.nx-tile-header</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-content</code></td>
-            <td className="nx-cell"><code className="nx-code">NxTile.Content</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
+      <NxP>The base building block of our pages.</NxP>
+      <NxP>
+        There are three default classes that can be used within an <NxCode>.nx-tile</NxCode>.
+        It can also be paired with <NxCode>.nx-alert</NxCode> to create tiles with alert coloring.
+      </NxP>
+      <NxP>They're all showcased in the table below:</NxP>
+      <NxTable>
+        <NxTable.Head>
+          <NxTable.Row>
+            <NxTable.Cell>Class</NxTable.Cell>
+            <NxTable.Cell>Convenience Component</NxTable.Cell>
+            <NxTable.Cell>Location</NxTable.Cell>
+            <NxTable.Cell>Details</NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Head>
+        <NxTable.Body>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile</NxCode></NxTable.Cell>
+            <NxTable.Cell>Top-Level</NxTable.Cell>
+            <NxTable.Cell>The parent tile class.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile__actions</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.HeaderActions</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>Used for actions (buttons or dropdowns) that appear in a tile header.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-header</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.Header</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>Used for tile titles, it has title and optional sub-title elements.</NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-header__title</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.HeaderTitle</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile-header</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Used for the main title inside an <NxCode>.nx-tile-header</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-header__subtitle</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.HeaderSubtitle</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile-header</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Used for the subtitle inside an <NxCode>.nx-tile-header</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-content</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxTile.Content</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used for the tile content. It is possible to have multiple of these in a row, particularly when one
               is an accordion container (see below).
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-tile-content--accordion-container</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile-content</code></td>
-            <td className="nx-cell">
-              Creates a container for displaying one or more <code className="nx-code">NxAccordion</code>s
-              within an <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-footer</code></td>
-            <td className="nx-cell"><code className="nx-code">NxFooter</code></td>
-            <td className="nx-cell">Nested inside <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-tile-content--accordion-container</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile-content</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Creates a container for displaying one or more <NxCode>NxAccordion</NxCode>s
+              within an <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-footer</NxCode></NxTable.Cell>
+            <NxTable.Cell><NxCode>NxFooter</NxCode></NxTable.Cell>
+            <NxTable.Cell>Nested inside <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
               Used for footer contents (buttons for example). This class is not
-              called <code className="nx-code">nx-tile-footer</code> because it is used across a number of different
+              called <NxCode>nx-tile-footer</NxCode> because it is used across a number of different
               containers (e.g. forms and modals in addition to tiles) which have identical footer styles.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-alert</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
-              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-alert--info</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
-              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-          <tr className="nx-table-row">
-            <td className="nx-cell"><code className="nx-code">.nx-alert--error</code></td>
-            <td className="nx-cell"/>
-            <td className="nx-cell">Modifier of <code className="nx-code">.nx-tile</code></td>
-            <td className="nx-cell">
-              Class for providing alert colorings to <code className="nx-code">.nx-tile</code>.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-alert</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Class for providing alert colorings to <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-alert--info</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Class for providing alert colorings to <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+          <NxTable.Row>
+            <NxTable.Cell><NxCode>.nx-alert--error</NxCode></NxTable.Cell>
+            <NxTable.Cell/>
+            <NxTable.Cell>Modifier of <NxCode>.nx-tile</NxCode></NxTable.Cell>
+            <NxTable.Cell>
+              Class for providing alert colorings to <NxCode>.nx-tile</NxCode>.
+            </NxTable.Cell>
+          </NxTable.Row>
+        </NxTable.Body>
+      </NxTable>
     </GalleryDescriptionTile>
 
     <NxTilesExamples />

--- a/gallery/src/styles/NxTile/NxTilePage.tsx
+++ b/gallery/src/styles/NxTile/NxTilePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import { NxTable, NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 
 import NxTilesExamples from './NxTilesExamples';
 

--- a/gallery/src/styles/NxTile/NxTilesExamples.tsx
+++ b/gallery/src/styles/NxTile/NxTilesExamples.tsx
@@ -5,14 +5,15 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
+
 import { GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxCode } from '@sonatype/react-shared-components';
 
 import NxTileFormExample from './NxTileFormExample';
 import NxTileFormErrorExample from './NxTileFormErrorExample';
 import NxTileDropdownActionsExample from './NxTileDropdownActionsExample';
 import NxTileAccordionExample from './NxTileAccordionExample';
 import NxTilePolicyViolationIndicatorExample from './NxTilePolicyViolationIndicatorExample';
-import { NxCode } from '@sonatype/react-shared-components';
 
 const NxSimpleTileCode = require('./NxSimpleTileExample.html'),
     NxTileWithActionsCode = require('./NxTileWithActionsExample.html'),
@@ -32,7 +33,7 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         htmlExample={NxSimpleTileCode}
                         codeExamples={NxSimpleTileCode}>
-      A simple example of an <code className="nx-code">nx-tile</code> including a header and a footer.
+      A simple example of an <NxCode>nx-tile</NxCode> including a header and a footer.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Tile with Actions Example"
@@ -40,7 +41,7 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         htmlExample={NxTileWithActionsCode}
                         codeExamples={NxTileWithActionsCode}>
-      An example of an <code className="nx-code">nx-tile</code> with action buttons and a subtitle in the header.
+      An example of an <NxCode>nx-tile</NxCode> with action buttons and a subtitle in the header.
       Note that the title text does not wrap but truncates when it reaches the action buttons.
     </GalleryExampleTile>
 
@@ -49,7 +50,7 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         htmlExample={NxTileWithSubtitleCode}
                         codeExamples={NxTileWithSubtitleCode}>
-      An example of an <code className="nx-code">nx-tile</code> with a long subtitle that wraps.
+      An example of an <NxCode>nx-tile</NxCode> with a long subtitle that wraps.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Tile with a Subsection Header Example"
@@ -57,7 +58,7 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         htmlExample={NxTileSubsectionCode}
                         codeExamples={NxTileSubsectionCode}>
-      An example of an <code className="nx-code">nx-tile</code> containing mulitple subsections. Note the horizontal
+      An example of an <NxCode>nx-tile</NxCode> containing mulitple subsections. Note the horizontal
       rule which appears before the first subsection, but not between subsections.
     </GalleryExampleTile>
 
@@ -66,7 +67,7 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxTileFormExample}
                         codeExamples={NxTileFormCode}>
-      An example of an <code className="nx-code">nx-tile</code> which solely contains a form.
+      An example of an <NxCode>nx-tile</NxCode> which solely contains a form.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Tile with form error"
@@ -74,7 +75,7 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxTileFormErrorExample}
                         codeExamples={NxTileFormErrorCode}>
-      An example of an <code className="nx-code">nx-tile</code> which contains an <NxCode>NxForm</NxCode> that
+      An example of an <NxCode>nx-tile</NxCode> which contains an <NxCode>NxForm</NxCode> that
       is in an error state.
     </GalleryExampleTile>
 
@@ -83,8 +84,8 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxTileDropdownActionsExample}
                         codeExamples={NxTileDropdownActionsCode}>
-      An example of a tile with an <code className="nx-code">NxDropdown</code> (or
-      {' '}<code className="nx-code">NxStatefulDropdown</code>, as the case may be) in the actions area.
+      An example of a tile with an <NxCode>NxDropdown</NxCode> (or
+      {' '}<NxCode>NxStatefulDropdown</NxCode>, as the case may be) in the actions area.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Tile with accordions"
@@ -92,8 +93,8 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxTileAccordionExample}
                         codeExamples={NxTileAccordionCode}>
-      An example of a tile with <code className="nx-code">NxAccordions</code>{' '}
-      (or <code className="nx-code">NxStatefulAccordions</code>) within.
+      An example of a tile with <NxCode>NxAccordions</NxCode>{' '}
+      (or <NxCode>NxStatefulAccordions</NxCode>) within.
     </GalleryExampleTile>
 
     <GalleryExampleTile title="NX Tile with Policy Violation Indicator"
@@ -101,7 +102,7 @@ const NxTilesExamples = () =>
                         defaultCheckeredBackground={true}
                         liveExample={NxTilePolicyViolationIndicatorExample}
                         codeExamples={NxTilePolicyViolationIndicatorCode}>
-      An example of a tile with <code className="nx-code">NxPolicyViolationIndicator</code>{' '}
+      An example of a tile with <NxCode>NxPolicyViolationIndicator</NxCode>{' '}
       in the header.
     </GalleryExampleTile>
 

--- a/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
+++ b/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
@@ -6,8 +6,8 @@
  */
 import React from 'react';
 
-import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTruncateExample from './NxTruncateExample';
 

--- a/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
+++ b/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
+import { NxP, NxCode } from '@sonatype/react-shared-components';
 
 import NxTruncateExample from './NxTruncateExample';
 
@@ -22,12 +23,12 @@ const NxTruncatePage = () => {
   return (
     <>
       <GalleryDescriptionTile>
-        <p className="nx-p">
-          The <code className="nx-code">.nx-truncate-ellipsis</code> mixin is a simple way to add ellipsis truncation to
+        <NxP>
+          The <NxCode>.nx-truncate-ellipsis</NxCode> mixin is a simple way to add ellipsis truncation to
           any object. The mixin automatically adds the three required CSS attributes, but the end user must provide the
-          <code className="nx-code">max-width:</code> value to their SCSS for truncation to work properly. Since this
+          <NxCode>max-width:</NxCode> value to their SCSS for truncation to work properly. Since this
           value is likley to be custom no default has be set.
-        </p>
+        </NxP>
       </GalleryDescriptionTile>
       <GalleryExampleTile title="General Example"
                           codeExamples={codeExamples}

--- a/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
+++ b/gallery/src/styles/NxTruncateEllipsis/NxTruncatePage.tsx
@@ -5,8 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import { NxP, NxCode } from '@sonatype/react-shared-components';
+
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxTruncateExample from './NxTruncateExample';

--- a/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
+++ b/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
@@ -14,7 +14,9 @@ import {
   NxStatefulAccordion,
   NxAccordion,
   NxP,
-  NxTextLink
+  NxTextLink,
+  NxTile,
+  NxH2
 } from '@sonatype/react-shared-components';
 
 const NxViewportSizedExample = require('./NxViewportSizedExample.tsx?raw'),
@@ -25,13 +27,13 @@ const NxViewportSizedExample = require('./NxViewportSizedExample.tsx?raw'),
 export default function NxViewportSizedPage() {
   return (
     <>
-      <section className="nx-tile">
-        <header className="nx-tile-header">
-          <div className="nx-tile-header__title">
-            <h2 className="nx-h2">Description</h2>
-          </div>
-        </header>
-        <div className="nx-tile-content">
+      <NxTile>
+        <NxTile.Header>
+          <NxTile.HeaderTitle>
+            <NxH2>Description</NxH2>
+          </NxTile.HeaderTitle>
+        </NxTile.Header>
+        <NxTile.Content>
           <NxP>
             In applications that do not use full-page scrolling, there are often pages where it is desired for
             the page content to fit the viewport height, and for one element in particular to shrink and/or expand
@@ -170,15 +172,15 @@ export default function NxViewportSizedPage() {
             and without the <NxCode>nx-viewport-sized</NxCode> family of classes, and to make manual
             adjustments if necessary.
           </NxWarningAlert>
-        </div>
-      </section>
-      <section className="nx-tile">
-        <header className="nx-tile-header">
-          <div className="nx-tile-header__title">
-            <h2 className="nx-h2">Expanding Example</h2>
-          </div>
-        </header>
-        <div className="nx-tile-content">
+        </NxTile.Content>
+      </NxTile>
+      <NxTile>
+        <NxTile.Header>
+          <NxTile.HeaderTitle>
+            <NxH2>Expanding Example</NxH2>
+          </NxTile.HeaderTitle>
+        </NxTile.Header>
+        <NxTile.Content>
           <NxP>
             In this example, the dynamic element is a small table whose scroll container expands to fill the
             available space in the page.
@@ -193,23 +195,23 @@ export default function NxViewportSizedPage() {
               Click here to navigate to the live example.
             </NxTextLink>
           </NxP>
-        </div>
-        <div className="nx-tile-content nx-tile-content--accordion-container">
+        </NxTile.Content>
+        <NxTile.Content className="nx-tile-content--accordion-container">
           <NxStatefulAccordion>
             <NxAccordion.Header>
               <h2 className="nx-accordion__header-title">Code Examples</h2>
             </NxAccordion.Header>
             <CodeExample content={NxViewportSizedExpandingExample} />
           </NxStatefulAccordion>
-        </div>
-      </section>
-      <section className="nx-tile">
-        <header className="nx-tile-header">
-          <div className="nx-tile-header__title">
-            <h2 className="nx-h2">Shrinking Example</h2>
-          </div>
-        </header>
-        <div className="nx-tile-content">
+        </NxTile.Content>
+      </NxTile>
+      <NxTile>
+        <NxTile.Header>
+          <NxTile.HeaderTitle>
+            <NxH2>Shrinking Example</NxH2>
+          </NxTile.HeaderTitle>
+        </NxTile.Header>
+        <NxTile.Content>
           <NxP>
             In this example, the dynamic element is a large table whose scroll container shrinks to fit into the page.
           </NxP>
@@ -223,23 +225,23 @@ export default function NxViewportSizedPage() {
               Click here to navigate to the live example.
             </NxTextLink>
           </NxP>
-        </div>
-        <div className="nx-tile-content nx-tile-content--accordion-container">
+        </NxTile.Content>
+        <NxTile.Content className="nx-tile-content--accordion-container">
           <NxStatefulAccordion>
             <NxAccordion.Header>
               <h2 className="nx-accordion__header-title">Code Examples</h2>
             </NxAccordion.Header>
             <CodeExample content={NxViewportSizedExample} />
           </NxStatefulAccordion>
-        </div>
-      </section>
-      <section className="nx-tile">
-        <header className="nx-tile-header">
-          <div className="nx-tile-header__title">
-            <h2 className="nx-h2">Adjacent Scrollables Example</h2>
-          </div>
-        </header>
-        <div className="nx-tile-content">
+        </NxTile.Content>
+      </NxTile>
+      <NxTile>
+        <NxTile.Header>
+          <NxTile.HeaderTitle>
+            <NxH2>Adjacent Scrollables Example</NxH2>
+          </NxTile.HeaderTitle>
+        </NxTile.Header>
+        <NxTile.Content>
           <NxP>
             In this example, two adjacent scrollable elements are present.{' '}
             <NxCode>.nx-viewport-size__container--adjacent</NxCode> is used on the closest common ancestor of the
@@ -254,8 +256,8 @@ export default function NxViewportSizedPage() {
               Click here to navigate to the live example.
             </NxTextLink>
           </NxP>
-        </div>
-        <div className="nx-tile-content nx-tile-content--accordion-container">
+        </NxTile.Content>
+        <NxTile.Content className="nx-tile-content--accordion-container">
           <NxStatefulAccordion>
             <NxAccordion.Header>
               <h2 className="nx-accordion__header-title">Code Examples</h2>
@@ -263,8 +265,8 @@ export default function NxViewportSizedPage() {
             <CodeExample content={NxViewportSizedAdjacentStyles} language="scss" />
             <CodeExample content={NxViewportSizedAdjacentExample} />
           </NxStatefulAccordion>
-        </div>
-      </section>
+        </NxTile.Content>
+      </NxTile>
     </>
   );
 }

--- a/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
+++ b/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
@@ -5,7 +5,6 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-
 import {
   NxTable,
   NxWarningAlert,
@@ -18,6 +17,7 @@ import {
   NxTile,
   NxH2
 } from '@sonatype/react-shared-components';
+
 import CodeExample from '../../CodeExample';
 
 const NxViewportSizedExample = require('./NxViewportSizedExample.tsx?raw'),

--- a/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
+++ b/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
@@ -7,16 +7,14 @@
 import React from 'react';
 import CodeExample from '../../CodeExample';
 import {
-  NxTableHead,
-  NxTableRow,
-  NxTableCell,
   NxTable,
-  NxTableBody,
   NxWarningAlert,
   NxInfoAlert,
   NxCode,
   NxStatefulAccordion,
-  NxAccordion
+  NxAccordion,
+  NxP,
+  NxTextLink
 } from '@sonatype/react-shared-components';
 
 const NxViewportSizedExample = require('./NxViewportSizedExample.tsx?raw'),
@@ -34,13 +32,13 @@ export default function NxViewportSizedPage() {
           </div>
         </header>
         <div className="nx-tile-content">
-          <p className="nx-p">
+          <NxP>
             In applications that do not use full-page scrolling, there are often pages where it is desired for
             the page content to fit the viewport height, and for one element in particular to shrink and/or expand
             in order to enable that fit, scrolling its contents if necessary. Often, the dynamically-sized element
             is a table or list.
-          </p>
-          <p className="nx-p">
+          </NxP>
+          <NxP>
             In years past, this could generally only be accomplished using JavaScript helpers that would compute
             the appropriate height of the dynamic element. This approach tended to be fragile. With modern CSS however,
             it is possible to use flexbox to accomplish this goal, with some effort. The key, essentially, is to
@@ -49,12 +47,12 @@ export default function NxViewportSizedPage() {
             the element which is intended to shrink or expand is reached. Note, of course, that it isn't really just
             the scrollable element that is dynamically sized, but rather it is that
             element <em>and all of its ancestors</em>.  This is why each ancestor needs to be laid out using flexbox.
-          </p>
-          <p className="nx-p">
+          </NxP>
+          <NxP>
             This approach is not without caveats. Mainly, changing the ancestor elements from block layout to
             flex layout removes some of the ancillary behaviors of block layout that we generally rely on. There are at
             least two significant places where this makes a difference:
-          </p>
+          </NxP>
           <ul className="nx-list">
             <li className="nx-list__item">
               <span className="nx-list__text">Margin collapsing</span>
@@ -68,108 +66,108 @@ export default function NxViewportSizedPage() {
             <li className="nx-list__item">
               <span className="nx-list__text">Default child width with automatic margins</span>
               <span className="nx-list__subtext">
-                The behavior of left and right margins set to <code className="nx-code">auto</code> differs between
+                The behavior of left and right margins set to <NxCode>auto</NxCode> differs between
                 block layouts and flex-column layouts. In block layout, a child with auto side margins will default
                 to the full width of its container unless it has a width or max-width set.  In flex-column layout,
                 a child with auto side margins and no explicit width will default to its implicit width, even if it
                 has a max-width set. To get max-width to behave the way that it does in block
-                layouts, <code className="nx-code">width: 100%</code> must be applied. In RSC, this issue comes up
-                around <code className="nx-code">NxAlert</code>s in particular.
+                layouts, <NxCode>width: 100%</NxCode> must be applied. In RSC, this issue comes up
+                around <NxCode>NxAlert</NxCode>s in particular.
               </span>
             </li>
           </ul>
-          <p className="nx-p">
-            The <code className="nx-code">nx-viewport-sized</code> family of CSS classes accomplishes the
+          <NxP>
+            The <NxCode>nx-viewport-sized</NxCode> family of CSS classes accomplishes the
             layout goals described above. These classes take care of setting the flexbox styles and mitigating the
             caveats listed above. See the class details below.
-          </p>
+          </NxP>
           <NxTable>
-            <NxTableHead>
-              <NxTableRow>
-                <NxTableCell>Class Name</NxTableCell>
-                <NxTableCell>Location</NxTableCell>
-                <NxTableCell>Description</NxTableCell>
-              </NxTableRow>
-            </NxTableHead>
-            <NxTableBody>
-              <NxTableRow>
-                <NxTableCell><code className="nx-code">nx-viewport-sized</code></NxTableCell>
-                <NxTableCell>
+            <NxTable.Head>
+              <NxTable.Row>
+                <NxTable.Cell>Class Name</NxTable.Cell>
+                <NxTable.Cell>Location</NxTable.Cell>
+                <NxTable.Cell>Description</NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Head>
+            <NxTable.Body>
+              <NxTable.Row>
+                <NxTable.Cell><NxCode>nx-viewport-sized</NxCode></NxTable.Cell>
+                <NxTable.Cell>
                   An ancestor element which is already sized to take up all available height by other means outside
-                  of <code className="nx-code">nx-viewport-sized</code>. Typically
-                  an <code className="nx-code">.nx-page-main</code> or <code className="nx-code">.nx-page-sidebar</code>
-                </NxTableCell>
-                <NxTableCell>
+                  of <NxCode>nx-viewport-sized</NxCode>. Typically
+                  an <NxCode>.nx-page-main</NxCode> or <NxCode>.nx-page-sidebar</NxCode>
+                </NxTable.Cell>
+                <NxTable.Cell>
                   Viewport-sized pages inherit their height from a parent element which is already sized to the
                   available on-screen height through other means. When using the RSC page layout classes, this parent
-                  element would be the <code className="nx-code">.nx-page-main</code> or{' '}
-                  <code className="nx-code">.nx-page-sidebar</code>, which get their height from the cross-axis
-                  alignment settings on <code className="nx-code">.nx-page-content</code>, which in turn gets its height
-                  from the flex layout of <code className="nx-code">.nx-page</code>, which gets it's height from
-                  <code className="nx-code">.nx-body</code> and <code className="nx-code">.nx-html</code> having
+                  element would be the <NxCode>.nx-page-main</NxCode> or{' '}
+                  <NxCode>.nx-page-sidebar</NxCode>, which get their height from the cross-axis
+                  alignment settings on <NxCode>.nx-page-content</NxCode>, which in turn gets its height
+                  from the flex layout of <NxCode>.nx-page</NxCode>, which gets it's height from
+                  <NxCode>.nx-body</NxCode> and <NxCode>.nx-html</NxCode> having
                   height 100%, which ultimately sets it all to the viewport's height. The already-correctly-sized
-                  parent (e.g. <code className="nx-code">.nx-page-main</code>) must include
-                  the <code className="nx-code">.nx-viewport-sized</code> class in order to turn it into a flex
+                  parent (e.g. <NxCode>.nx-page-main</NxCode>) must include
+                  the <NxCode>.nx-viewport-sized</NxCode> class in order to turn it into a flex
                   container capable of sizing its children based on its own height.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell><code className="nx-code">nx-viewport-sized__container</code></NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell><NxCode>nx-viewport-sized__container</NxCode></NxTable.Cell>
+                <NxTable.Cell>
                   Each element that is both a descendant
-                  of <code className="nx-code">.nx-viewport-sized</code> and an ancestor of the element which is
+                  of <NxCode>.nx-viewport-sized</NxCode> and an ancestor of the element which is
                   intended to dynamically take up the slack in the page.
-                </NxTableCell>
-                <NxTableCell>
-                  In order to pass the sizing down from <code className="nx-code">.nx-viewport-sized</code> to the
+                </NxTable.Cell>
+                <NxTable.Cell>
+                  In order to pass the sizing down from <NxCode>.nx-viewport-sized</NxCode> to the
                   dynamically-sized scrollable, every ancestor in between must also be a flex container, set up
                   using this class.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell><NxCode>nx-viewport-sized__container--adjacent</NxCode></NxTableCell>
-                <NxTableCell>Modifier of <NxCode>nx-viewport-sized__container</NxCode></NxTableCell>
-                <NxTableCell>
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell><NxCode>nx-viewport-sized__container--adjacent</NxCode></NxTable.Cell>
+                <NxTable.Cell>Modifier of <NxCode>nx-viewport-sized__container</NxCode></NxTable.Cell>
+                <NxTable.Cell>
                   This class causes its children to be laid out adjacently in the horizontal direction while
                   still carrying down the sizing context necessary for those children or their descendants to size
                   to the viewport. It is expected that every child of this element will be either
                   an <NxCode>nx-viewport-sized__container</NxCode> or an <NxCode>nx-viewport-sized__scrollable</NxCode>.
-                </NxTableCell>
-              </NxTableRow>
-              <NxTableRow>
-                <NxTableCell><code className="nx-code">nx-viewport-sized__scrollable</code></NxTableCell>
-                <NxTableCell>
-                  The <code className="nx-code">.nx-scrollable</code> that is intended to adjust to the size of
+                </NxTable.Cell>
+              </NxTable.Row>
+              <NxTable.Row>
+                <NxTable.Cell><NxCode>nx-viewport-sized__scrollable</NxCode></NxTable.Cell>
+                <NxTable.Cell>
+                  The <NxCode>.nx-scrollable</NxCode> that is intended to adjust to the size of
                   the page.
-                </NxTableCell>
-                <NxTableCell>
-                  This class makes the target <code className="nx-code">.nx-scrollable</code> shrink or expand from its
+                </NxTable.Cell>
+                <NxTable.Cell>
+                  This class makes the target <NxCode>.nx-scrollable</NxCode> shrink or expand from its
                   natural height to fit the page. It removes the default max-height from
-                  the <code className="nx-code">.nx-scrollable</code>.
-                </NxTableCell>
-              </NxTableRow>
-            </NxTableBody>
+                  the <NxCode>.nx-scrollable</NxCode>.
+                </NxTable.Cell>
+              </NxTable.Row>
+            </NxTable.Body>
           </NxTable>
           <NxInfoAlert>
-            As described on the <a className="nx-text-link" href="#/pages/Page Layout">Page Layout</a> page,
+            As described on the <NxTextLink href="#/pages/Page Layout">Page Layout</NxTextLink> page,
             RSC's page-level styles support two overall scrolling modes. In the default "section scrolling" mode,
-            the <code className="nx-code">.nx-page-sidebar</code> and <code className="nx-code">.nx-page-main</code>
+            the <NxCode>.nx-page-sidebar</NxCode> and <NxCode>.nx-page-main</NxCode>
             are sized the fill the available space in the viewport and may scroll individually if their contents
             require. In the alternative "page scrolling" mode, those two elements are allowed to be as tall as their
             content, and the page itself scrolls at the viewport level.{' '}
             <strong>
-              Only the "section scrolling" mode is compatible with <code className="nx-code">nx-viewport-sized</code>.
+              Only the "section scrolling" mode is compatible with <NxCode>nx-viewport-sized</NxCode>.
             </strong>
             {' '}Note that although the RSC gallery generally uses page scrolling, the live example pages for
-            the <code className="nx-code">nx-viewport-sized</code> classes use section scrolling.
+            the <NxCode>nx-viewport-sized</NxCode> classes use section scrolling.
           </NxInfoAlert>
           <NxWarningAlert>
-            <code className="nx-code">.nx-viewport-sized__container</code> unsets the top margin of all of its
+            <NxCode>.nx-viewport-sized__container</NxCode> unsets the top margin of all of its
             immediate children in order to address the margin-collapsing issue described above. It is believed that this
             should correctly address the issue in the vast majority of cases for RSC elements, however it is possible
             that there are combinations of elements where this would not result in the correct spacing. Application
             developers are encouraged to double check that the effective spacing between elements is the same with
-            and without the <code className="nx-code">nx-viewport-sized</code> family of classes, and to make manual
+            and without the <NxCode>nx-viewport-sized</NxCode> family of classes, and to make manual
             adjustments if necessary.
           </NxWarningAlert>
         </div>
@@ -181,20 +179,20 @@ export default function NxViewportSizedPage() {
           </div>
         </header>
         <div className="nx-tile-content">
-          <p className="nx-p">
+          <NxP>
             In this example, the dynamic element is a small table whose scroll container expands to fill the
             available space in the page.
-          </p>
-          <p className="nx-p">
+          </NxP>
+          <NxP>
             Demonstrating viewport sizing requires that the other content on the page is small enough to
             give the scrollable element adequate vertical space at any supported resolution. Therefore, while the code
             snippets are displayed below, the actual live example is a separate page.
-          </p>
-          <p className="nx-p">
-            <a className="nx-text-link" href="#/NxViewportSizedExpandingExample">
+          </NxP>
+          <NxP>
+            <NxTextLink href="#/NxViewportSizedExpandingExample">
               Click here to navigate to the live example.
-            </a>
-          </p>
+            </NxTextLink>
+          </NxP>
         </div>
         <div className="nx-tile-content nx-tile-content--accordion-container">
           <NxStatefulAccordion>
@@ -212,19 +210,19 @@ export default function NxViewportSizedPage() {
           </div>
         </header>
         <div className="nx-tile-content">
-          <p className="nx-p">
+          <NxP>
             In this example, the dynamic element is a large table whose scroll container shrinks to fit into the page.
-          </p>
-          <p className="nx-p">
+          </NxP>
+          <NxP>
             Demonstrating viewport sizing requires that the other content on the page is small enough to
             give the scrollable element adequate vertical space at any supported resolution. Therefore, while the code
             snippets are displayed below, the actual live example is a separate page.
-          </p>
-          <p className="nx-p">
-            <a className="nx-text-link" href="#/NxViewportSizedExample">
+          </NxP>
+          <NxP>
+            <NxTextLink href="#/NxViewportSizedExample">
               Click here to navigate to the live example.
-            </a>
-          </p>
+            </NxTextLink>
+          </NxP>
         </div>
         <div className="nx-tile-content nx-tile-content--accordion-container">
           <NxStatefulAccordion>
@@ -242,20 +240,20 @@ export default function NxViewportSizedPage() {
           </div>
         </header>
         <div className="nx-tile-content">
-          <p className="nx-p">
+          <NxP>
             In this example, two adjacent scrollable elements are present.{' '}
             <NxCode>.nx-viewport-size__container--adjacent</NxCode> is used on the closest common ancestor of the
             two scrollables in order to facilitate this.
-          </p>
-          <p className="nx-p">
+          </NxP>
+          <NxP>
             In this situation, widths and spacing between the adjacent children will often be usage-specific,
             requiring custom styles as demonstrated here.
-          </p>
-          <p className="nx-p">
-            <a className="nx-text-link" href="#/NxViewportSizedAdjacentExample">
+          </NxP>
+          <NxP>
+            <NxTextLink href="#/NxViewportSizedAdjacentExample">
               Click here to navigate to the live example.
-            </a>
-          </p>
+            </NxTextLink>
+          </NxP>
         </div>
         <div className="nx-tile-content nx-tile-content--accordion-container">
           <NxStatefulAccordion>

--- a/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
+++ b/gallery/src/styles/NxViewportSized/NxViewportSizedPage.tsx
@@ -5,7 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import CodeExample from '../../CodeExample';
+
 import {
   NxTable,
   NxWarningAlert,
@@ -18,6 +18,7 @@ import {
   NxTile,
   NxH2
 } from '@sonatype/react-shared-components';
+import CodeExample from '../../CodeExample';
 
 const NxViewportSizedExample = require('./NxViewportSizedExample.tsx?raw'),
     NxViewportSizedExpandingExample = require('./NxViewportSizedExpandingExample.tsx?raw'),

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.7.1",
+  "version": "7.7.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I standardized the documentation tables on `*Page.tsx` files to use the correct `NxTable`, `NxTile`, `NxCode`, `NxTextLink`, and `NxP` tags. 

I did not do the lists because we already have tickets out for them (and I ran out of time).