### PR TITLE
NxToggle role switch RSC-780

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "9.1.9",
+  "version": "9.1.10",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "9.1.10",
+  "version": "9.1.11",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "9.1.10",
+  "version": "9.1.11",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "9.1.9",
+  "version": "9.1.10",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxToggle/NxToggle.tsx
+++ b/lib/src/components/NxToggle/NxToggle.tsx
@@ -42,7 +42,7 @@ const NxToggle = forwardRef<HTMLLabelElement, Props>(
       );
 
       return (
-        <label { ...otherProps } ref={ref} className={labelClasses}>
+        <label { ...otherProps } ref={ref} className={labelClasses} role="switch" aria-checked={isChecked}>
           <input type="checkbox"
                  id={otherInputAttributes.id || inputId || undefined}
                  className={classnames('nx-toggle__input', checkboxClassName)}


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-780

Added `role="switch` and `aria-checked` to `NxToggle` to match the selectable `NxTag`.