### PR TITLE
Change pristine border colour RSC-662

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -13,7 +13,7 @@
   --nx-color-site-background: var(--nx-swatch-indigo-97);
 
   --nx-color-form-element-border: var(--nx-swatch-grey-05);
-  --nx-color-form-element-border-pristine: var(--nx-swatch-indigo-95);
+  --nx-color-form-element-border-pristine: var(--nx-swatch-indigo-90);
 
   --nx-color-interactive-background-selected: var(--nx-swatch-blue-90);
   --nx-color-interactive-background-active: var(--nx-swatch-blue-95);


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-662

The pristine state form element border is very light and Kaleido v2 notes a change to `indigo-90` which is not reflected in the code. This PR fixes that.