### PR TITLE
Update threat colors RSC-670

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.8.7",
+  "version": "7.8.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.8.7",
+  "version": "7.8.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -35,9 +35,9 @@
   --nx-color-threat-unspecified: var(--nx-swatch-indigo-95);
   --nx-color-threat-none: var(--nx-swatch-blue-70);
   --nx-color-threat-low: var(--nx-swatch-blue-40);
-  --nx-color-threat-moderate: var(--nx-swatch-yellow-65);
-  --nx-color-threat-severe: var(--nx-swatch-orange-55);
-  --nx-color-threat-critical: var(--nx-swatch-red-45);
+  --nx-color-threat-moderate: var(--nx-swatch-yellow-50);
+  --nx-color-threat-severe: var(--nx-swatch-orange-50);
+  --nx-color-threat-critical: var(--nx-swatch-red-40);
 
   --nx-color-validation-valid: var(--nx-swatch-green-30);
   --nx-color-validation-invalid: var(--nx-swatch-red-45);

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -35,7 +35,7 @@
   --nx-color-threat-unspecified: var(--nx-swatch-indigo-95);
   --nx-color-threat-none: var(--nx-swatch-blue-70);
   --nx-color-threat-low: var(--nx-swatch-blue-40);
-  --nx-color-threat-moderate: var(--nx-swatch-yellow-50);
+  --nx-color-threat-moderate: var(--nx-swatch-yellow-60);
   --nx-color-threat-severe: var(--nx-swatch-orange-50);
   --nx-color-threat-critical: var(--nx-swatch-red-40);
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-670

Update threat colors to:
```
moderate: var(--nx-swatch-yellow-60); //was 65
severe: var(--nx-swatch-orange-50); //was 55
critical: var(--nx-swatch-red-40); //was 45
```