### PR TITLE
RSC-1066: Few small tweaks to get build running on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,24 @@ again from the top directory of the repo.
 docker run --rm -it -w /home/jenkins/gallery -v $PWD:/home/jenkins rsc-visualtesting yarn test
 ```
 
+---
+
+### Windows Users!!
+
+For you seemingly rare Windows (Windows 11 to be precise) users, you have a couple options
+
+From simple command prompt
+```
+docker run --rm -it -w /home/jenkins/gallery -v %CD%:/home/jenkins rsc-visualtesting yarn test
+```
+
+And from powershell
+```
+docker run --rm -it -w /home/jenkins/gallery -v $pwd:/home/jenkins rsc-visualtesting yarn test
+```
+
+---
+
 Note that the `yarn test` command will (re-)install the gallery dependencies, ensuring that puppeteer downloads the
 correct version of Chromium before running the gallery build and tests.
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ docker run --rm -it -w /home/jenkins/gallery -v %CD%:/home/jenkins rsc-visualtes
 
 And from powershell
 ```
-docker run --rm -it -w /home/jenkins/gallery -v $pwd:/home/jenkins rsc-visualtesting yarn test
+docker run --rm -it -w /home/jenkins/gallery -v $pwd\:/home/jenkins rsc-visualtesting yarn test
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ And from powershell
 docker run --rm -it -w /home/jenkins/gallery -v $pwd\:/home/jenkins rsc-visualtesting yarn test
 ```
 
+Also keep in mind that the [auto-crlf](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) 
+setting in git for your cloned repository should be **false**, you will have issues with some visual test failures otherwise.
+
 ---
 
 Note that the `yarn test` command will (re-)install the gallery dependencies, ensuring that puppeteer downloads the

--- a/README.md
+++ b/README.md
@@ -228,9 +228,6 @@ And from powershell
 docker run --rm -it -w /home/jenkins/gallery -v $pwd\:/home/jenkins rsc-visualtesting yarn test
 ```
 
-Also keep in mind that the [auto-crlf](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) 
-setting in git for your cloned repository should be **false**, you will have issues with some visual test failures otherwise.
-
 ---
 
 Note that the `yarn test` command will (re-)install the gallery dependencies, ensuring that puppeteer downloads the

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -7,7 +7,7 @@
     "start": "npm-run-all lint webpack-dev-server",
     "build": "npm-run-all lint webpack copy-assets",
     "copy-assets": "cpx \"{src/index.html,src/assets/images/favicon*}\" dist",
-    "lint": "eslint 'src/**/*.{js,ts}{,x}'",
+    "lint": "eslint \"./src/**/*.{js,ts}{,x}\"",
     "lint-tests": "eslint --no-eslintrc -c .eslintrc-tests \"visualtests/*.js\"",
     "webpack": "webpack --env production --mode=production",
     "webpack-dev-server": "webpack serve",

--- a/gallery/src/util/exampleUtil.ts
+++ b/gallery/src/util/exampleUtil.ts
@@ -6,11 +6,12 @@
  */
 
 // Quick and dirty removal of any comment appearing at the beginning of the content, as it is assumed to be
-// a license which is not helpful to the example display. Both HTML-syntax and C-syntax comments are removed
+// a license which is not helpful to the example display. Both HTML-syntax and C-syntax comments are removed.
+// Will handle both unix and windows line endings
 export const removeLicense = (content: string) =>
   content
-      .replace(/^<!--(.|\n)*?-->\s*\n?/, '')
-      .replace(/^\/\*(.|\n)*?\*\/\s*\n?/, '');
+      .replace(/^<!--(.|\r*\n)*?-->\s*\r*\n?/, '')
+      .replace(/^\/\*(.|\r*\n)*?\*\/\s*\r*\n?/, '');
 
 // Copies a string to the clipboard.
 export const copyTextToClipboard = (textToCopy: string) => {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "npm-run-all -p lint compile-ts compile-scss copy-scss copy-package-json copy-assets",
     "watch": "npm-run-all -p lint compile-ts-watch compile-scss-watch copy-scss-watch copy-package-json-watch copy-assets-watch",
-    "lint": "eslint --ignore-pattern __tests__ --ignore-pattern __mocks__ --ignore-pattern __testutils__ 'src/**/*.{js,ts}{,x}'",
-    "lint-tests": "eslint --no-eslintrc -c .eslintrc-tests 'src/**/{__tests__,__mocks__,__testutils__}/**/*.{js,ts}{,x}'",
+    "lint": "eslint --ignore-pattern __tests__ --ignore-pattern __mocks__ --ignore-pattern __testutils__ \"./src/**/*.{js,ts}{,x}\"",
+    "lint-tests": "eslint --no-eslintrc -c .eslintrc-tests \"./src/**/{__tests__,__mocks__,__testutils__}/**/*.{js,ts}{,x}\"",
     "compile-ts": "tsc --project tsconfig.build.json",
     "compile-scss": "webpack-cli --config=webpack.config.styles.js",
     "copy-scss": "cpx \"src/**/*.scss\" dist",


### PR DESCRIPTION
- [X] Build on win11
- [X] Run snapshot tests with command prompt
- [X] Run snapshot tests with powershell
- [X] Find why a hunk of the snapshot tests are failing
- [X] Build branch on Jenkins
- [X] Find existing JIRA ticket, or create new one
- [X] Investigate why license headers aren't stripped from sample code
- [X] Investigate why external link icon different

Update 4/28
Previous test failures were seemingly because of intellij removing content while cli was building
And test failures from earlier today were simply because of line endings, ~so updated readme one final time~ so updated the stripLicense function to handle both styles of line endings

https://issues.sonatype.org/browse/RSC-1066
Jenkins: https://jenkins.ci.sonatype.dev/job/uxui/job/sonatype-react-shared-components/job/rsc-for-windows-man/