### PR TITLE
Avoid changing focus borders when hovered - RSC-694

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/visualtests/nxButton.js
+++ b/gallery/visualtests/nxButton.js
@@ -64,7 +64,7 @@ describe('NxButton', function() {
     it('has a dark grey border when hovered', hoverTest(selector));
     it('has a dark grey border and light grey background when clicked', clickTest(selector));
     it('has a light blue border when focused', focusTest(selector));
-    it('has a dark grey border when focused and hovered', focusAndHoverTest(selector));
+    it('has a blue border and blue glow when focused and hovered', focusAndHoverTest(selector));
   });
 
   describe('Error NxButton', function() {

--- a/gallery/visualtests/nxCloseButton.js
+++ b/gallery/visualtests/nxCloseButton.js
@@ -17,5 +17,5 @@ describe('NxCloseButton', function() {
   it('has a dark grey border when hovered', hoverTest(selector));
   it('has a dark grey border and light grey background when clicked', clickTest(selector));
   it('has a light blue border when focused', focusTest(selector));
-  it('has a dark grey border when focused and hovered', focusAndHoverTest(selector));
+  it('has a blue border and blue glow when focused and hovered', focusAndHoverTest(selector));
 });

--- a/gallery/visualtests/nxIconDropdown.js
+++ b/gallery/visualtests/nxIconDropdown.js
@@ -19,7 +19,7 @@ describe('NxIconDropdown', function() {
     it('has no border by default', simpleTest(defaultSelector + ' .nx-icon-dropdown__toggle'));
     it('has a dark grey border when hovered', hoverTest(defaultSelector + ' .nx-icon-dropdown__toggle'));
     it('has a light blue border when focused', focusTest(defaultSelector + ' .nx-icon-dropdown__toggle'));
-    it('has a dark grey border when focused and hovered',
+    it('has a blue border and blue glow when focused and hovered',
         focusAndHoverTest(defaultSelector + ' .nx-icon-dropdown__toggle'));
     it('has a dark grey border and light grey background when clicked',
         clickTest(defaultSelector + ' .nx-icon-dropdown__toggle'));

--- a/gallery/visualtests/nxTag.js
+++ b/gallery/visualtests/nxTag.js
@@ -42,7 +42,7 @@ describe('NxTag', function() {
     it('has a blue/grey border and lighter blue/grey background by default', simpleTest(selector));
     it('has a dark grey border when hovered', hoverTest(selector));
     it('has a light blue glow and light blue border when focused', focusTest(selector));
-    it('has a light blue glow and dark grey border when focused and hovered', focusAndHoverTest(selector));
+    it('has a light blue glow and blue border when focused and hovered', focusAndHoverTest(selector));
 
     it('has a dark blue/grey background when clicked', async function() {
       const targetElement = await browser.$(selector);

--- a/gallery/visualtests/nxTextInput.js
+++ b/gallery/visualtests/nxTextInput.js
@@ -35,7 +35,7 @@ describe('NxTextInput', function() {
     it('has a blue border when focused',
         focusTest(simpleComponentSelector, getInputElementSelector(simpleComponentSelector)));
 
-    it('has a dark border when hovered and focused',
+    it('has a blue border and blue glow when hovered and focused',
         focusAndHoverTest(simpleComponentSelector, getInputElementSelector(simpleComponentSelector)));
 
     it('has a dark border when non-empty', async function() {

--- a/gallery/visualtests/nxTransferList.js
+++ b/gallery/visualtests/nxTransferList.js
@@ -39,7 +39,7 @@ describe('NxTransferList', function() {
 
   it('puts a dark border on hovered items', hoverTest(simpleListSelector, secondItemSelector));
   it('puts a blue border and glow on focused items', focusTest(simpleListSelector, secondItemSelector));
-  it('puts a dark border and blue glow on focused+hovered items',
+  it('puts a blue border and blue glow on focused+hovered items',
       focusAndHoverTest(simpleListSelector, secondItemSelector));
   it('puts a grey background on clicked items', clickTest(simpleListSelector, secondItemSelector));
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-btn.scss
+++ b/lib/src/base-styles/_nx-btn.scss
@@ -72,6 +72,10 @@
     background-color: transparent;
   }
 
+  &:focus:hover {
+    border-color: var(--nx-color-interactive-border-focus);
+  }
+
   &:active {
     background-color: var(--nx-swatch-grey-95);
     border-color: var(--nx-swatch-grey-05);

--- a/lib/src/base-styles/_nx-btn.scss
+++ b/lib/src/base-styles/_nx-btn.scss
@@ -70,9 +70,6 @@
 
   &:focus {
     background-color: transparent;
-  }
-
-  &:focus:hover {
     border-color: var(--nx-color-interactive-border-focus);
   }
 

--- a/lib/src/base-styles/_nx-pagination.scss
+++ b/lib/src/base-styles/_nx-pagination.scss
@@ -44,6 +44,10 @@
     border-color: var(--nx-swatch-grey-10);
   }
 
+  &:focus:hover {
+    border-color: var(--nx-color-interactive-border-focus);
+  }
+
   &:active {
     background-color: var(--nx-swatch-grey-95);
     border-color: var(--nx-swatch-grey-60);

--- a/lib/src/base-styles/_nx-pagination.scss
+++ b/lib/src/base-styles/_nx-pagination.scss
@@ -44,7 +44,7 @@
     border-color: var(--nx-swatch-grey-10);
   }
 
-  &:focus:hover {
+  &:focus {
     border-color: var(--nx-color-interactive-border-focus);
   }
 

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -26,6 +26,12 @@
         border-color: var(--nx-color-form-element-border);
       }
     }
+
+    &:focus-within:hover {
+      .nx-text-input__box {
+        border-color: var(--nx-color-interactive-border-focus);
+      }
+    }
   }
 
   &.invalid {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -14,22 +14,16 @@
   max-width: 100%;
 
   &, &.pristine, &.pristine.valid {
-    &:focus-within {
-      .nx-text-input__box {
-        border-color: var(--nx-color-interactive-border-focus);
-        box-shadow: var(--nx-box-shadow-focus);
-      }
-    }
-
     &:hover {
       .nx-text-input__box {
         border-color: var(--nx-color-form-element-border);
       }
     }
 
-    &:focus-within:hover {
+    &:focus-within {
       .nx-text-input__box {
         border-color: var(--nx-color-interactive-border-focus);
+        box-shadow: var(--nx-box-shadow-focus);
       }
     }
   }

--- a/lib/src/components/NxColorPicker/NxColorPicker.scss
+++ b/lib/src/components/NxColorPicker/NxColorPicker.scss
@@ -43,6 +43,10 @@
   &:hover {
     border-color: var(--nx-swatch-grey-05);
   }
+
+  &:focus-within:hover {
+    border-color: var(--nx-color-interactive-border-focus);
+  }
 }
 
 .nx-color-picker__input {

--- a/lib/src/components/NxColorPicker/NxColorPicker.scss
+++ b/lib/src/components/NxColorPicker/NxColorPicker.scss
@@ -35,17 +35,13 @@
     border-color: var(--nx-swatch-teal-60);
   }
 
-  &:focus-within {
-    border-color: var(--nx-color-interactive-border-focus);
-    box-shadow: var(--nx-box-shadow-focus);
-  }
-
   &:hover {
     border-color: var(--nx-swatch-grey-05);
   }
 
-  &:focus-within:hover {
+  &:focus-within {
     border-color: var(--nx-color-interactive-border-focus);
+    box-shadow: var(--nx-box-shadow-focus);
   }
 }
 

--- a/lib/src/components/NxTag/NxTag.scss
+++ b/lib/src/components/NxTag/NxTag.scss
@@ -45,6 +45,10 @@
   &:hover {
     border-color: var(--nx-swatch-grey-10);
   }
+
+  &:hover:focus {
+    border-color: var(--nx-color-interactive-border-focus);
+  }
 }
 
 .nx-tag--selected {

--- a/lib/src/components/NxTag/NxTag.scss
+++ b/lib/src/components/NxTag/NxTag.scss
@@ -36,18 +36,14 @@
 
   background-color: var(--nx-selectable-color-light);
 
-  &:focus {
-    border: 1px solid var(--nx-color-interactive-border-focus);
-    box-shadow: var(--nx-box-shadow-focus);
-    outline: none;
-  }
-
   &:hover {
     border-color: var(--nx-swatch-grey-10);
   }
 
-  &:hover:focus {
-    border-color: var(--nx-color-interactive-border-focus);
+  &:focus {
+    border: 1px solid var(--nx-color-interactive-border-focus);
+    box-shadow: var(--nx-box-shadow-focus);
+    outline: none;
   }
 }
 

--- a/lib/src/components/NxTransferList/TransferListHalf.scss
+++ b/lib/src/components/NxTransferList/TransferListHalf.scss
@@ -112,6 +112,10 @@ $-visible-item-count: 10;
     border-color: var(--nx-swatch-grey-05);
   }
 
+  &:focus-within:hover {
+    border-color: var(--nx-color-interactive-border-focus);
+  }
+
   &:active {
     background-color: transparent;
     border-color: var(--nx-swatch-grey-05);

--- a/lib/src/components/NxTransferList/TransferListHalf.scss
+++ b/lib/src/components/NxTransferList/TransferListHalf.scss
@@ -103,17 +103,13 @@ $-visible-item-count: 10;
   margin: var(--nx-spacing-2x) 0;
   padding: var(--nx-spacing-2x);
 
-  &:focus-within {
-    border-color: var(--nx-color-interactive-border-focus);
-    box-shadow: var(--nx-box-shadow-focus);
-  }
-
   &:hover {
     border-color: var(--nx-swatch-grey-05);
   }
 
-  &:focus-within:hover {
+  &:focus-within {
     border-color: var(--nx-color-interactive-border-focus);
+    box-shadow: var(--nx-box-shadow-focus);
   }
 
   &:active {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-694

The changes in this PR affect the following components:

- NxButton (tertiary and icon-only variant),
- NxSegmentedButton (tertiary variant),
- NxStatefulSegmentedButton ((tertiary variant),
- NxColorPicker,
- NxCloseButton,
- NxDropdown,
- NxStatefulDropdown,
- NxIconDropdown,
- NxPagination,
- NxIndeterminatePagination,
- NxTag,
- NxTextInput,
- NxStatefulTextInput,
- NxTransferList

Expected behavior:

- hovered: grey-05 border;
- focused: var(--nx-color-interactive-border-focus) i.e. teal-45 border
- focused + hovered: var(--nx-color-interactive-border-focus) i.e. teal-45 border (focus style should override hover style)