### PR TITLE
Updated nx-code styling to match Kaleido - RSC-826

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "9.5.4",
+  "version": "9.5.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "9.5.4",
+  "version": "9.5.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-color-swatches.scss
+++ b/lib/src/base-styles/_nx-color-swatches.scss
@@ -69,6 +69,7 @@
   --nx-swatch-pink-80: hsl(var(--nx-swatch-pink-hs), 80%);
   --nx-swatch-pink-90: hsl(var(--nx-swatch-pink-hs), 90%);
   --nx-swatch-pink-95: hsl(var(--nx-swatch-pink-hs), 95%);
+  --nx-swatch-pink-97: hsl(var(--nx-swatch-pink-hs), 97%);
 
   // Green
   --nx-swatch-green-hs:102, 86%;

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -74,15 +74,15 @@
 %nx-p {
   margin: var(--nx-spacing-4x) 0 var(--nx-spacing-6x) 0;
   max-width: var(--nx-width-text-wrapping);
-}
+} 
 
 %nx-code {
   @include monospace;
-  background-color: var(--nx-swatch-grey-95);
-  border: 1px solid var(--nx-swatch-grey-90);
-  border-radius: var(--nx-border-radius);
-  color: var(--nx-swatch-red-40);
-  padding: 1px 4px;
+  background-color: var(--nx-swatch-pink-97);
+  border: 1px solid var(--nx-swatch-pink-95);
+  border-radius: 4px;
+  color: var(--nx-swatch-grey-20);
+  padding: 1px;
   white-space: nowrap;
 }
 

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -74,7 +74,7 @@
 %nx-p {
   margin: var(--nx-spacing-4x) 0 var(--nx-spacing-6x) 0;
   max-width: var(--nx-width-text-wrapping);
-} 
+}
 
 %nx-code {
   @include monospace;


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-826