### PR TITLE
SPIKE merge examples in tabs RSC-842

### DIFF
--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -50,7 +50,7 @@ export default function NxAccordionPage() {
               NxAccordion renders a panel with an always-visible header and a collapsible/expandable body section.
               This is analogous to the HTML 5 <NxCode>&lt;details&gt;</NxCode> element (which it is
               implemented on top of). There are three related components: <NxCode>NxAccordion</NxCode> itself,
-              <NxCode>NxAccordion.Header</NxCode> which represents the header content, and
+              {' '}<NxCode>NxAccordion.Header</NxCode> which represents the header content, and
               {' '}<NxCode>NxAccordion.Title</NxCode> which is a convenience component for the header title. All other
               children of <NxCode>NxAccordion</NxCode> aside from
               the <NxCode>Header</NxCode> and the <NxCode>Title</NxCode> are rendered in the collapsible section.
@@ -77,14 +77,14 @@ export default function NxAccordionPage() {
             <NxList bulleted>
               <NxList.Item>
                 Displaying critical system information or a primary action to be taken on the page. (for example,
-                <a href="/components/alert">alerts</a>, confirmation or cancellation buttons).
+                {' '}<a href="/components/alert">alerts</a>, confirmation or cancellation buttons).
               </NxList.Item>
               <NxList.Item>
                 Displaying navigation elements such as <a href="/components/tabs">tabs</a>.
               </NxList.Item>
               <NxList.Item>
                 Displaying links pointing to sections of the same page, instead use a
-                <a href="/components/list">list</a>.
+                {' '}<a href="/components/list">list</a>.
               </NxList.Item>
               <NxList.Item>
                 Creating hierarchy levels by nesting them within each other. If you need to add hierarchy to the

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -4,184 +4,265 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React from 'react';
-import { NxTable, NxInfoAlert, NxCode, NxTextLink, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
+import React, {useState} from 'react';
+import {
+  NxTable,
+  NxInfoAlert,
+  NxCode,
+  NxTextLink,
+  NxP,
+  NxH3,
+  NxTile,
+  NxTabs,
+  NxTabList,
+  NxTab,
+  NxTabPanel,
+  NxH2,
+  NxList
+} from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
 import NxAccordionSimpleExample from './NxAccordionExample';
 import NxAccordionComplexExample from './NxAccordionComplexExample';
 import NxAccordionTertiaryButtonExample from './NxAccordionTertiaryButtonExample';
+import NxStatefulAccordionExample from '../NxStatefulAccordion/NxStatefulAccordionExample';
 
 const NxAccordionSimpleCode = require('./NxAccordionExample?raw'),
     NxAccordionComplexCode = require('./NxAccordionComplexExample?raw'),
-    NxAccordionTertiaryButtonCode = require('./NxAccordionTertiaryButtonExample?raw');
+    NxAccordionTertiaryButtonCode = require('./NxAccordionTertiaryButtonExample?raw'),
+    NxStatefulAccordionCode = require('../NxStatefulAccordion/NxStatefulAccordionExample?raw');
 
-const NxAccordionPage = () =>
-  <>
-    <GalleryDescriptionTile>
-      <NxP>
-        NxAccordion renders a panel with an always-visible header and a collapsible/expandable body section.
-        This is analogous to the HTML 5 <NxCode>&lt;details&gt;</NxCode> element (which it is
-        implemented on top of). There are three related components: <NxCode>NxAccordion</NxCode> itself,
-        <NxCode>NxAccordion.Header</NxCode> which represents the header content, and
-        {' '}<NxCode>NxAccordion.Title</NxCode> which is a convenience component for the header title. All other
-        children of <NxCode>NxAccordion</NxCode> aside from
-        the <NxCode>Header</NxCode> and the <NxCode>Title</NxCode> are rendered in the collapsible section.
+export default function NxAccordionPage() {
+  const [activeTabId, setActiveTabId] = useState(0);
 
-        Note that this component is stateless – its open state must be tracked externally.
-        See <NxCode>NxStatefulAccordion</NxCode> for a version which tracks its own open state.
-      </NxP>
-      <NxTile.Subsection>
-        <NxTile.SubsectionHeader>
-          <NxH3>NxAccordion</NxH3>
-        </NxTile.SubsectionHeader>
-        <NxTable>
-          <NxTable.Head>
-            <NxTable.Row>
-              <NxTable.Cell>Name</NxTable.Cell>
-              <NxTable.Cell>Type</NxTable.Cell>
-              <NxTable.Cell>Required</NxTable.Cell>
-              <NxTable.Cell>Description</NxTable.Cell>
-            </NxTable.Row>
-          </NxTable.Head>
-          <NxTable.Body>
-            <NxTable.Row>
-              <NxTable.Cell>onToggle</NxTable.Cell>
-              <NxTable.Cell>(() =&gt; void)</NxTable.Cell>
-              <NxTable.Cell>No</NxTable.Cell>
-              <NxTable.Cell>
-                A function which gets called when the accordion collapse/expand state is toggled.
+  return (
+    <>
+      <NxTabs activeTab={activeTabId} onTabSelect={setActiveTabId}>
+        <NxTabList aria-label="Table Component Examples">
+          <NxTab>Usage</NxTab>
+          <NxTab>Stateless Examples</NxTab>
+          <NxTab>Stateful Examples</NxTab>
+        </NxTabList>
+        <NxTabPanel>
+          <GalleryDescriptionTile>
+            <NxP>
+              NxAccordion renders a panel with an always-visible header and a collapsible/expandable body section.
+              This is analogous to the HTML 5 <NxCode>&lt;details&gt;</NxCode> element (which it is
+              implemented on top of). There are three related components: <NxCode>NxAccordion</NxCode> itself,
+              <NxCode>NxAccordion.Header</NxCode> which represents the header content, and
+              {' '}<NxCode>NxAccordion.Title</NxCode> which is a convenience component for the header title. All other
+              children of <NxCode>NxAccordion</NxCode> aside from
+              the <NxCode>Header</NxCode> and the <NxCode>Title</NxCode> are rendered in the collapsible section.
 
-                <NxInfoAlert>
-                  Deprecated behavior: the onToggle callback does actually get passed a value; it gets the
-                  presumed new value of the open state. However with the introduction of
-                  the <NxTextLink href="#/pages/useToggle">useToggle</NxTextLink> hook, that is of minimal
-                  value, so for the sake of API consistency the intent going forward is to treat this as a
-                  parameterless callback.
-                </NxInfoAlert>
-              </NxTable.Cell>
-            </NxTable.Row>
-            <NxTable.Row>
-              <NxTable.Cell>open</NxTable.Cell>
-              <NxTable.Cell>boolean</NxTable.Cell>
-              <NxTable.Cell>Yes</NxTable.Cell>
-              <NxTable.Cell>
-                Whether or not the accordion should be rendered "open" with its full content visible, as
-                opposed to collapsed.
-              </NxTable.Cell>
-            </NxTable.Row>
-            <NxTable.Row>
-              <NxTable.Cell>HTML <NxCode>&lt;details&gt;</NxCode> Attributes</NxTable.Cell>
-              <NxTable.Cell>
-                <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/details">
-                  HTML details Attributes
-                </NxTextLink>
-              </NxTable.Cell>
-              <NxTable.Cell>No</NxTable.Cell>
-              <NxTable.Cell>
-                NxAccordion supports any html attribute that's normally supported by the
-                {' '}<NxCode>&lt;details&gt;</NxCode> element
-              </NxTable.Cell>
-            </NxTable.Row>
-          </NxTable.Body>
-        </NxTable>
-      </NxTile.Subsection>
-      <NxTile.Subsection>
-        <NxTile.SubsectionHeader>
-          <NxH3>NxAccordion.Header</NxH3>
-        </NxTile.SubsectionHeader>
-        <NxP>
-          <NxCode>NxAccordion.Header</NxCode> can receive standard
-          HTML <NxCode>&lt;summary&gt;</NxCode> attributes.
-        </NxP>
-      </NxTile.Subsection>
-      <NxTile.Subsection>
-        <NxTile.SubsectionHeader>
-          <NxH3>NxAccordion.Title</NxH3>
-          <NxP>
-            First child of <NxCode>NxAccordion.Header</NxCode>.
-            It is expected that the first child of <NxCode>NxAccordion.Header</NxCode> will
-            always be an <NxCode>NxAccordion.Title</NxCode>.
-            It is a convenience component for <NxCode>&lt;h2&gt;</NxCode> with
-            the <NxCode>.nx-accordion__header-title</NxCode> class containing
-            the text content of the always-visible section of the accordion. Note
-            that <NxCode>NxAccordion</NxCode> is a{' '}
-            <NxTextLink external href="https://html.spec.whatwg.org/multipage/sections.html#sectioning-root">
-              sectioning root
-            </NxTextLink>
-            , so it does not matter whether this header is a lower-rank heading than that of its surrounding
-            section.
-          </NxP>
-        </NxTile.SubsectionHeader>
-      </NxTile.Subsection>
-      <NxTile.Subsection>
-        <NxTile.SubsectionHeader>
-          <NxH3>Helper Classes</NxH3>
-        </NxTile.SubsectionHeader>
-        <NxP>The following CSS classes are available for use on child elements.</NxP>
-        <NxTable>
-          <NxTable.Head>
-            <NxTable.Row>
-              <NxTable.Cell>Name</NxTable.Cell>
-              <NxTable.Cell>Location</NxTable.Cell>
-              <NxTable.Cell>Description</NxTable.Cell>
-            </NxTable.Row>
-          </NxTable.Head>
-          <NxTable.Body>
-            <NxTable.Row>
-              <NxTable.Cell><NxCode>nx-btn-bar</NxCode></NxTable.Cell>
-              <NxTable.Cell>Last child of <NxCode>NxAccordion.Header</NxCode></NxTable.Cell>
-              <NxTable.Cell>
-                <NxCode>NxAccordion.Header</NxCode> supports the inclusion of buttons on
-                its right-hand side. This is accomplished by adding
-                an <NxCode>.nx-btn-bar</NxCode> after
-                the <NxCode>NxAccordion.Title</NxCode>.
-              </NxTable.Cell>
-            </NxTable.Row>
-            <NxTable.Row>
-              <NxTable.Cell><NxCode>nx-h3</NxCode></NxTable.Cell>
-              <NxTable.Cell>Subheader within accordion body</NxTable.Cell>
-              <NxTable.Cell>
-                The contents of the accordion body may include subheaders which should
-                be <NxCode>&lt;h3&gt;</NxCode> elements with
-                the <NxCode>.nx-h3</NxCode> class.
-              </NxTable.Cell>
-            </NxTable.Row>
-          </NxTable.Body>
-        </NxTable>
-      </NxTile.Subsection>
-    </GalleryDescriptionTile>
+              Note that this component is stateless – its open state must be tracked externally.
+              See <NxCode>NxStatefulAccordion</NxCode> for a version which tracks its own open state.
+            </NxP>
+            <NxH3>Stateful Accordion</NxH3>
+            <NxP>
+              <NxCode>NxStatefulAccordion</NxCode> is a wrapper
+              around <NxCode>NxAccordion</NxCode> which tracks its own toggle state. It accepts
+              the same props as <NxCode>NxAccordion</NxCode>, except that instead
+              of <NxCode>open</NxCode>, it accepts <NxCode>defaultOpen</NxCode> which
+              provides the initial toggle state.
+            </NxP>
+            <NxH2>Guidelines</NxH2>
+            <NxH3>When to Use</NxH3>
+            <NxList bulleted>
+              <NxList.Item>Displaying and grouping additional information.</NxList.Item>
+              <NxList.Item>Adding granular control over the information on a given page.</NxList.Item>
+              <NxList.Item>Shortening pages to reduce scrolling.</NxList.Item>
+            </NxList>
+            <NxH3>When Not to Use</NxH3>
+            <NxList bulleted>
+              <NxList.Item>
+                Displaying critical system information or a primary action to be taken on the page. (for example,
+                <a href="/components/alert">alerts</a>, confirmation or cancellation buttons).
+              </NxList.Item>
+              <NxList.Item>
+                Displaying navigation elements such as <a href="/components/tabs">tabs</a>.
+              </NxList.Item>
+              <NxList.Item>
+                Displaying links pointing to sections of the same page, instead use a
+                <a href="/components/list">list</a>.
+              </NxList.Item>
+              <NxList.Item>
+                Creating hierarchy levels by nesting them within each other. If you need to add hierarchy to the
+                content use a <a href="/components/tree">tree</a>.
+              </NxList.Item>
+              <NxList.Item>
+                Displaying a set of visual components following the same style, prefer using Collapsable.(TODO: Add
+                link to collapsable).
+              </NxList.Item>
+            </NxList>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxAccordion</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Name</NxTable.Cell>
+                    <NxTable.Cell>Type</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Description</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell>onToggle</NxTable.Cell>
+                    <NxTable.Cell>(() =&gt; void)</NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      A function which gets called when the accordion collapse/expand state is toggled.
 
-    <GalleryExampleTile title="Simple Example"
-                        defaultCheckeredBackground={true}
-                        liveExample={NxAccordionSimpleExample}
-                        codeExamples={NxAccordionSimpleCode}>
-      A simple example of an <NxCode>NxAccordion</NxCode>.
-    </GalleryExampleTile>
+                      <NxInfoAlert>
+                        Deprecated behavior: the onToggle callback does actually get passed a value; it gets the
+                        presumed new value of the open state. However with the introduction of
+                        the <NxTextLink href="#/pages/useToggle">useToggle</NxTextLink> hook, that is of minimal
+                        value, so for the sake of API consistency the intent going forward is to treat this as a
+                        parameterless callback.
+                      </NxInfoAlert>
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>open</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>Yes</NxTable.Cell>
+                    <NxTable.Cell>
+                      Whether or not the accordion should be rendered "open" with its full content visible, as
+                      opposed to collapsed.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>HTML <NxCode>&lt;details&gt;</NxCode> Attributes</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/details">
+                        HTML details Attributes
+                      </NxTextLink>
+                    </NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      NxAccordion supports any html attribute that's normally supported by the
+                      {' '}<NxCode>&lt;details&gt;</NxCode> element
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxAccordion.Header</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                <NxCode>NxAccordion.Header</NxCode> can receive standard
+                HTML <NxCode>&lt;summary&gt;</NxCode> attributes.
+              </NxP>
+            </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxAccordion.Title</NxH3>
+                <NxP>
+                  First child of <NxCode>NxAccordion.Header</NxCode>.
+                  It is expected that the first child of <NxCode>NxAccordion.Header</NxCode> will
+                  always be an <NxCode>NxAccordion.Title</NxCode>.
+                  It is a convenience component for <NxCode>&lt;h2&gt;</NxCode> with
+                  the <NxCode>.nx-accordion__header-title</NxCode> class containing
+                  the text content of the always-visible section of the accordion. Note
+                  that <NxCode>NxAccordion</NxCode> is a{' '}
+                  <NxTextLink external href="https://html.spec.whatwg.org/multipage/sections.html#sectioning-root">
+                    sectioning root
+                  </NxTextLink>
+                  , so it does not matter whether this header is a lower-rank heading than that of its surrounding
+                  section.
+                </NxP>
+              </NxTile.SubsectionHeader>
+            </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>Helper Classes</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>The following CSS classes are available for use on child elements.</NxP>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Name</NxTable.Cell>
+                    <NxTable.Cell>Location</NxTable.Cell>
+                    <NxTable.Cell>Description</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell><NxCode>nx-btn-bar</NxCode></NxTable.Cell>
+                    <NxTable.Cell>Last child of <NxCode>NxAccordion.Header</NxCode></NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxCode>NxAccordion.Header</NxCode> supports the inclusion of buttons on
+                      its right-hand side. This is accomplished by adding
+                      an <NxCode>.nx-btn-bar</NxCode> after
+                      the <NxCode>NxAccordion.Title</NxCode>.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell><NxCode>nx-h3</NxCode></NxTable.Cell>
+                    <NxTable.Cell>Subheader within accordion body</NxTable.Cell>
+                    <NxTable.Cell>
+                      The contents of the accordion body may include subheaders which should
+                      be <NxCode>&lt;h3&gt;</NxCode> elements with
+                      the <NxCode>.nx-h3</NxCode> class.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
+          </GalleryDescriptionTile>
+        </NxTabPanel>
+        <NxTabPanel>
+          <GalleryExampleTile title="Simple Example"
+                              defaultCheckeredBackground={true}
+                              liveExample={NxAccordionSimpleExample}
+                              codeExamples={NxAccordionSimpleCode}
+                              collapseCodeExample>
+            A simple example of an <NxCode>NxAccordion</NxCode>.
+          </GalleryExampleTile>
 
-    <GalleryExampleTile title="Example with optional elements"
-                        id="nx-accordion-example"
-                        defaultCheckeredBackground={true}
-                        liveExample={NxAccordionComplexExample}
-                        codeExamples={NxAccordionComplexCode}>
-      A more complex <NxCode>NxAccordion</NxCode> including header buttons and a subheader.
-      This example also demonstrates that clicks on the header and buttons are handled correctly. Clicking a header
-      button does not cause the accordion to toggle, but clicking anywhere else on the header does, even including
-      places that have their own click handlers (e.g. the accordion title in this example). This example also
-      demonstrates that the header title uses ellipsis truncation to handle long content, while the subheader wraps.
-      Developers should however avoid creating titles and subheaders that are long enough to trigger these behaviors
-      when possible.
-    </GalleryExampleTile>
+          <GalleryExampleTile title="Example with optional elements"
+                              id="nx-accordion-example"
+                              defaultCheckeredBackground={true}
+                              liveExample={NxAccordionComplexExample}
+                              codeExamples={NxAccordionComplexCode}
+                              collapseCodeExample>
+            A more complex <NxCode>NxAccordion</NxCode> including header buttons and a subheader.
+            This example also demonstrates that clicks on the header and buttons are handled correctly. Clicking a
+            header
+            button does not cause the accordion to toggle, but clicking anywhere else on the header does, even including
+            places that have their own click handlers (e.g. the accordion title in this example). This example also
+            demonstrates that the header title uses ellipsis truncation to handle long content, while the subheader
+            wraps.
+            Developers should however avoid creating titles and subheaders that are long enough to trigger these
+            behaviors
+            when possible.
+          </GalleryExampleTile>
 
-    <GalleryExampleTile title="Example with tertiary button in header"
-                        id="nx-accordion-tertiary-button-example"
-                        defaultCheckeredBackground={true}
-                        liveExample={NxAccordionTertiaryButtonExample}
-                        codeExamples={NxAccordionTertiaryButtonCode}>
-      An <NxCode>NxAccordion</NxCode> which contains a tertiary button in the header. Note that the
-      height of this button causes the height of the entire header to grow slightly.
-    </GalleryExampleTile>
-  </>;
-
-export default NxAccordionPage;
+          <GalleryExampleTile title="Example with tertiary button in header"
+                              id="nx-accordion-tertiary-button-example"
+                              defaultCheckeredBackground={true}
+                              liveExample={NxAccordionTertiaryButtonExample}
+                              codeExamples={NxAccordionTertiaryButtonCode}
+                              collapseCodeExample>
+            An <NxCode>NxAccordion</NxCode> which contains a tertiary button in the header. Note that the
+            height of this button causes the height of the entire header to grow slightly.
+          </GalleryExampleTile>
+        </NxTabPanel>
+        <NxTabPanel>
+          <GalleryExampleTile title="Example"
+                              defaultCheckeredBackground={true}
+                              liveExample={NxStatefulAccordionExample}
+                              codeExamples={NxStatefulAccordionCode}
+                              collapseCodeExample>
+            A simple example of an <NxCode>NxStatefulAccordion</NxCode> that is initially open.
+          </GalleryExampleTile>
+        </NxTabPanel>
+      </NxTabs>
+    </>
+  );
+}

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -32,6 +32,13 @@ import NxTableFilterExample from './NxTableFilterExample';
 import NxTablePaginationExample from './NxTablePaginationExample';
 import NxTablePaginationFilterExample from './NxTablePaginationFilterExample';
 
+import NxTableClickableExampleHTML from '../../styles/NxTable/NxTableClickableExample';
+import NxTableIconButtonExampleHTML from '../../styles/NxTable/NxTableIconButtonExample';
+import NxTableErrorExampleHTML from '../../styles/NxTable/NxTableErrorStateExample';
+import NxTableFixedLayoutExampleHTML from '../../styles/NxTable/NxTableFixedLayoutExample';
+import NxTableSortableExampleHTML from '../../styles/NxTable/NxTableSortableExample';
+import NxTableFilterExampleHTML from '../../styles/NxTable/NxTableFilterExample';
+
 const tableSimpleExampleCode = require('./NxTableSimpleExample?raw');
 const tableClickableExample = require('./NxTableClickableExample?raw');
 const tableClickableCustomExample = require('./NxTableClickableCustomExample?raw');
@@ -48,6 +55,30 @@ const tableMetaInfoExample = require('./NxTableMetaInfoExample?raw');
 
 import './NxTablePaginationExample.scss';
 import './NxTablePaginationFilterExample.scss';
+
+import '../../styles/NxTable/NxTableTruncationAndWrappingExample.scss';
+import '../../styles/NxTable/NxTableFixedLayoutExample.scss';
+
+const NxTableSimpleCode = require('../../styles/NxTable/NxTableDefaultExample.html'),
+    NxTableClickableCode = require('../../styles/NxTable/NxTableClickableExample?raw'),
+    NxTableIconButtonCode = require('../../styles/NxTable/NxTableIconButtonExample?raw'),
+    NxTableEmptyCode = require('../../styles/NxTable/NxTableEmptyExample.html'),
+    NxTableErrorStateCode = require('../../styles/NxTable/NxTableErrorStateExample?raw'),
+    NxTableTruncationAndWrappingCode = require('../../styles/NxTable/NxTableTruncationAndWrappingExample.html'),
+    NxTableFixedLayoutCode = require('../../styles/NxTable/NxTableFixedLayoutExample?raw'),
+    NxTableTruncationAndWrappingScss = require('../../styles/NxTable/NxTableTruncationAndWrappingExample.scss?raw'),
+    NxTableFixedLayoutScss = require('../../styles/NxTable/NxTableFixedLayoutExample.scss?raw'),
+    NxTableFilterCode = require('../../styles/NxTable/NxTableFilterExample?raw'),
+    NxTableSortableCode = require('../../styles/NxTable/NxTableSortableExample?raw');
+
+const truncationAndWrappingCodeExamples = [
+      NxTableTruncationAndWrappingCode,
+      { content: NxTableTruncationAndWrappingScss, language: 'scss'}
+    ],
+    fixedLayoutCodeExamples = [
+      NxTableFixedLayoutCode,
+      { content: NxTableFixedLayoutScss, language: 'scss'}
+    ];
 
 const paginationCodeExamples = [
       tablePaginationExample,
@@ -67,7 +98,7 @@ export default function NxTablePage() {
         <NxTabList aria-label="Table Component Examples">
           <NxTab>Usage</NxTab>
           <NxTab>React Examples</NxTab>
-          <NxTab>HTML Only Example</NxTab>
+          <NxTab>HTML Examples</NxTab>
         </NxTabList>
 
         <NxTabPanel>
@@ -460,14 +491,11 @@ export default function NxTablePage() {
               </NxTile.SubsectionHeader>
               <NxP>
                 As seen above, the various child components of <NxCode>NxTable</NxCode> are attached as properties on
-                the
-                <NxCode>NxTable</NxCode> object and typically accessed using JavaScript dot notation. In previous
-                versions
-                of RSC, this was not the case and the subobjects were instead exposed as top level exports with names
-                along
-                the lines of <NxCode>NxTable.Row</NxCode>, <NxCode>NxTable.Cell</NxCode>, and so on. These old names are
-                still exported by RSC for backwards compatibility, but are deprecated and may be removed in a future
-                major version release.
+                the <NxCode>NxTable</NxCode> object and typically accessed using JavaScript dot notation. In previous
+                versions of RSC, this was not the case and the subobjects were instead exposed as top level exports
+                with names along the lines of <NxCode>NxTable.Row</NxCode>, <NxCode>NxTable.Cell</NxCode>, and so on.
+                These old names are still exported by RSC for backwards compatibility, but are deprecated and may be
+                removed in a future major version release.
               </NxP>
             </NxTile.Subsection>
 
@@ -540,21 +568,24 @@ export default function NxTablePage() {
 
           <GalleryExampleTile title="Simple Example"
                               liveExample={NxTableSimpleExample}
-                              codeExamples={tableSimpleExampleCode}>
+                              codeExamples={tableSimpleExampleCode}
+                              collapseCodeExample>
             A basic example of <NxCode>NxTable</NxCode>.
           </GalleryExampleTile>
 
           <GalleryExampleTile title="Clickable Row Example"
                               id="nx-table-clickable-example"
                               liveExample={NxTableClickableExample}
-                              codeExamples={tableClickableExample}>
+                              codeExamples={tableClickableExample}
+                              collapseCodeExample>
             An example where the rows are styled to indicate that they are clickable.
           </GalleryExampleTile>
 
           <GalleryExampleTile title="Clickable Row Custom Icon Example"
                               id="nx-table-clickable-custom-example"
                               liveExample={NxTableClickableCustomExample}
-                              codeExamples={tableClickableCustomExample}>
+                              codeExamples={tableClickableCustomExample}
+                              collapseCodeExample>
             An example where the rows are styled to indicate that they are clickable, using a custom icon rather than
             the typical right-facing chevron.
           </GalleryExampleTile>
@@ -562,14 +593,16 @@ export default function NxTablePage() {
           <GalleryExampleTile title="Sortable Columns Example"
                               id="nx-table-sortable-example"
                               liveExample={NxTableSortableExample}
-                              codeExamples={tableSortableExample}>
+                              codeExamples={tableSortableExample}
+                              collapseCodeExample>
             An example with a sortable column.
           </GalleryExampleTile>
 
           <GalleryExampleTile title="Filter Columns Example"
                               id="nx-table-filter-example"
                               liveExample={NxTableFilterExample}
-                              codeExamples={tableFilterExample}>
+                              codeExamples={tableFilterExample}
+                              collapseCodeExample>
             An example with filter columns.
             The first column has a basic filter input, the rows will be filtered
             if any name contains the text provided in the input.
@@ -580,7 +613,8 @@ export default function NxTablePage() {
           <GalleryExampleTile title="Pagination Example"
                               id="nx-table-pagination-example"
                               liveExample={NxTablePaginationExample}
-                              codeExamples={paginationCodeExamples}>
+                              codeExamples={paginationCodeExamples}
+                              collapseCodeExample>
             An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
             paging.
           </GalleryExampleTile>
@@ -588,7 +622,8 @@ export default function NxTablePage() {
           <GalleryExampleTile title="Pagination and Filtering Example"
                               id="nx-table-pagination-filter-example"
                               liveExample={NxTablePaginationFilterExample}
-                              codeExamples={paginationFilterCodeExamples}>
+                              codeExamples={paginationFilterCodeExamples}
+                              collapseCodeExample>
             An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
             paging as well as a row of filter headers. Demonstrates the use of
             the <NxCode>pagination-table-height</NxCode> SCSS function when a filter row is present.
@@ -597,29 +632,115 @@ export default function NxTablePage() {
           <GalleryExampleTile title="Loading Example"
                               id="nx-table-loading-example"
                               liveExample={NxTableLoadingExample}
-                              codeExamples={tableLoadingExample}>
+                              codeExamples={tableLoadingExample}
+                              collapseCodeExample>
             An example of how <NxCode>NxTable</NxCode> should be used while its data is loading.
           </GalleryExampleTile>
 
           <GalleryExampleTile title="Error Example"
                               id="nx-table-error-example"
                               liveExample={NxTableErrorExample}
-                              codeExamples={tableErrorExample}>
+                              codeExamples={tableErrorExample}
+                              collapseCodeExample>
             An example of how <NxCode>NxTable</NxCode> should be used to indicate that there was an error
             loading its data.
           </GalleryExampleTile>
 
           <GalleryExampleTile title="Empty Example"
                               liveExample={NxTableEmptyExample}
-                              codeExamples={tableEmptyExample}>
+                              codeExamples={tableEmptyExample}
+                              collapseCodeExample>
             An example of how <NxCode>NxTable</NxCode> should be used to indicate that there is no data
             to be seen.
           </GalleryExampleTile>
 
           <GalleryExampleTile title="Custom Meta-Info Example"
                               liveExample={NxTableMetaInfoExample}
-                              codeExamples={tableMetaInfoExample}>
+                              codeExamples={tableMetaInfoExample}
+                              collapseCodeExample>
             An example of how <NxCode>NxTable</NxCode> should be used with a custom meta-info situation.
+          </GalleryExampleTile>
+        </NxTabPanel>
+        <NxTabPanel>
+          <GalleryExampleTile title="NX Table Simple Example"
+                              htmlExample={NxTableSimpleCode}
+                              codeExamples={NxTableSimpleCode}
+                              collapseCodeExample>
+            A simple, static demonstration of <NxCode>nx-table</NxCode> styles.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table Truncation and Wrapping Example"
+                              id="nx-table-truncation-wrapping-example"
+                              htmlExample={NxTableTruncationAndWrappingCode}
+                              codeExamples={truncationAndWrappingCodeExamples}
+                              collapseCodeExample>
+            A demonstration of text truncation and wrapping within table cells. The first column truncates, while the
+            second wraps. Notice that wrapping is the default behavior. Truncation requires an extra element within the
+            table cell, which must have an explicit width.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table with Clickable Rows Example"
+                              liveExample={NxTableClickableExampleHTML}
+                              codeExamples={NxTableClickableCode}
+                              collapseCodeExample>
+            A demonstration of an <NxCode>nx-table</NxCode> with rows that receive clickable styling and
+            a chevron column.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table Fixed Layout Example"
+                              id="nx-table-fixed-layout-example"
+                              liveExample={NxTableFixedLayoutExampleHTML}
+                              codeExamples={fixedLayoutCodeExamples}
+                              collapseCodeExample>
+            This example demonstrates the nx-table--fixed-layout class which is typically used in conjunction with
+            a custom class to explicitly set the widths of table rows. Notice here that the implementation of a
+            truncated column is simpler: the inner <NxCode>div</NxCode> is not necessary and instead
+            the <NxCode>.nx-truncate-ellipsis</NxCode> class can be applied directly to the table cell.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table Empty Example"
+                              htmlExample={NxTableEmptyCode}
+                              codeExamples={NxTableEmptyCode}
+                              collapseCodeExample>
+            A demonstration of the expected styling and content of an empty <NxCode>nx-table</NxCode>.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table with Error Message Example"
+                              liveExample={NxTableErrorExampleHTML}
+                              codeExamples={NxTableErrorStateCode}
+                              collapseCodeExample>
+            A demonstration of the expected styling and content and an <NxCode>nx-table</NxCode> whose
+            contents failed to load.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table with Sortable Rows Example"
+                              liveExample={NxTableSortableExampleHTML}
+                              codeExamples={NxTableSortableCode}
+                              collapseCodeExample>
+            A demonstration of a <NxCode>nx-table</NxCode> used for columns that can be sorted.
+            In this example the interactivity to sort columns is not wired up. Note
+            the <NxCode>&lt;button&gt;</NxCode> surrounding the sort header contents.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table with Filter Rows Example"
+                              liveExample={NxTableFilterExampleHTML}
+                              codeExamples={NxTableFilterCode}
+                              collapseCodeExample>
+            A demonstration of a <NxCode>nx-table</NxCode> with a header
+            cell that contains a filter. Rows can be filtered depending on the text provided in the input.
+            In this example the interactivity to filter content is not wired up. Note
+            the <NxCode>&lt;button&gt;</NxCode> surrounding the chevron cell contents.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="NX Table with Icon Buttons Example"
+                              id="nx-table-icon-buttons-example"
+                              liveExample={NxTableIconButtonExampleHTML}
+                              codeExamples={NxTableIconButtonCode}
+                              collapseCodeExample>
+            A demonstration of an <NxCode>nx-table</NxCode> with icon-only buttons and an icon-only dropdown in both the
+            filter row and the content rows. Note that the buttons in the filter row are the standard height while the
+            buttons in the content rows are smaller. The default styles only support these sorts of buttons in the
+            rightmost column.
           </GalleryExampleTile>
         </NxTabPanel>
       </NxTabs>

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -50,10 +50,82 @@ const paginationCodeExamples = [
 export default function NxTablePage() {
   return (
     <>
-      <GalleryDescriptionTile>
-        <NxP>
-          A set of React components which encapsulate and assist with the styles for HTML tables.
-        </NxP>
+      <NxTabs activeTab={activeTabId} onTabSelect={setActiveTabId}>
+        <NxTabList aria-label="Table Component Examples">
+          <NxTab>Usage</NxTab>
+          <NxTab>React Examples</NxTab>
+          <NxTab>HTML Only Example</NxTab>
+        </NxTabList>
+        <NxTabPanel>
+          <GalleryDescriptionTile>
+            <NxP>
+              A React component and basic HTML styles are availble which encapsulate and assist with the styles for HTML
+              tables.
+            </NxP>
+            <NxP>
+              For guidance on the construction of a scrolling table, see the scrolling example on
+              the <NxCode>nx-table-container</NxCode> HTML element page.
+            </NxP>
+            <h2 className="nx-h2">Guidelines</h2>
+            <h3 className="nx-h3"> When to use:</h3>
+            <ul className="nx-list nx-list--bulleted">
+              <li className="nx-list__item">convenience store shrine beef noodles fluidity boy voodoo god</li>
+              <li className="nx-list__item">human knife skyscraper paranoid nodal point</li>
+              <li className="nx-list__item">Shibuya sentient corporation rifle</li>
+            </ul>
+            <h3 className="nx-h3">When not to use:</h3>
+            <ul className="nx-list nx-list--bulleted">
+              <li className="nx-list__item">
+                urban boat hotdog dead. systema rain shrine tattoo bomb BASE jump human
+              </li>
+              <li className="nx-list__item">
+                stimulate industrial grade woman systemic footage media sensory.
+              </li>
+              <li className="nx-list__item">
+                office computer papier-mache -space range-rover uplink dead.
+              </li>
+              <li className="nx-list__item">
+                city sign plastic gang math- wristwatch industrial grade
+              </li>
+              <li className="nx-list__item">
+                film drone advert tank-traps DIY monofilament industrial grade. office car kanji cartel monofilament
+              </li>
+            </ul>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxTable Props and Classes</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                The top-level component to use when displaying tables of data.
+                It can have <NxCode>NxTable.Head</NxCode> and
+                {' '}<NxCode>NxTable.Body</NxCode> components as children.
+              </NxP>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Prop</NxTable.Cell>
+                    <NxTable.Cell>Type</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Details</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell>HTML <NxCode>&lt;table&gt;</NxCode> Attributes</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/table">
+                        HTML table Attributes
+                      </NxTextLink>
+                    </NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxCode>NxTable</NxCode> supports any HTML attribute that's normally
+                      supported by <NxCode>&lt;table&gt;</NxCode>.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
 
         <NxTile.Subsection>
           <NxTile.SubsectionHeader>

--- a/gallery/src/components/NxTable/NxTablePage.tsx
+++ b/gallery/src/components/NxTable/NxTablePage.tsx
@@ -4,8 +4,19 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React from 'react';
-import { NxTable, NxTile, NxH3, NxP, NxCode, NxTextLink } from '@sonatype/react-shared-components';
+import React, {useState} from 'react';
+import {
+  NxTable,
+  NxTile,
+  NxH3,
+  NxP,
+  NxCode,
+  NxTextLink,
+  NxTabs,
+  NxTabList,
+  NxTab,
+  NxTabPanel
+} from '@sonatype/react-shared-components';
 
 import {GalleryDescriptionTile, GalleryExampleTile} from '../../gallery-components/GalleryTiles';
 
@@ -48,6 +59,8 @@ const paginationCodeExamples = [
     ];
 
 export default function NxTablePage() {
+  const [activeTabId, setActiveTabId] = useState(0);
+
   return (
     <>
       <NxTabs activeTab={activeTabId} onTabSelect={setActiveTabId}>
@@ -56,6 +69,7 @@ export default function NxTablePage() {
           <NxTab>React Examples</NxTab>
           <NxTab>HTML Only Example</NxTab>
         </NxTabList>
+
         <NxTabPanel>
           <GalleryDescriptionTile>
             <NxP>
@@ -127,479 +141,488 @@ export default function NxTablePage() {
               </NxTable>
             </NxTile.Subsection>
 
-        <NxTile.Subsection>
-          <NxTile.SubsectionHeader>
-            <NxH3>NxTable</NxH3>
-          </NxTile.SubsectionHeader>
-          <NxP>
-            The top-level component to use when displaying tables of data.
-            It can have <NxCode>NxTable.Head</NxCode> and
-            {' '}<NxCode>NxTable.Body</NxCode> components as children.
-          </NxP>
-          <NxTable>
-            <NxTable.Head>
-              <NxTable.Row>
-                <NxTable.Cell>Prop</NxTable.Cell>
-                <NxTable.Cell>Type</NxTable.Cell>
-                <NxTable.Cell>Required</NxTable.Cell>
-                <NxTable.Cell>Details</NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Head>
-            <NxTable.Body>
-              <NxTable.Row>
-                <NxTable.Cell>HTML <NxCode>&lt;table&gt;</NxCode> Attributes</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/table">
-                    HTML table Attributes
-                  </NxTextLink>
-                </NxTable.Cell>
-                <NxTable.Cell>No</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxCode>NxTable</NxCode> supports any HTML attribute that's normally
-                  supported by <NxCode>&lt;table&gt;</NxCode>.
-                </NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Body>
-          </NxTable>
-        </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxTable</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                The top-level component to use when displaying tables of data.
+                It can have <NxCode>NxTable.Head</NxCode> and
+                {' '}<NxCode>NxTable.Body</NxCode> components as children.
+              </NxP>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Prop</NxTable.Cell>
+                    <NxTable.Cell>Type</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Details</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell>HTML <NxCode>&lt;table&gt;</NxCode> Attributes</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/table">
+                        HTML table Attributes
+                      </NxTextLink>
+                    </NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxCode>NxTable</NxCode> supports any HTML attribute that's normally
+                      supported by <NxCode>&lt;table&gt;</NxCode>.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
 
-        <NxTile.Subsection>
-          <NxTile.SubsectionHeader>
-            <NxH3>NxTable.Head</NxH3>
-          </NxTile.SubsectionHeader>
-          <NxP>
-            Equivalent to the <NxCode>&lt;thead&gt;</NxCode> element.
-            The <NxCode>NxTable.Row</NxCode> component is the only valid child.
-          </NxP>
-          <NxTable>
-            <NxTable.Head>
-              <NxTable.Row>
-                <NxTable.Cell>Prop</NxTable.Cell>
-                <NxTable.Cell>Type</NxTable.Cell>
-                <NxTable.Cell>Required</NxTable.Cell>
-                <NxTable.Cell>Details</NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Head>
-            <NxTable.Body>
-              <NxTable.Row>
-                <NxTable.Cell>HTML <NxCode>&lt;thead&gt;</NxCode> Attributes</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/thead">
-                    HTML thead Attributes
-                  </NxTextLink>
-                </NxTable.Cell>
-                <NxTable.Cell>No</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxCode>NxTable.Head</NxCode> supports any HTML attribute that's normally
-                  supported by <NxCode>&lt;thead&gt;</NxCode>.
-                </NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Body>
-          </NxTable>
-        </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxTable.Head</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                Equivalent to the <NxCode>&lt;thead&gt;</NxCode> element.
+                The <NxCode>NxTable.Row</NxCode> component is the only valid child.
+              </NxP>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Prop</NxTable.Cell>
+                    <NxTable.Cell>Type</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Details</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell>HTML <NxCode>&lt;thead&gt;</NxCode> Attributes</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/thead">
+                        HTML thead Attributes
+                      </NxTextLink>
+                    </NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxCode>NxTable.Head</NxCode> supports any HTML attribute that's normally
+                      supported by <NxCode>&lt;thead&gt;</NxCode>.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
 
-        <NxTile.Subsection>
-          <NxTile.SubsectionHeader>
-            <NxH3>NxTable.Body</NxH3>
-          </NxTile.SubsectionHeader>
-          <NxP>
-            Equivalent to the <NxCode>&lt;tbody&gt;</NxCode> element.
-            It should have <NxCode>NxTable.Row</NxCode> for children.
-          </NxP>
-          <NxTable>
-            <NxTable.Head>
-              <NxTable.Row>
-                <NxTable.Cell>Prop</NxTable.Cell>
-                <NxTable.Cell>Type</NxTable.Cell>
-                <NxTable.Cell>Required</NxTable.Cell>
-                <NxTable.Cell>Details</NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Head>
-            <NxTable.Body>
-              <NxTable.Row>
-                <NxTable.Cell>isLoading</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>Used to show a loading spinner instead of the table content</NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>error</NxTable.Cell>
-                <NxTable.Cell>string</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>Used to show an error message instead of the table content</NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>retryHandler</NxTable.Cell>
-                <NxTable.Cell>Function</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  Used to provide the handler for the Retry button that appears when the error state is active.
-                  Required when <NxCode>error</NxCode> is present.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>emptyMessage</NxTable.Cell>
-                <NxTable.Cell>string</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  Used to show a message when the table is otherwise empty (i.e. when it has no externally specified
-                  child rows, is not loading, and is not in an error state. This prop must be specified if the
-                  table is empty. If this table is not empty, this prop may be specified, having no effect.
-                  In essence, the best practice is to specify this prop on all tables which <em>may</em> be empty.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>HTML <NxCode>&lt;tbody&gt;</NxCode> Attributes</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tbody">
-                    HTML tbody Attributes
-                  </NxTextLink>
-                </NxTable.Cell>
-                <NxTable.Cell>No</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxCode>NxTable.Body</NxCode> supports any HTML attribute that's normally
-                  supported by <NxCode>&lt;tbody&gt;</NxCode>.
-                </NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Body>
-          </NxTable>
-        </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxTable.Body</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                Equivalent to the <NxCode>&lt;tbody&gt;</NxCode> element.
+                It should have <NxCode>NxTable.Row</NxCode> for children.
+              </NxP>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Prop</NxTable.Cell>
+                    <NxTable.Cell>Type</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Details</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell>isLoading</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>Used to show a loading spinner instead of the table content</NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>error</NxTable.Cell>
+                    <NxTable.Cell>string</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>Used to show an error message instead of the table content</NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>retryHandler</NxTable.Cell>
+                    <NxTable.Cell>Function</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      Used to provide the handler for the Retry button that appears when the error state is active.
+                      Required when <NxCode>error</NxCode> is present.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>emptyMessage</NxTable.Cell>
+                    <NxTable.Cell>string</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      Used to show a message when the table is otherwise empty (i.e. when it has no externally specified
+                      child rows, is not loading, and is not in an error state. This prop must be specified if the
+                      table is empty. If this table is not empty, this prop may be specified, having no effect.
+                      In essence, the best practice is to specify this prop on all tables which <em>may</em> be empty.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>HTML <NxCode>&lt;tbody&gt;</NxCode> Attributes</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tbody">
+                        HTML tbody Attributes
+                      </NxTextLink>
+                    </NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxCode>NxTable.Body</NxCode> supports any HTML attribute that's normally
+                      supported by <NxCode>&lt;tbody&gt;</NxCode>.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
 
-        <NxTile.Subsection>
-          <NxTile.SubsectionHeader>
-            <NxH3>NxTable.Row</NxH3>
-          </NxTile.SubsectionHeader>
-          <NxP>
-            Equivalent to the <NxCode>&lt;tr&gt;</NxCode> element.
-            It should have <NxCode>NxTable.Cell</NxCode> for children.
-          </NxP>
-          <NxTable>
-            <NxTable.Head>
-              <NxTable.Row>
-                <NxTable.Cell>Prop</NxTable.Cell>
-                <NxTable.Cell>Type</NxTable.Cell>
-                <NxTable.Cell>Required</NxTable.Cell>
-                <NxTable.Cell>Details</NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Head>
-            <NxTable.Body>
-              <NxTable.Row>
-                <NxTable.Cell>isClickable</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>Indicates that a table row is clickable.</NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>isFilterHeader</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>Indicates that this row is a table header row containing filter inputs.</NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>selected</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  For clickable table rows, indicates that this row is the currently selected one.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>clickAccessibleLabel</NxTable.Cell>
-                <NxTable.Cell>string</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  The accessible name to set on the click target for this row – i.e. the value to read out in a
-                  screenreader when the row (the icon button at the end, really) is focused. If not specified, the
-                  full text content of all cells in the row will be used as the label.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>HTML <NxCode>&lt;tr&gt;</NxCode> Attributes</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tr">
-                    HTML tr Attributes
-                  </NxTextLink>
-                </NxTable.Cell>
-                <NxTable.Cell>No</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxCode>NxTable.Row</NxCode> supports any HTML attribute that's normally
-                  supported by <NxCode>&lt;tr&gt;</NxCode>.
-                </NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Body>
-          </NxTable>
-        </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxTable.Row</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                Equivalent to the <NxCode>&lt;tr&gt;</NxCode> element.
+                It should have <NxCode>NxTable.Cell</NxCode> for children.
+              </NxP>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Prop</NxTable.Cell>
+                    <NxTable.Cell>Type</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Details</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell>isClickable</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>Indicates that a table row is clickable.</NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>isFilterHeader</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>Indicates that this row is a table header row containing filter inputs.</NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>selected</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      For clickable table rows, indicates that this row is the currently selected one.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>clickAccessibleLabel</NxTable.Cell>
+                    <NxTable.Cell>string</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      The accessible name to set on the click target for this row – i.e. the value to read out in a
+                      screenreader when the row (the icon button at the end, really) is focused. If not specified, the
+                      full text content of all cells in the row will be used as the label.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>HTML <NxCode>&lt;tr&gt;</NxCode> Attributes</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/tr">
+                        HTML tr Attributes
+                      </NxTextLink>
+                    </NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxCode>NxTable.Row</NxCode> supports any HTML attribute that's normally
+                      supported by <NxCode>&lt;tr&gt;</NxCode>.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
 
-        <NxTile.Subsection>
-          <NxTile.SubsectionHeader>
-            <NxH3>NxTable.Cell</NxH3>
-          </NxTile.SubsectionHeader>
-          <NxP>
-            Equivalent to the <NxCode>&lt;th&gt;</NxCode> or
-            {' '}<NxCode>&lt;td&gt;</NxCode> element.
-          </NxP>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>NxTable.Cell</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                Equivalent to the <NxCode>&lt;th&gt;</NxCode> or
+                {' '}<NxCode>&lt;td&gt;</NxCode> element.
+              </NxP>
 
-          <NxTable>
-            <NxTable.Head>
-              <NxTable.Row>
-                <NxTable.Cell>Prop</NxTable.Cell>
-                <NxTable.Cell>Type</NxTable.Cell>
-                <NxTable.Cell>Required</NxTable.Cell>
-                <NxTable.Cell>Details</NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Head>
-            <NxTable.Body>
-              <NxTable.Row>
-                <NxTable.Cell>metaInfo</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  Sets the <NxCode>.nx-cell--meta-info</NxCode> class on the cell. This class is
-                  applied to table cells that provide meta-information about the table data, such as loading, error,
-                  and empty table states. For those three states, the caller of
-                  the <NxCode>NxTable</NxCode> react component does not manage the table cells
-                  directly (instead using the appropriate props on <NxCode>NxTable.Body</NxCode>), and
-                  therefore does not need to use this prop. However, the prop is available for any
-                  other meta-info states that the caller might wish to convey. The intended usage is that a cell
-                  using this prop would be the only cell in the only row in the table body, and would have
-                  a <NxCode>colspan</NxCode> attribute causing it to span all the way across the
-                  table.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>isNumeric</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>Used for columns that contain numeric information</NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>isSortable</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  Used for column headers that can be sorted. Should not be applied to data cells
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>sortDir</NxTable.Cell>
-                <NxTable.Cell style={{whiteSpace: 'nowrap'}}>asc | desc</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  Used to indicate the sorting direction applied.
-                  A null value indicates the column is not yet sorted.
-                  This should only be used for <NxCode>NxTable.Cell</NxCode> components
-                  in the <NxCode>NxTable.Head</NxCode>
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>hasIcon</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  Used to indicate a column whose data cells contain only one or
-                  more <NxCode>NxFontAwesomeIcon</NxCode>s
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>rowBtnIcon</NxTable.Cell>
-                <NxTable.Cell>FontAwesome Icon Descriptor</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  Desginates a cell that should contain only the the specified icon. This is to be used at that end of
-                  clickable table rows. <NxCode>NxTable.Cell</NxCode>s with this prop set will
-                  self-populate with the icon, and do not take <NxCode>children</NxCode>. The icon
-                  will be wrapped in a button for accessibility purposes, with the button's accessible name set by
-                  the row's <NxCode>clickAccessibleLabel</NxCode> prop or generated from the text contents of the
-                  rest of the row.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>chevron</NxTable.Cell>
-                <NxTable.Cell>boolean</NxTable.Cell>
-                <NxTable.Cell>false</NxTable.Cell>
-                <NxTable.Cell>
-                  An alternative to <NxCode>rowBtnIcon</NxCode> for the most common clickable row icon: the
-                  right-facing chevron. This is provided for convenience and backwards compatibility. If set
-                  simultaneously with <NxCode>rowBtnIcon</NxCode>, that prop takes precedence.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell>HTML <NxCode>&lt;td&gt;</NxCode> Attributes</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/td">
-                    HTML td Attributes
-                  </NxTextLink>
-                </NxTable.Cell>
-                <NxTable.Cell>No</NxTable.Cell>
-                <NxTable.Cell>
-                  <NxCode>NxTable.Cell</NxCode> supports any HTML attribute that's normally
-                  supported by <NxCode>&lt;td&gt;</NxCode>.
-                </NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Body>
-          </NxTable>
-        </NxTile.Subsection>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Prop</NxTable.Cell>
+                    <NxTable.Cell>Type</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Details</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell>metaInfo</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      Sets the <NxCode>.nx-cell--meta-info</NxCode> class on the cell. This class is
+                      applied to table cells that provide meta-information about the table data, such as loading, error,
+                      and empty table states. For those three states, the caller of
+                      the <NxCode>NxTable</NxCode> react component does not manage the table cells
+                      directly (instead using the appropriate props on <NxCode>NxTable.Body</NxCode>), and
+                      therefore does not need to use this prop. However, the prop is available for any
+                      other meta-info states that the caller might wish to convey. The intended usage is that a cell
+                      using this prop would be the only cell in the only row in the table body, and would have
+                      a <NxCode>colspan</NxCode> attribute causing it to span all the way across the
+                      table.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>isNumeric</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>Used for columns that contain numeric information</NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>isSortable</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      Used for column headers that can be sorted. Should not be applied to data cells
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>sortDir</NxTable.Cell>
+                    <NxTable.Cell style={{whiteSpace: 'nowrap'}}>asc | desc</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      Used to indicate the sorting direction applied.
+                      A null value indicates the column is not yet sorted.
+                      This should only be used for <NxCode>NxTable.Cell</NxCode> components
+                      in the <NxCode>NxTable.Head</NxCode>
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>hasIcon</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      Used to indicate a column whose data cells contain only one or
+                      more <NxCode>NxFontAwesomeIcon</NxCode>s
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>rowBtnIcon</NxTable.Cell>
+                    <NxTable.Cell>FontAwesome Icon Descriptor</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      Desginates a cell that should contain only the the specified icon. This is to be used at that end
+                      of clickable table rows. <NxCode>NxTable.Cell</NxCode>s with this prop set will
+                      self-populate with the icon, and do not take <NxCode>children</NxCode>. The icon
+                      will be wrapped in a button for accessibility purposes, with the button's accessible name set by
+                      the row's <NxCode>clickAccessibleLabel</NxCode> prop or generated from the text contents of the
+                      rest of the row.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>chevron</NxTable.Cell>
+                    <NxTable.Cell>boolean</NxTable.Cell>
+                    <NxTable.Cell>false</NxTable.Cell>
+                    <NxTable.Cell>
+                      An alternative to <NxCode>rowBtnIcon</NxCode> for the most common clickable row icon: the
+                      right-facing chevron. This is provided for convenience and backwards compatibility. If set
+                      simultaneously with <NxCode>rowBtnIcon</NxCode>, that prop takes precedence.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell>HTML <NxCode>&lt;td&gt;</NxCode> Attributes</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxTextLink external href="https://developer.mozilla.org/en/docs/Web/HTML/Element/td">
+                        HTML td Attributes
+                      </NxTextLink>
+                    </NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>
+                      <NxCode>NxTable.Cell</NxCode> supports any HTML attribute that's normally
+                      supported by <NxCode>&lt;td&gt;</NxCode>.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
 
-        <NxTile.Subsection>
-          <NxTile.SubsectionHeader>
-            <NxH3>Deprecated Component Names</NxH3>
-          </NxTile.SubsectionHeader>
-          <NxP>
-            As seen above, the various child components of <NxCode>NxTable</NxCode> are attached as properties on the
-            <NxCode>NxTable</NxCode> object and typically accessed using JavaScript dot notation. In previous versions
-            of RSC, this was not the case and the subobjects were instead exposed as top level exports with names along
-            the lines of <NxCode>NxTable.Row</NxCode>, <NxCode>NxTable.Cell</NxCode>, and so on. These old names are
-            still exported by RSC for backwards compatibility, but are deprecated and may be removed in a future major
-            version release.
-          </NxP>
-        </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>Deprecated Component Names</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                As seen above, the various child components of <NxCode>NxTable</NxCode> are attached as properties on
+                the
+                <NxCode>NxTable</NxCode> object and typically accessed using JavaScript dot notation. In previous
+                versions
+                of RSC, this was not the case and the subobjects were instead exposed as top level exports with names
+                along
+                the lines of <NxCode>NxTable.Row</NxCode>, <NxCode>NxTable.Cell</NxCode>, and so on. These old names are
+                still exported by RSC for backwards compatibility, but are deprecated and may be removed in a future
+                major version release.
+              </NxP>
+            </NxTile.Subsection>
 
-        <NxTile.Subsection>
-          <NxTile.SubsectionHeader>
-            <NxH3>SCSS Helper Functions</NxH3>
-          </NxTile.SubsectionHeader>
-          <NxP>
-            When constructing a table of paginated data, it is often the case that the table is intended to be exactly
-            tall enough to contain one full page's worth of rows, even when on the last page, which may contain fewer
-            rows. Achieving this effect requires setting an explicit height on the table container element that is
-            equal to the height that it would implicitly get when full. Calculating this height however is
-            somewhat complex, requiring summing up the heights of the various table elements in play. Therefore
-            RSC provides a SCSS helper function which will return the height of
-            the <NxCode>.nx-table-container</NxCode>'s content box for a paginated table with the
-            given parameters. The function, located in
-            the <NxCode>scss-shared/_nx-table-helpers.scss</NxCode> file, is named
-            <NxCode>pagination-table-height</NxCode>. See the description of its parameters below.
-          </NxP>
-          <NxTable>
-            <NxTable.Head>
-              <NxTable.Row>
-                <NxTable.Cell>Name</NxTable.Cell>
-                <NxTable.Cell>Required</NxTable.Cell>
-                <NxTable.Cell>Default Value</NxTable.Cell>
-                <NxTable.Cell>Description</NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Head>
-            <NxTable.Body>
-              <NxTable.Row>
-                <NxTable.Cell><NxCode>$body-row-count</NxCode></NxTable.Cell>
-                <NxTable.Cell>Yes</NxTable.Cell>
-                <NxTable.Cell>N/A</NxTable.Cell>
-                <NxTable.Cell>
-                  The number of rows of content that the table body should have room for. This assumes that each
-                  row contains only a single line of text. Wrapping text or other elements that expand the size
-                  of any row will throw off the calculation.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell><NxCode>$header-filter-row-count</NxCode></NxTable.Cell>
-                <NxTable.Cell>No</NxTable.Cell>
-                <NxTable.Cell>0</NxTable.Cell>
-                <NxTable.Cell>
-                  The number of filter header rows on the table.
-                </NxTable.Cell>
-              </NxTable.Row>
-              <NxTable.Row>
-                <NxTable.Cell><NxCode>$header-row-count</NxCode></NxTable.Cell>
-                <NxTable.Cell>No</NxTable.Cell>
-                <NxTable.Cell>1</NxTable.Cell>
-                <NxTable.Cell>
-                  The number of standard header rows on the table. This number should not include the count of any
-                  filter header rows.
-                </NxTable.Cell>
-              </NxTable.Row>
-            </NxTable.Body>
-          </NxTable>
-        </NxTile.Subsection>
+            <NxTile.Subsection>
+              <NxTile.SubsectionHeader>
+                <NxH3>SCSS Helper Functions</NxH3>
+              </NxTile.SubsectionHeader>
+              <NxP>
+                When constructing a table of paginated data, it is often the case that the table is intended to be
+                exactly tall enough to contain one full page's worth of rows, even when on the last page, which may
+                contain fewer
+                rows. Achieving this effect requires setting an explicit height on the table container element that is
+                equal to the height that it would implicitly get when full. Calculating this height however is
+                somewhat complex, requiring summing up the heights of the various table elements in play. Therefore
+                RSC provides a SCSS helper function which will return the height of
+                the <NxCode>.nx-table-container</NxCode>'s content box for a paginated table with the
+                given parameters. The function, located in
+                the <NxCode>scss-shared/_nx-table-helpers.scss</NxCode> file, is named
+                <NxCode>pagination-table-height</NxCode>. See the description of its parameters below.
+              </NxP>
+              <NxTable>
+                <NxTable.Head>
+                  <NxTable.Row>
+                    <NxTable.Cell>Name</NxTable.Cell>
+                    <NxTable.Cell>Required</NxTable.Cell>
+                    <NxTable.Cell>Default Value</NxTable.Cell>
+                    <NxTable.Cell>Description</NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Head>
+                <NxTable.Body>
+                  <NxTable.Row>
+                    <NxTable.Cell><NxCode>$body-row-count</NxCode></NxTable.Cell>
+                    <NxTable.Cell>Yes</NxTable.Cell>
+                    <NxTable.Cell>N/A</NxTable.Cell>
+                    <NxTable.Cell>
+                      The number of rows of content that the table body should have room for. This assumes that each
+                      row contains only a single line of text. Wrapping text or other elements that expand the size
+                      of any row will throw off the calculation.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell><NxCode>$header-filter-row-count</NxCode></NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>0</NxTable.Cell>
+                    <NxTable.Cell>
+                      The number of filter header rows on the table.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                  <NxTable.Row>
+                    <NxTable.Cell><NxCode>$header-row-count</NxCode></NxTable.Cell>
+                    <NxTable.Cell>No</NxTable.Cell>
+                    <NxTable.Cell>1</NxTable.Cell>
+                    <NxTable.Cell>
+                      The number of standard header rows on the table. This number should not include the count of any
+                      filter header rows.
+                    </NxTable.Cell>
+                  </NxTable.Row>
+                </NxTable.Body>
+              </NxTable>
+            </NxTile.Subsection>
 
-        <NxP>
-          For guidance on the construction of a scrolling table, see the scrolling example on
-          the <NxCode>nx-table-container</NxCode> HTML element page.
-        </NxP>
-      </GalleryDescriptionTile>
+            <NxP>
+              For guidance on the construction of a scrolling table, see the scrolling example on
+              the <NxCode>nx-table-container</NxCode> HTML element page.
+            </NxP>
+          </GalleryDescriptionTile>
+        </NxTabPanel>
 
-      <GalleryExampleTile title="Simple Example"
-                          liveExample={NxTableSimpleExample}
-                          codeExamples={tableSimpleExampleCode}>
-        A basic example of <NxCode>NxTable</NxCode>.
-      </GalleryExampleTile>
+        <NxTabPanel>
 
-      <GalleryExampleTile title="Clickable Row Example"
-                          id="nx-table-clickable-example"
-                          liveExample={NxTableClickableExample}
-                          codeExamples={tableClickableExample}>
-        An example where the rows are styled to indicate that they are clickable.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Simple Example"
+                              liveExample={NxTableSimpleExample}
+                              codeExamples={tableSimpleExampleCode}>
+            A basic example of <NxCode>NxTable</NxCode>.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Clickable Row Custom Icon Example"
-                          id="nx-table-clickable-custom-example"
-                          liveExample={NxTableClickableCustomExample}
-                          codeExamples={tableClickableCustomExample}>
-        An example where the rows are styled to indicate that they are clickable, using a custom icon rather than the
-        typical right-facing chevron.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Clickable Row Example"
+                              id="nx-table-clickable-example"
+                              liveExample={NxTableClickableExample}
+                              codeExamples={tableClickableExample}>
+            An example where the rows are styled to indicate that they are clickable.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Sortable Columns Example"
-                          id="nx-table-sortable-example"
-                          liveExample={NxTableSortableExample}
-                          codeExamples={tableSortableExample}>
-        An example with a sortable column.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Clickable Row Custom Icon Example"
+                              id="nx-table-clickable-custom-example"
+                              liveExample={NxTableClickableCustomExample}
+                              codeExamples={tableClickableCustomExample}>
+            An example where the rows are styled to indicate that they are clickable, using a custom icon rather than
+            the typical right-facing chevron.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Filter Columns Example"
-                          id="nx-table-filter-example"
-                          liveExample={NxTableFilterExample}
-                          codeExamples={tableFilterExample}>
-        An example with filter columns.
-        The first column has a basic filter input, the rows will be filtered
-        if any name contains the text provided in the input.
-        The second column has a filter input which provides a suggestion capability, the rows will be filtered
-        when the country contains the text provided in the input.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Sortable Columns Example"
+                              id="nx-table-sortable-example"
+                              liveExample={NxTableSortableExample}
+                              codeExamples={tableSortableExample}>
+            An example with a sortable column.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Pagination Example"
-                          id="nx-table-pagination-example"
-                          liveExample={NxTablePaginationExample}
-                          codeExamples={paginationCodeExamples}>
-        An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
-        paging.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Filter Columns Example"
+                              id="nx-table-filter-example"
+                              liveExample={NxTableFilterExample}
+                              codeExamples={tableFilterExample}>
+            An example with filter columns.
+            The first column has a basic filter input, the rows will be filtered
+            if any name contains the text provided in the input.
+            The second column has a filter input which provides a suggestion capability, the rows will be filtered
+            when the country contains the text provided in the input.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Pagination and Filtering Example"
-                          id="nx-table-pagination-filter-example"
-                          liveExample={NxTablePaginationFilterExample}
-                          codeExamples={paginationFilterCodeExamples}>
-        An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
-        paging as well as a row of filter headers. Demonstrates the use of
-        the <NxCode>pagination-table-height</NxCode> SCSS function when a filter row is present.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Pagination Example"
+                              id="nx-table-pagination-example"
+                              liveExample={NxTablePaginationExample}
+                              codeExamples={paginationCodeExamples}>
+            An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
+            paging.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Loading Example"
-                          id="nx-table-loading-example"
-                          liveExample={NxTableLoadingExample}
-                          codeExamples={tableLoadingExample}>
-        An example of how <NxCode>NxTable</NxCode> should be used while its data is loading.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Pagination and Filtering Example"
+                              id="nx-table-pagination-filter-example"
+                              liveExample={NxTablePaginationFilterExample}
+                              codeExamples={paginationFilterCodeExamples}>
+            An example of a table with an <NxCode>NxPagination</NxCode> component in the footer to control
+            paging as well as a row of filter headers. Demonstrates the use of
+            the <NxCode>pagination-table-height</NxCode> SCSS function when a filter row is present.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Error Example"
-                          id="nx-table-error-example"
-                          liveExample={NxTableErrorExample}
-                          codeExamples={tableErrorExample}>
-        An example of how <NxCode>NxTable</NxCode> should be used to indicate that there was an error
-        loading its data.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Loading Example"
+                              id="nx-table-loading-example"
+                              liveExample={NxTableLoadingExample}
+                              codeExamples={tableLoadingExample}>
+            An example of how <NxCode>NxTable</NxCode> should be used while its data is loading.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Empty Example"
-                          liveExample={NxTableEmptyExample}
-                          codeExamples={tableEmptyExample}>
-        An example of how <NxCode>NxTable</NxCode> should be used to indicate that there is no data
-        to be seen.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Error Example"
+                              id="nx-table-error-example"
+                              liveExample={NxTableErrorExample}
+                              codeExamples={tableErrorExample}>
+            An example of how <NxCode>NxTable</NxCode> should be used to indicate that there was an error
+            loading its data.
+          </GalleryExampleTile>
 
-      <GalleryExampleTile title="Custom Meta-Info Example"
-                          liveExample={NxTableMetaInfoExample}
-                          codeExamples={tableMetaInfoExample}>
-        An example of how <NxCode>NxTable</NxCode> should be used with a custom meta-info situation.
-      </GalleryExampleTile>
+          <GalleryExampleTile title="Empty Example"
+                              liveExample={NxTableEmptyExample}
+                              codeExamples={tableEmptyExample}>
+            An example of how <NxCode>NxTable</NxCode> should be used to indicate that there is no data
+            to be seen.
+          </GalleryExampleTile>
+
+          <GalleryExampleTile title="Custom Meta-Info Example"
+                              liveExample={NxTableMetaInfoExample}
+                              codeExamples={tableMetaInfoExample}>
+            An example of how <NxCode>NxTable</NxCode> should be used with a custom meta-info situation.
+          </GalleryExampleTile>
+        </NxTabPanel>
+      </NxTabs>
     </>
   );
 }

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -141,7 +141,6 @@ import NxTreePage from './components/NxTree/NxTreePage';
 const pageConfig: PageConfig = {
   'React Components': {
     NxAccordion: NxAccordionPage,
-    NxStatefulAccordion: NxStatefulAccordionPage,
     NxAlert: NxAlertComponentsPage,
     NxStatefulAlert: NxStatefulAlertComponentsPage,
     NxBackButton: NxBackButtonPage,

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -80,7 +80,6 @@ import NxBinaryDonutChartPage from './components/NxBinaryDonutChart/NxBinaryDonu
 import NxNexusPageHeaderPage from './components/NxNexusPageHeader/NxNexusPageHeaderPage';
 import NxFormSelectPage from './styles/NxFormSelect/NxFormSelectPage';
 import NxAccordionPage from './components/NxAccordion/NxAccordionPage';
-import NxStatefulAccordionPage from './components/NxStatefulAccordion/NxStatefulAccordionPage';
 import NxViewportSizedPage from './styles/NxViewportSized/NxViewportSizedPage';
 import NxPolicyViolationIndicatorPage from './components/NxPolicyViolationIndicator/NxPolicyViolationIndicatorPage';
 import NxReadOnlyPage from './styles/NxReadOnly/NxReadOnlyPage';


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-842

This is a spike to demonstrate changes to the Gallery layout. The goal is to consolidate stateless, stateful, React, and HTML examples on one page using tabs. An additional goal is to reduce the length of the pages by showing the usage/props/etc in a tab separate from the examples.

Please look at the NxAccordion and NxTable pages (under components) for examples.
