### PR TITLE
Show guidelines in NxAccordion RSC-843

### DIFF
--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -44,7 +44,7 @@ const NxAccordionPage = () =>
       </NxP>
       <NxTile.Subsection>
         <NxTile.SubsectionHeader>
-          <NxH3>Guidelines</NxH3>
+          <NxH2>Guidelines</NxH2>
         </NxTile.SubsectionHeader>
         <NxH3>When to Use</NxH3>
         <NxList bulleted>
@@ -56,18 +56,18 @@ const NxAccordionPage = () =>
         <NxList bulleted>
           <NxList.Item>
             Displaying critical system information or a primary action to be taken on the page. (for example,
-            {' '}<a href="/components/alert">alerts</a>, confirmation or cancellation buttons).
+            {' '}<NxTextLink href="/components/alert">alerts</NxTextLink>, confirmation or cancellation buttons).
           </NxList.Item>
           <NxList.Item>
             Displaying navigation elements such as <a href="/components/tabs">tabs</a>.
           </NxList.Item>
           <NxList.Item>
             Displaying links pointing to sections of the same page, instead use a
-            {' '}<a href="/components/list">list</a>.
+            {' '}<NxTextLink href="/components/list">list</NxTextLink>.
           </NxList.Item>
           <NxList.Item>
             Creating hierarchy levels by nesting them within each other. If you need to add hierarchy to the
-            content use a <a href="/components/tree">tree</a>.
+            content use a <NxTextLink href="/components/tree">tree</NxTextLink>.
           </NxList.Item>
           <NxList.Item>
             Displaying a set of visual components following the same style, prefer using Collapsable.(TODO: Add

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -42,7 +42,10 @@ const NxAccordionPage = () =>
         Note that this component is stateless – its open state must be tracked externally.
         See <NxCode>NxStatefulAccordion</NxCode> for a version which tracks its own open state.
       </NxP>
-      <NxH2>Guidelines</NxH2>
+      <NxTile.Subsection>
+        <NxTile.SubsectionHeader>
+          <NxH3>Guidelines</NxH3>
+        </NxTile.SubsectionHeader>
         <NxH3>When to Use</NxH3>
         <NxList bulleted>
           <NxList.Item>Displaying and grouping additional information.</NxList.Item>
@@ -71,6 +74,7 @@ const NxAccordionPage = () =>
             link to collapsable).
           </NxList.Item>
         </NxList>
+      </NxTile.Subsection>
       <NxTile.Subsection>
         <NxTile.SubsectionHeader>
           <NxH3>NxAccordion</NxH3>

--- a/gallery/src/components/NxAccordion/NxAccordionPage.tsx
+++ b/gallery/src/components/NxAccordion/NxAccordionPage.tsx
@@ -5,7 +5,17 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 import React from 'react';
-import { NxTable, NxInfoAlert, NxCode, NxTextLink, NxP, NxH3, NxTile } from '@sonatype/react-shared-components';
+import {
+  NxTable,
+  NxInfoAlert,
+  NxCode,
+  NxTextLink,
+  NxP,
+  NxH3,
+  NxTile,
+  NxH2,
+  NxList
+} from '@sonatype/react-shared-components';
 
 import { GalleryDescriptionTile, GalleryExampleTile } from '../../gallery-components/GalleryTiles';
 
@@ -32,6 +42,35 @@ const NxAccordionPage = () =>
         Note that this component is stateless – its open state must be tracked externally.
         See <NxCode>NxStatefulAccordion</NxCode> for a version which tracks its own open state.
       </NxP>
+      <NxH2>Guidelines</NxH2>
+        <NxH3>When to Use</NxH3>
+        <NxList bulleted>
+          <NxList.Item>Displaying and grouping additional information.</NxList.Item>
+          <NxList.Item>Adding granular control over the information on a given page.</NxList.Item>
+          <NxList.Item>Shortening pages to reduce scrolling.</NxList.Item>
+        </NxList>
+        <NxH3>When Not to Use</NxH3>
+        <NxList bulleted>
+          <NxList.Item>
+            Displaying critical system information or a primary action to be taken on the page. (for example,
+            {' '}<a href="/components/alert">alerts</a>, confirmation or cancellation buttons).
+          </NxList.Item>
+          <NxList.Item>
+            Displaying navigation elements such as <a href="/components/tabs">tabs</a>.
+          </NxList.Item>
+          <NxList.Item>
+            Displaying links pointing to sections of the same page, instead use a
+            {' '}<a href="/components/list">list</a>.
+          </NxList.Item>
+          <NxList.Item>
+            Creating hierarchy levels by nesting them within each other. If you need to add hierarchy to the
+            content use a <a href="/components/tree">tree</a>.
+          </NxList.Item>
+          <NxList.Item>
+            Displaying a set of visual components following the same style, prefer using Collapsable.(TODO: Add
+            link to collapsable).
+          </NxList.Item>
+        </NxList>
       <NxTile.Subsection>
         <NxTile.SubsectionHeader>
           <NxH3>NxAccordion</NxH3>


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-843

Quick demonstration of a Guidelines section in the `NxAccordion` docs.

NOTE: The content is cribbed from Gitlab's accordion component and should be re-written to match the requirements of `NxAccordion`.