### PR TITLE
Fixed NxTextInputs height in Safari. - RSC-762

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -102,6 +102,7 @@
   flex-grow: 1;
   font-size: var(--nx-font-size);
   line-height: var(--nx-line-height);
+  margin: 0;
   padding: 0;
 
   &:focus {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-762

Apparently, Safari adds 2px margin to input fields by default.

Fixed:
<img width="387" alt="Screen Shot 2021-10-18 at 11 12 28 AM" src="https://user-images.githubusercontent.com/10160030/137759710-18a1c51b-e6ec-4bde-883e-c847bf376525.png">


