### PR TITLE
Add URL path to uncheck "show checkered background" - RSC-941

### DIFF
--- a/gallery/src/gallery-components/GalleryTiles.tsx
+++ b/gallery/src/gallery-components/GalleryTiles.tsx
@@ -19,6 +19,8 @@ import {
 } from '@sonatype/react-shared-components';
 import { GalleryTileFooter } from './GalleryTileFooter';
 
+import { useLocation } from 'react-router-dom';
+
 interface PropsWithRequiredChildren {
   children: ReactNode;
 }
@@ -87,7 +89,12 @@ export const GalleryExampleTile: FunctionComponent<GalleryExampleTileProps> =
           defaultCheckeredBackground
         } = props,
 
-        [checkeredBackground, toggleCheckeredBackground] = useToggle(defaultCheckeredBackground || false),
+        location = useLocation(),
+
+        overrideCheckeredBackground = location.pathname.includes('no-checkered-background'),
+
+        [checkeredBackground, toggleCheckeredBackground] =
+          useToggle((overrideCheckeredBackground ? false : defaultCheckeredBackground) || false),
 
         liveExampleRender =
           htmlExample ? <RawHtmlExample html={htmlExample} /> :


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-941

With this PR, can navigate to a page and add the /no-checkered-background at the of the URL to uncheck all the "show checkered background" checkboxes.

Example URL: /pages/Page%20Title/no-checkered-background