### PR TITLE
Avoid second type parameter - RSC-649

### DIFF
--- a/lib/src/components/NxTransferList/NxTransferList.tsx
+++ b/lib/src/components/NxTransferList/NxTransferList.tsx
@@ -20,8 +20,7 @@ const defaultItemsCountFormatter = (kind: string) => (n: number) => `${n} item${
     defaultAvailableItemsCountFormatter = defaultItemsCountFormatter('available'),
     defaultSelectedItemsCountFormatter = defaultItemsCountFormatter('transferred');
 
-export default function NxTransferList
-<T extends string | number = string, P extends Set<T> | T[] = Set<T>>(props: Props<T, P>) {
+export default function NxTransferList <T extends string | number = string>(props: Props<T>) {
   const {
     allowReordering,
     allItems,
@@ -65,7 +64,14 @@ export default function NxTransferList
   const availableCount = allItems.length - selectedItemsArray.length,
       selectedCount = selectedItemsArray.length;
 
-  const handleOnChangeProp = (array: T[]) => onChangeProp((allowReordering ? array : new Set(array)) as P);
+  const handleOnChangeProp = (array: T[]) => {
+    if (allowReordering) {
+      (onChangeProp as (newSelected: T[]) => void)(array);
+    }
+    else {
+      (onChangeProp as (newSelected: Set<T>) => void)(new Set(array));
+    }
+  };
 
   function onChange(checked: boolean, id: T) {
     const newSelectedItemsArray = checked

--- a/lib/src/components/NxTransferList/stateful/NxStatefulTransferList.tsx
+++ b/lib/src/components/NxTransferList/stateful/NxStatefulTransferList.tsx
@@ -12,12 +12,12 @@ import NxTransferList from '../NxTransferList';
 export { StatefulProps as Props };
 
 export default function NxStatefulTransferList
-<T extends string | number = string, P extends Set<T> | T[] = Set<T>>(props: StatefulProps<T, P>) {
+<T extends string | number = string>(props: StatefulProps<T>) {
   const [availableItemsFilter, setAvailableItemsFilter] = useState(''),
       [selectedItemsFilter, setSelectedItemsFilter] = useState('');
 
-  return <NxTransferList<T, P> onAvailableItemsFilterChange={setAvailableItemsFilter}
-                               onSelectedItemsFilterChange={setSelectedItemsFilter}
-                               { ...{ availableItemsFilter, selectedItemsFilter } }
-                               { ...props } />;
+  return <NxTransferList<T> onAvailableItemsFilterChange={setAvailableItemsFilter}
+                            onSelectedItemsFilterChange={setSelectedItemsFilter}
+                            { ...{ availableItemsFilter, selectedItemsFilter } }
+                            { ...props } />;
 }

--- a/lib/src/components/NxTransferList/types.ts
+++ b/lib/src/components/NxTransferList/types.ts
@@ -40,7 +40,7 @@ export interface TransferListHalfProps<T extends string | number = string> {
   allowReordering?: boolean | null;
 }
 
-export interface StatefulProps<T extends string | number = string, P extends Set<T> | T[] = Set<T>>
+interface BaseStatefulProps<T extends string | number = string>
   extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'> {
   allItems: DataItem<T>[];
   availableItemsLabel?: ReactNode;
@@ -49,18 +49,29 @@ export interface StatefulProps<T extends string | number = string, P extends Set
   selectedItemsCountFormatter?: ((n: number) => string) | null;
   showMoveAll?: boolean | null;
   filterFn?: ((filterStr: string, itemDisplayName: string) => boolean) | null;
-  allowReordering?: boolean | null;
-  selectedItems: P;
-  onChange: (newSelected: P) => void;
 }
 
-export interface Props<T extends string | number = string, P extends Set<T> | T[] = Set<T>>
-  extends StatefulProps<T, P> {
+interface UnorderedStatefulProps<T extends string | number = string> extends BaseStatefulProps<T> {
+  allowReordering?: false | null;
+  selectedItems: Set<T>;
+  onChange: (newSelected: Set<T>) => void;
+}
+
+interface OrderedStatefulProps<T extends string | number = string> extends BaseStatefulProps<T> {
+  allowReordering: true;
+  selectedItems: T[];
+  onChange: (newSelected: T[]) => void;
+}
+
+export type StatefulProps<T extends string | number = string> =
+    UnorderedStatefulProps<T> | OrderedStatefulProps<T>;
+
+export type Props<T extends string | number = string> = StatefulProps<T> & {
   availableItemsFilter: string;
   selectedItemsFilter: string;
   onAvailableItemsFilterChange: NxFilterInputProps['onChange'];
   onSelectedItemsFilterChange: NxFilterInputProps['onChange'];
-}
+};
 
 // allItems, selectedItems, onAvailableItemsFilterChange, onSelectedItemsFilterChange
 // are excluded in the propTypes due to clash with parametric Props;


### PR DESCRIPTION
By making two separate interfaces, one for when `allowReordering` is true and one for when it isn't, this avoids the need for the second type parameter