### PR TITLE
NxList automated a11y fix eslint - RSC-915

### DIFF
--- a/gallery/src/styles/NxList/NxListDeprecatedClickableExample.tsx
+++ b/gallery/src/styles/NxList/NxListDeprecatedClickableExample.tsx
@@ -32,6 +32,7 @@ const NxListDeprecatedClickableExample = () =>
       </span>
       <NxFontAwesomeIcon icon={faAngleRight} className="nx-chevron" />
     </li>
+    {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
     <li className="nx-list__item disabled" aria-disabled="true">
       <span className="nx-list__text">This list item is disabled</span>
       <NxFontAwesomeIcon icon={faAngleRight} className="nx-chevron" />


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-915

Eslint says that the `aria-disabled` attribute is not allowed on list items.

My initial idea here was to remove the `aria-disabled` attribute and set up a URL flag to hide this deprecated `nx-list` example from the a11y test (similar to what was done with `NxAccordion`.  However, upon double checking the ARIA spec I was reminded that `aria-disabled` is in fact valid on list items - its valid on all elements.  In fact it seems that I had come across this in the past and contributed to a discussion about this being a bug in the eslint plugin: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/805 

Since this is a bug in the eslint plugin I decided that the best solution is to disable the eslint rule for this line.