### PR TITLE
correct accordion container in NxTextInput docs RSC-732

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.8.5",
+  "version": "8.8.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxTextInput/NxTextInputPage.tsx
+++ b/gallery/src/components/NxTextInput/NxTextInputPage.tsx
@@ -192,33 +192,35 @@ const NxTextInputPage = () =>
           </NxTable.Row>
         </NxTable.Body>
       </NxTable>
-      <NxStatefulAccordion defaultOpen={false}>
-        <NxAccordion.Header>
-          <h2 className="nx-accordion__header-title">Regarding &lt;input type="number"&gt;</h2>
-        </NxAccordion.Header>
-        <NxP>
-          <NxCode>NxTextInput</NxCode> using <NxCode>type="number"</NxCode> has been an oft requested addition to the
-          RSC but there are problems with its implementation at the browser level that make its use within RSC
-          too complicated to justify further development at this time.
-        </NxP>
-        <NxP>
-          In Chrome it works mostly as expected, however Safari and Firefox allow the user to input non-number
-          characters but do not recognize those characters as values. If a user inputs "aaaa" or 123a"
-          , <NxCode>onChange</NxCode> receives "" as the value in both of those invalid cases. It should be
-          setting that as the value stored in the state, which goes in as the value of the &lt;input&gt; in the next
-          render, which should clear the input. Normally you'd expect that as soon as you enter an invalid character
-          after the number, the input should have cleared. But for some reason that doesn't happen. We have traced
-          through the code and all of the state handling in our examples and components is correct. But for some
-          reason, when that empty string gets passed back into the &lt;input&gt; in <NxCode>NxTextInput</NxCode>,
-          it just ignores it. The whole React workflow around <NxCode>type="number"</NxCode> seems to be broken,
-          not to mention our RSC validation workflow.
-        </NxP>
-        <NxP>
-          At this point if an input that only accepts numbers is required, it is strongly suggested that the developer
-          create a custom validation rule. Here is a simple Regex that will detect only digits to get you
-          started: <NxCode>/^\d+$/</NxCode>.
-        </NxP>
-      </NxStatefulAccordion>
+      <div className="nx-tile-content--accordion-container">
+        <NxStatefulAccordion defaultOpen={false}>
+          <NxAccordion.Header>
+            <h2 className="nx-accordion__header-title">Regarding &lt;input type="number"&gt;</h2>
+          </NxAccordion.Header>
+          <NxP>
+            <NxCode>NxTextInput</NxCode> using <NxCode>type="number"</NxCode> has been an oft requested addition to the
+            RSC but there are problems with its implementation at the browser level that make its use within RSC
+            too complicated to justify further development at this time.
+          </NxP>
+          <NxP>
+            In Chrome it works mostly as expected, however Safari and Firefox allow the user to input non-number
+            characters but do not recognize those characters as values. If a user inputs "aaaa" or 123a"
+            , <NxCode>onChange</NxCode> receives "" as the value in both of those invalid cases. It should be
+            setting that as the value stored in the state, which goes in as the value of the &lt;input&gt; in the next
+            render, which should clear the input. Normally you'd expect that as soon as you enter an invalid character
+            after the number, the input should have cleared. But for some reason that doesn't happen. We have traced
+            through the code and all of the state handling in our examples and components is correct. But for some
+            reason, when that empty string gets passed back into the &lt;input&gt; in <NxCode>NxTextInput</NxCode>,
+            it just ignores it. The whole React workflow around <NxCode>type="number"</NxCode> seems to be broken,
+            not to mention our RSC validation workflow.
+          </NxP>
+          <NxP>
+            At this point if an input that only accepts numbers is required, it is strongly suggested that the developer
+            create a custom validation rule. Here is a simple Regex that will detect only digits to get you
+            started: <NxCode>/^\d+$/</NxCode>.
+          </NxP>
+        </NxStatefulAccordion>
+      </div>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Simple Example"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.8.5",
+  "version": "8.8.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-732

Added correct wrapping container around the accordion