### PR TITLE
Update NxGrid padding - RSC-693

### DIFF
--- a/lib/src/base-styles/_nx-grid.scss
+++ b/lib/src/base-styles/_nx-grid.scss
@@ -21,7 +21,7 @@
   box-sizing: border-box;
   flex: 1 0;
   overflow-x: hidden;
-  padding: 0 var(--nx-spacing-12x);
+  padding: 0 var(--nx-spacing-6x);
 
   overflow-wrap: break-word;
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-693

It says vertical padding in the ticket but the one that is mismatched with Kaleido is the horizontal padding.