### PR TITLE
NxOverflowTooltip nextjs support - RSC-864

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "9.6.2",
+  "version": "9.6.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxTooltip/NxOverflowTooltip.tsx
+++ b/lib/src/components/NxTooltip/NxOverflowTooltip.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { useRef, useState, useLayoutEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import useResizeObserver from '@react-hook/resize-observer';
 
 import { textContent } from '../../util/childUtil';
@@ -38,7 +38,7 @@ export default function NxOverflowTooltip({ title, children, ...otherProps }: Ov
   }
 
   // check the width on initial layout and any time computedTitle changes
-  useLayoutEffect(updateNeedsTooltip, [computedTitle]);
+  useEffect(updateNeedsTooltip, [computedTitle]);
 
   // check the width any time the element resizes
   useResizeObserver(ref, updateNeedsTooltip);


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-864

All tests still pass if we just use `useEffect` instead of `useLayoutEffect`, and it makes next happy.