### PR TITLE
nx-table docs extra icon fix RSC-653

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.8.8",
+  "version": "7.8.9",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.8.7",
+  "version": "7.8.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/styles/NxTable/NxTableStylePage.tsx
+++ b/gallery/src/styles/NxTable/NxTableStylePage.tsx
@@ -70,7 +70,6 @@ const NxTableStylePage = () =>
               Used to apply{' '}
               <NxTextLink external href="https://developer.mozilla.org/en-US/docs/Web/CSS/table-layout">
                 <NxCode>table-layout: fixed</NxCode>
-                <NxFontAwesomeIcon icon={faExternalLinkAlt} />
               </NxTextLink>
               {' '}to <NxCode>nx-table</NxCode>s. This class should be used in lieu of setting
               <NxCode>table-layout</NxCode> manually, as it also makes some adjustments to the

--- a/gallery/src/styles/NxTable/NxTableStylePage.tsx
+++ b/gallery/src/styles/NxTable/NxTableStylePage.tsx
@@ -5,9 +5,8 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxInfoAlert, NxFontAwesomeIcon, NxWarningAlert, NxTable, NxP, NxCode, NxTextLink }
+import { NxInfoAlert, NxWarningAlert, NxTable, NxP, NxCode, NxTextLink }
   from '@sonatype/react-shared-components';
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
 import { GalleryDescriptionTile } from '../../gallery-components/GalleryTiles';
 import NxTableExamples from './NxTableExamples';

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.8.7",
+  "version": "7.8.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.8.8",
+  "version": "7.8.9",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-653

Deleted extra external link icon