### PR TITLE
Move textarea validation icon gutter from the right to the bottom RSC-683

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "7.8.8",
+  "version": "7.8.9",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/visualtests/nxTextInput.js
+++ b/gallery/visualtests/nxTextInput.js
@@ -127,7 +127,7 @@ describe('NxTextInput', function() {
       await browser.keys(['Backspace', 'Backspace', 'Backspace']);
 
       const { x, y } = await targetElement.getLocation();
-      const region = new Region(parseInt(x, 10), parseInt(y, 10), 300, 270);
+      const region = new Region(parseInt(x, 10), parseInt(y, 10), 300, 300);
 
       await browser.eyesRegionSnapshot(null, Target.region(region));
     });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "7.8.8",
+  "version": "7.8.9",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -122,7 +122,7 @@
     flex-direction: column;
 
     &::before {
-      content: unset;
+      content: none;
     }
 
     svg {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -125,7 +125,7 @@
       content: none;
     }
 
-    svg {
+    .nx-icon {
       align-self: flex-end;
       margin: var(--nx-spacing-2x) 0 0 0;
     }

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -117,7 +117,7 @@
 
 .nx-text-input--textarea {
   .nx-text-input__box {
-    align-items: unset;
+    align-items: initial;
     display: flex;
     flex-direction: column;
 

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -133,11 +133,9 @@
 }
 
 textarea.nx-text-input__input {
-  //To disable horizontal resize of textarea
-  max-width: 100%;
-  min-width: 100%;
   min-height: 220px;
   padding: 0;
+  resize: vertical;
 }
 
 ::-ms-clear {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -117,11 +117,25 @@
 
 .nx-text-input--textarea {
   .nx-text-input__box {
-    align-items: flex-end;
+    align-items: unset;
+    display: flex;
+    flex-direction: column;
+
+    &::before {
+      content: unset;
+    }
+
+    svg {
+      align-self: flex-end;
+      margin: var(--nx-spacing-2x) 0 0 0;
+    }
   }
 }
 
 textarea.nx-text-input__input {
+  //To disable horizontal resize of textarea
+  max-width: 100%;
+  min-width: 100%;
   min-height: 220px;
   padding: 0;
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-683

- Used `flex-direction: column` to move icon gutter to bottom.
- Disabled horizontal resize by setting both `max-width` and `min-width` to be 100%.
- Added top margin of validation icon to be `var(--nx-spacing-2x)`.