### PR TITLE
SPIKE: line charts RSC-754

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -65,6 +65,7 @@
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@nivo/core": "^0.73.0",
     "@nivo/pie": "^0.73.0",
+    "@nivo/line": "^0.73.0",
     "@nivo/tooltip": "^0.73.0",
     "@react-hook/debounce": "^4.0.0",
     "@sonatype/react-shared-components": "link:../lib/dist",

--- a/gallery/src/chart-poc/nivo/NivoLineChartExample.tsx
+++ b/gallery/src/chart-poc/nivo/NivoLineChartExample.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { useEffect, useState } from 'react';
+import { selectableColorValues } from '@sonatype/react-shared-components';
+import { ResponsiveLine } from '@nivo/line';
+
+const data = [
+  {
+    'id': 'Long Story',
+    'data': [
+      {
+        'x': 'Critical',
+        'y': 264
+      },
+      {
+        'x': 'Severe',
+        'y': 117
+      },
+      {
+        'x': 'Moderate',
+        'y': 0
+      },
+      {
+        'x': 'Low',
+        'y': 213
+      },
+      {
+        'x': 'None',
+        'y': 148
+      }
+    ]
+  },
+  {
+    'id': 'Song Story',
+    'data': [
+      {
+        'x': 'Critical',
+        'y': 88
+      },
+      {
+        'x': 'Severe',
+        'y': 263
+      },
+      {
+        'x': 'Moderate',
+        'y': 282
+      },
+      {
+        'x': 'Low',
+        'y': 39
+      },
+      {
+        'x': 'None',
+        'y': 83
+      }
+    ]
+  },
+  {
+    'id': 'Later Daters',
+    'data': [
+      {
+        'x': 'Critical',
+        'y': 27
+      },
+      {
+        'x': 'Severe',
+        'y': 43
+      },
+      {
+        'x': 'Moderate',
+        'y': 136
+      },
+      {
+        'x': 'Low',
+        'y': 125
+      },
+      {
+        'x': 'None',
+        'y': 281
+      }
+    ]
+  },
+  {
+    'id': 'Free Runner',
+    'data': [
+      {
+        'x': 'Critical',
+        'y': 17
+      },
+      {
+        'x': 'Severe',
+        'y': 238
+      },
+      {
+        'x': 'Moderate',
+        'y': 13
+      },
+      {
+        'x': 'Low',
+        'y': 211
+      },
+      {
+        'x': 'None',
+        'y': 146
+      }
+    ]
+  }
+];
+
+export default function NivoLineChartExample() {
+  const [colors, setColors] = useState<string[] | undefined>(undefined);
+
+  useEffect(function() {
+    selectableColorValues.then(({ dark }) => setColors(dark));
+  }, []);
+
+  if (colors) {
+    return (
+      <div style={{ height: '500px' }}>
+        <ResponsiveLine data={data}
+                        colors={colors}
+                        margin={{ top: 50, right: 110, bottom: 50, left: 60 }}
+                        xScale={{ type: 'point' }}
+                        yScale={{ type: 'linear', min: 'auto', max: 'auto', stacked: true, reverse: false }}
+                        yFormat=' >-.2f'
+                        axisTop={null}
+                        axisRight={null}
+                        axisBottom={{
+                          tickSize: 5,
+                          tickPadding: 5,
+                          tickRotation: 0,
+                          legend: 'Violation Level',
+                          legendOffset: 36,
+                          legendPosition: 'middle'
+                        }}
+                        axisLeft={{
+                          tickSize: 5,
+                          tickPadding: 5,
+                          tickRotation: 0,
+                          legend: 'Violation Count',
+                          legendOffset: -40,
+                          legendPosition: 'middle'
+                        }}
+                        pointSize={10}
+                        pointColor={{ theme: 'background' }}
+                        pointBorderWidth={2}
+                        pointBorderColor={{ from: 'serieColor' }}
+                        pointLabelYOffset={-12}
+                        useMesh={true}
+                        legends={[
+                          {
+                            anchor: 'bottom-right',
+                            direction: 'column',
+                            justify: false,
+                            translateX: 100,
+                            translateY: 0,
+                            itemsSpacing: 0,
+                            itemDirection: 'left-to-right',
+                            itemWidth: 80,
+                            itemHeight: 20,
+                            itemOpacity: 0.75,
+                            symbolSize: 12,
+                            symbolShape: 'circle',
+                            symbolBorderColor: 'rgba(0, 0, 0, .5)',
+                            effects: [
+                              {
+                                on: 'hover',
+                                style: {
+                                  itemBackground: 'rgba(0, 0, 0, .03)',
+                                  itemOpacity: 1
+                                }
+                              }
+                            ]
+                          }
+                        ]}
+        />
+      </div>
+    );
+  }
+  else {
+    return null;
+  }
+}

--- a/gallery/src/chart-poc/nivo/NivoLineChartExample.tsx
+++ b/gallery/src/chart-poc/nivo/NivoLineChartExample.tsx
@@ -150,15 +150,16 @@ export default function NivoLineChartExample() {
                         pointBorderWidth={2}
                         pointBorderColor={{ from: 'serieColor' }}
                         pointLabelYOffset={-12}
+                        isInteractive={false}
                         useMesh={true}
                         legends={[
                           {
-                            anchor: 'bottom-right',
-                            direction: 'column',
+                            anchor: 'top',
+                            direction: 'row',
                             justify: false,
-                            translateX: 100,
-                            translateY: 0,
-                            itemsSpacing: 0,
+                            translateX: 50,
+                            translateY: -25,
+                            itemsSpacing: 24,
                             itemDirection: 'left-to-right',
                             itemWidth: 80,
                             itemHeight: 20,

--- a/gallery/src/chart-poc/nivo/NivoPOCPage.tsx
+++ b/gallery/src/chart-poc/nivo/NivoPOCPage.tsx
@@ -10,8 +10,10 @@ import { NxP, NxTextLink } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import Example from './NivoExample';
+import LineChartExample from './NivoLineChartExample';
 
 const code = require('./NivoExample?raw');
+const lineChartCode = require('./NivoLineChartExample?raw');
 
 export default function NxTablePage() {
   return (
@@ -40,6 +42,12 @@ export default function NxTablePage() {
       <GalleryExampleTile title="Example"
                           liveExample={Example}
                           codeExamples={code}>
+        Example
+      </GalleryExampleTile>
+
+      <GalleryExampleTile title="Line Chart Example"
+                          liveExample={LineChartExample}
+                          codeExamples={lineChartCode}>
         Example
       </GalleryExampleTile>
     </>

--- a/gallery/src/chart-poc/recharts/RechartsLineExample.tsx
+++ b/gallery/src/chart-poc/recharts/RechartsLineExample.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import { LineChart, Line, Legend, CartesianGrid, XAxis, YAxis } from 'recharts';
+
+import './RechartsExample.scss';
+
+const data = [
+  {
+    'name': 'Critical',
+    'Long Story': 264,
+    'Later Daters': 117,
+    'Song Story': 0,
+    'Heart Game': 213,
+    'Turtle Crossing': 148
+  },
+  {
+    'name': 'Severe',
+    'Long Story': 88,
+    'Later Daters': 263,
+    'Song Story': 282,
+    'Heart Game': 39,
+    'Turtle Crossing': 83
+  },
+  {
+    'name': 'Moderate',
+    'Long Story': 27,
+    'Later Daters': 43,
+    'Song Story': 136,
+    'Heart Game': 125,
+    'Turtle Crossing': 281
+  },
+  {
+    'name': 'Low',
+    'Long Story': 17,
+    'Later Daters': 238,
+    'Song Story': 13,
+    'Heart Game': 211,
+    'Turtle Crossing': 146
+  }
+];
+
+export default function RechartsExample() {
+  return (
+    <LineChart width={730}
+               height={250}
+               data={data}
+               margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="name" />
+      <YAxis />
+      <Legend />
+      <Line type="natural" dataKey="Long Story" stroke="var(--nx-swatch-orange-55)" />
+      <Line type="natural" dataKey="Later Daters" stroke="var(--nx-swatch-green-60)" />
+      <Line type="natural" dataKey="Song Story" stroke="var(--nx-swatch-indigo-80)" />
+      <Line type="natural" dataKey="Heart Game" stroke="var(--nx-swatch-red-75)" />
+      <Line type="natural" dataKey="Turtle Crossing" stroke="var(--nx-swatch-purple-80)" />
+    </LineChart>
+  );
+}

--- a/gallery/src/chart-poc/recharts/RechartsPage.tsx
+++ b/gallery/src/chart-poc/recharts/RechartsPage.tsx
@@ -10,8 +10,10 @@ import { NxP, NxTextLink } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import Example from './RechartsExample';
+import LineExample from './RechartsLineExample';
 
 const code = require('./RechartsExample?raw');
+const lineCode = require('./RechartsLineExample?raw');
 const scss = require('./RechartsExample.scss?raw');
 
 export default function NxTablePage() {
@@ -40,6 +42,12 @@ export default function NxTablePage() {
       <GalleryExampleTile title="Example"
                           liveExample={Example}
                           codeExamples={[code, { language: 'scss', content: scss }]}>
+        Example
+      </GalleryExampleTile>
+
+      <GalleryExampleTile title="Line Example"
+                          liveExample={LineExample}
+                          codeExamples={[lineCode]}>
         Example
       </GalleryExampleTile>
     </>

--- a/gallery/src/chart-poc/victory/VictoryLineExample.tsx
+++ b/gallery/src/chart-poc/victory/VictoryLineExample.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { useEffect, useState } from 'react';
+import { selectableColorValues } from '@sonatype/react-shared-components';
+import { VictoryChart, VictoryLine } from 'victory';
+
+export default function VictoryExample() {
+  const [colors, setColors] = useState<string[] | undefined>(undefined);
+
+  useEffect(function() {
+    selectableColorValues.then(({ dark }) => setColors(dark));
+  }, []);
+
+  if (colors) {
+    return (
+      <div style={{ height: '500px' }}>
+        <VictoryChart categories={{ x: ['Critical', 'Severe', 'Moderate', 'Low'] }}>
+          <VictoryLine style={{
+            data: { stroke: 'var(--nx-swatch-orange-55)' }
+          }}
+                       data={[
+                         { x: 1, y: 264 },
+                         { x: 2, y: 88 },
+                         { x: 3, y: 27 },
+                         { x: 4, y: 17 }
+                       ]}
+                    />
+          <VictoryLine style={{
+            data: { stroke: 'var(--nx-swatch-indigo-80)' }
+          }}
+                       data={[
+                         { x: 1, y: 117 },
+                         { x: 2, y: 263 },
+                         { x: 3, y: 43 },
+                         { x: 4, y: 238 }
+                       ]}
+                    />
+          <VictoryLine style={{
+            data: { stroke: 'var(--nx-swatch-green-60)' }
+          }}
+                       data={[
+                         { x: 1, y: 0 },
+                         { x: 2, y: 282 },
+                         { x: 3, y: 136 },
+                         { x: 4, y: 13 }
+                       ]}
+                    />
+        </VictoryChart>
+      </div>
+    );
+  }
+  else {
+    return null;
+  }
+}

--- a/gallery/src/chart-poc/victory/VictoryLineExample.tsx
+++ b/gallery/src/chart-poc/victory/VictoryLineExample.tsx
@@ -4,56 +4,44 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { useEffect, useState } from 'react';
-import { selectableColorValues } from '@sonatype/react-shared-components';
+import React from 'react';
 import { VictoryChart, VictoryLine } from 'victory';
 
 export default function VictoryExample() {
-  const [colors, setColors] = useState<string[] | undefined>(undefined);
-
-  useEffect(function() {
-    selectableColorValues.then(({ dark }) => setColors(dark));
-  }, []);
-
-  if (colors) {
-    return (
-      <div style={{ height: '500px' }}>
-        <VictoryChart categories={{ x: ['Critical', 'Severe', 'Moderate', 'Low'] }}>
-          <VictoryLine style={{
-            data: { stroke: 'var(--nx-swatch-orange-55)' }
-          }}
-                       data={[
-                         { x: 1, y: 264 },
-                         { x: 2, y: 88 },
-                         { x: 3, y: 27 },
-                         { x: 4, y: 17 }
-                       ]}
-                    />
-          <VictoryLine style={{
-            data: { stroke: 'var(--nx-swatch-indigo-80)' }
-          }}
-                       data={[
-                         { x: 1, y: 117 },
-                         { x: 2, y: 263 },
-                         { x: 3, y: 43 },
-                         { x: 4, y: 238 }
-                       ]}
-                    />
-          <VictoryLine style={{
-            data: { stroke: 'var(--nx-swatch-green-60)' }
-          }}
-                       data={[
-                         { x: 1, y: 0 },
-                         { x: 2, y: 282 },
-                         { x: 3, y: 136 },
-                         { x: 4, y: 13 }
-                       ]}
-                    />
-        </VictoryChart>
-      </div>
-    );
-  }
-  else {
-    return null;
-  }
+  return (
+    <div style={{ height: '500px' }}>
+      <VictoryChart categories={{ x: ['Critical', 'Severe', 'Moderate', 'Low'] }}>
+        <VictoryLine style={{
+          data: { stroke: 'var(--nx-swatch-orange-55)' }
+        }}
+                     data={[
+                       { x: 1, y: 264 },
+                       { x: 2, y: 88 },
+                       { x: 3, y: 27 },
+                       { x: 4, y: 17 }
+                     ]}
+        />
+        <VictoryLine style={{
+          data: { stroke: 'var(--nx-swatch-indigo-80)' }
+        }}
+                     data={[
+                       { x: 1, y: 117 },
+                       { x: 2, y: 263 },
+                       { x: 3, y: 43 },
+                       { x: 4, y: 238 }
+                     ]}
+                  />
+        <VictoryLine style={{
+          data: { stroke: 'var(--nx-swatch-green-60)' }
+        }}
+                     data={[
+                       { x: 1, y: 0 },
+                       { x: 2, y: 282 },
+                       { x: 3, y: 136 },
+                       { x: 4, y: 13 }
+                     ]}
+                  />
+      </VictoryChart>
+    </div>
+  );
 }

--- a/gallery/src/chart-poc/victory/VictoryPage.tsx
+++ b/gallery/src/chart-poc/victory/VictoryPage.tsx
@@ -10,8 +10,10 @@ import { NxP, NxTextLink } from '@sonatype/react-shared-components';
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
 import Example from './VictoryExample';
+import LineExample from './VictoryLineExample';
 
 const code = require('./VictoryExample?raw');
+const lineCode = require('./VictoryLineExample?raw');
 
 export default function NxTablePage() {
   return (
@@ -31,6 +33,12 @@ export default function NxTablePage() {
       <GalleryExampleTile title="Example"
                           liveExample={Example}
                           codeExamples={code}>
+        Example
+      </GalleryExampleTile>
+
+      <GalleryExampleTile title="Line Example"
+                          liveExample={LineExample}
+                          codeExamples={lineCode}>
         Example
       </GalleryExampleTile>
     </>

--- a/gallery/yarn.lock
+++ b/gallery/yarn.lock
@@ -319,6 +319,15 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
+"@nivo/annotations@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.73.0.tgz#6b88b3c1b58a3c8a3b5dcc114b1026c34c083a6f"
+  integrity sha512-1rLAX5tcQh1Zo8ToENIO2WI1va72UhKc9K3219rtGRhXsy3f2hbmRZiw/iOJCLqzGtmT8RIKA++hOExWSyh4dQ==
+  dependencies:
+    "@nivo/colors" "0.73.0"
+    "@react-spring/web" "9.2.4"
+    lodash "^4.17.21"
+
 "@nivo/arcs@0.73.0":
   version "0.73.0"
   resolved "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.73.0.tgz#2211a0c41e8f6ed67374aeebdad607fbb3a1db2f"
@@ -327,6 +336,17 @@
     "@nivo/colors" "0.73.0"
     "@react-spring/web" "9.2.4"
     d3-shape "^1.3.5"
+
+"@nivo/axes@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.npmjs.org/@nivo/axes/-/axes-0.73.0.tgz#d4982bda3c21d318507e4c61b9cce31549f8c894"
+  integrity sha512-tyB+PqQTW117q9E5vz1jVTywDG6mjqD/RvtVGeqAwHziHAQxpSVb+r0UUtTFOgyaddEbLDaOXPqjD3l6Npo89g==
+  dependencies:
+    "@nivo/scales" "0.73.0"
+    "@react-spring/web" "9.2.4"
+    d3-format "^1.4.4"
+    d3-time "^1.0.11"
+    d3-time-format "^3.0.0"
 
 "@nivo/colors@0.73.0":
   version "0.73.0"
@@ -362,6 +382,21 @@
   resolved "https://registry.npmjs.org/@nivo/legends/-/legends-0.73.0.tgz#ef344038c4ff03249ffffebaf14412d012004fda"
   integrity sha512-OWyu3U6PJL2VGlAfoz6nTU4opXHlR0yp0h+0Q0rf/hMKQLiew6NmecKcR1Nx2Qw4dJHgOnZRXqQ6vQrhcNV3WQ==
 
+"@nivo/line@^0.73.0":
+  version "0.73.0"
+  resolved "https://registry.npmjs.org/@nivo/line/-/line-0.73.0.tgz#8d77963d0ff014138b2201cc0836f0a12593225f"
+  integrity sha512-ZxCJyoYN6tFx3NA4KvxKtbYLLzEl+S8TU57Qd/iGfJ2AbFAgiBhOiYH4kBY7VuxbUjcqQhPUvkPGcolnzqEXMg==
+  dependencies:
+    "@nivo/annotations" "0.73.0"
+    "@nivo/axes" "0.73.0"
+    "@nivo/colors" "0.73.0"
+    "@nivo/legends" "0.73.0"
+    "@nivo/scales" "0.73.0"
+    "@nivo/tooltip" "0.73.0"
+    "@nivo/voronoi" "0.73.0"
+    "@react-spring/web" "9.2.4"
+    d3-shape "^1.3.5"
+
 "@nivo/pie@^0.73.0":
   version "0.73.0"
   resolved "https://registry.npmjs.org/@nivo/pie/-/pie-0.73.0.tgz#4370bfdaaded5b0ba159cc544548b02373baf55a"
@@ -380,12 +415,30 @@
   dependencies:
     react-lifecycles-compat "^3.0.4"
 
+"@nivo/scales@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.npmjs.org/@nivo/scales/-/scales-0.73.0.tgz#ec1b660b3792fdc509326fd87e88e8f46a532f63"
+  integrity sha512-xnvCEXz6KkT7/SG4ubJ/hBtbMcTraZnJSKKSVkttBkvfIhkSpQChHkNX8g0Wd4hpwBv2QlltLbjoD6pJ0b/mRA==
+  dependencies:
+    d3-scale "^3.2.3"
+    d3-time "^1.0.11"
+    d3-time-format "^3.0.0"
+    lodash "^4.17.21"
+
 "@nivo/tooltip@0.73.0", "@nivo/tooltip@^0.73.0":
   version "0.73.0"
   resolved "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.73.0.tgz#c76d69ad90c1fb90b65b221ea74ad07b9e69ec59"
   integrity sha512-6tRRV5mzn1siArAlChXqBC/ISD0AV0tvGRbuyZokVXcM2xbvtfi6OAPaZ10UYbVejBo1rRI3gnhhyNkP0UG2ug==
   dependencies:
     "@react-spring/web" "9.2.4"
+
+"@nivo/voronoi@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.npmjs.org/@nivo/voronoi/-/voronoi-0.73.0.tgz#858aa5340c93bc299e07938b1e6770394ca7e9c9"
+  integrity sha512-jYDwNkNhEXRt4LR3hTxBZpuRDUQN4GtdP4fxcJIFGxvmh3Bsd3XQMWPqZYTNpgDddYjsnLtLe5RvR5gC7hBojw==
+  dependencies:
+    d3-delaunay "^5.3.0"
+    d3-scale "^3.2.3"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -2655,6 +2708,13 @@ d3-color@1:
   resolved "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
   integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
 
+d3-delaunay@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz#b47f05c38f854a4e7b3cea80e0bb12e57398772d"
+  integrity sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==
+  dependencies:
+    delaunator "4"
+
 d3-ease@^1.0.0:
   version "1.0.7"
   resolved "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
@@ -2759,7 +2819,7 @@ d3-time-format@2:
   dependencies:
     d3-time "1 - 2"
 
-d3-time@1:
+d3-time@1, d3-time@^1.0.11:
   version "1.1.0"
   resolved "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
@@ -2975,7 +3035,7 @@ del@^6.0.0:
     rimraf "^3.0.2"
     slash "^3.0.0"
 
-delaunator@^4.0.0:
+delaunator@4, delaunator@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
   integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-754

Again I felt that Nivo was the definite front runner here, not just because of the documentation, but also for the data layout. I really disliked Victory's requirement to lay out the data with `x,y` coordinates in the line declarations. Like Nivo, Recharts kept the data separate and I can't fault much about the implementation but it's just not as fully featured, or as nice looking (IMO) as Nivo.