### PR TITLE
Updated NxDropdown icon size to match Kaleido - RSC-682

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "8.9.3",
+  "version": "8.9.4",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "8.9.3",
+  "version": "8.9.4",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxDropdown/NxDropdown.tsx
+++ b/lib/src/components/NxDropdown/NxDropdown.tsx
@@ -59,7 +59,7 @@ const NxDropdown: FunctionComponent<Props> = function NxDropdown(props) {
               aria-haspopup="true"
               aria-expanded={isOpen}>
       <span className="nx-dropdown__toggle-label">{ label }</span>
-      <NxFontAwesomeIcon icon={isOpen ? faCaretUp : faCaretDown}/>
+      <NxFontAwesomeIcon icon={isOpen ? faCaretUp : faCaretDown} size="lg" />
     </NxButton>
   );
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-682

I wasn't sure if we should size it in CSS using `font-size` or use the sizings from FontAwesome.

I decided to go with the FontAwesome sizings because it felt more deliberate:
https://fontawesome.com/v5.15/how-to-use/on-the-web/styling/sizing-icons