### PR TITLE
error btn focus background RSC-704

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-btn.scss
+++ b/lib/src/base-styles/_nx-btn.scss
@@ -84,7 +84,7 @@
   color: var(--nx-swatch-white);
 
   &:focus {
-    border-color: var(--nx-color-interactive-border-focus);
+    background-color: var(--nx-swatch-red-35);
   }
 
   &:hover {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-704

Fixed the `:focus` background to match Sketch, also removed a redundant border style.