### PR TITLE
SPIKE: New Approach to Required Form Fields - RSC-1064

### DIFF
--- a/gallery/src/components/NxForm/NxFormCustomizedExample.tsx
+++ b/gallery/src/components/NxForm/NxFormCustomizedExample.tsx
@@ -65,16 +65,16 @@ export default function NxFormCustomizedExample() {
 
   return (
     <NxStatefulForm onSubmit={onSubmit}
-            onCancel={resetForm}
-            submitMaskState={submitMaskState}
-            className="gallery-custom-form"
-            submitBtnClasses="gallery-custom-form__submit"
-            submitError={submitError}
-            submitErrorTitleMessage="There was an error sending the message."
-            submitBtnText="Send it"
-            submitMaskMessage="Sending…"
-            submitMaskSuccessMessage="Sent!"
-            additionalFooterBtns={additionalFooterBtns}>
+                    onCancel={resetForm}
+                    submitMaskState={submitMaskState}
+                    className="gallery-custom-form"
+                    submitBtnClasses="gallery-custom-form__submit"
+                    submitError={submitError}
+                    submitErrorTitleMessage="There was an error sending the message."
+                    submitBtnText="Send it"
+                    submitMaskMessage="Sending…"
+                    submitMaskSuccessMessage="Sent!"
+                    additionalFooterBtns={additionalFooterBtns}>
       <NxFormGroup label="Username">
         <NxTextInput { ...usernameState } onChange={onUsernameChange} />
       </NxFormGroup>

--- a/gallery/src/components/NxForm/NxFormCustomizedExample.tsx
+++ b/gallery/src/components/NxForm/NxFormCustomizedExample.tsx
@@ -6,7 +6,8 @@
  */
 import React, { useState } from 'react';
 
-import { NxForm, NxFormGroup, NxTextInput, NxButton, nxTextInputStateHelpers } from '@sonatype/react-shared-components';
+import { NxFormGroup, NxTextInput, NxButton, nxTextInputStateHelpers, NxStatefulForm }
+  from '@sonatype/react-shared-components';
 import { SUCCESS_VISIBLE_TIME_MS } from '@sonatype/react-shared-components/components/NxSubmitMask/NxSubmitMask';
 
 const { initialState, userInput } = nxTextInputStateHelpers;
@@ -63,7 +64,7 @@ export default function NxFormCustomizedExample() {
   );
 
   return (
-    <NxForm onSubmit={onSubmit}
+    <NxStatefulForm onSubmit={onSubmit}
             onCancel={resetForm}
             submitMaskState={submitMaskState}
             className="gallery-custom-form"
@@ -80,6 +81,6 @@ export default function NxFormCustomizedExample() {
       <NxFormGroup label="Hostname">
         <NxTextInput { ...hostnameState } onChange={onHostnameChange} className="nx-text-input--long"/>
       </NxFormGroup>
-    </NxForm>
+    </NxStatefulForm>
   );
 }

--- a/gallery/src/components/NxForm/NxFormExample.tsx
+++ b/gallery/src/components/NxForm/NxFormExample.tsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect, FormEvent } from 'react';
 
 import {
   NxCheckbox,
-  NxForm,
+  NxStatefulForm,
   NxRadio,
   NxFormGroup,
   NxTextInput,
@@ -79,30 +79,32 @@ export default function NxFormExample() {
   }
 
   function onSubmit() {
-    // For the sake of example, simulate that the submit fails the first time, and then upon retry
-    // succeeds after 3 seconds
-    if (submitCount < 1) {
-      setSubmitError('The form could not be saved!');
-    }
-    else {
-      setSubmitError(null);
+    if (!hasValidationErrors(validationErrors)) {
+      // For the sake of example, simulate that the submit fails the first time, and then upon retry
+      // succeeds after 3 seconds
+      if (submitCount < 1) {
+        setSubmitError('The form could not be saved!');
+      }
+      else {
+        setSubmitError(null);
 
-      setSubmitMaskState(false);
-
-      setTimeout(function() {
-        setSubmitMaskState(true);
+        setSubmitMaskState(false);
 
         setTimeout(function() {
-          setSubmitMaskState(null);
-        }, SUCCESS_VISIBLE_TIME_MS);
-      }, 3000);
-    }
+          setSubmitMaskState(true);
 
-    setSubmitCount(submitCount + 1);
+          setTimeout(function() {
+            setSubmitMaskState(null);
+          }, SUCCESS_VISIBLE_TIME_MS);
+        }, 3000);
+      }
+
+      setSubmitCount(submitCount + 1);
+    }
   }
 
   return (
-    <NxForm loading={loading}
+    <NxStatefulForm loading={loading}
             doLoad={doLoad}
             onSubmit={onSubmit}
             loadError={loadError}
@@ -150,6 +152,6 @@ export default function NxFormExample() {
           <option value="option5">Option 5</option>
         </NxFormSelect>
       </NxFormGroup>
-    </NxForm>
+    </NxStatefulForm>
   );
 }

--- a/gallery/src/components/NxForm/NxFormExample.tsx
+++ b/gallery/src/components/NxForm/NxFormExample.tsx
@@ -39,17 +39,18 @@ export default function NxFormExample() {
       [redChecked, toggleRed] = useToggle(false),
       [blueChecked, toggleBlue] = useToggle(false),
       [greenChecked, toggleGreen] = useToggle(false),
+      [isFieldsetPristine, setIsFieldsetPristine] = useState(true),
       [radioColor, setRadioColor] = useState<string | null>(null),
       [loading, setLoading] = useState(true),
       [loadError, setLoadError] = useState<string | null>(null),
       [submitCount, setSubmitCount] = useState(0),
       [submitError, setSubmitError] = useState<string | null>(null),
       [submitMaskState, setSubmitMaskState] = useState<boolean | null>(null),
-      radioValidationErrors = (redChecked || blueChecked || greenChecked) ?
+      checkboxValidationErrors = (redChecked || blueChecked || greenChecked) ?
         null : 'Please select at least one checkbox',
       requiredFieldValidationErrors = hasValidationErrors(usernameState.validationErrors) ?
         'Missing required fields' : null,
-      validationErrors = combineValidationErrors(requiredFieldValidationErrors, radioValidationErrors);
+      validationErrors = combineValidationErrors(requiredFieldValidationErrors, checkboxValidationErrors);
 
   function onUsernameChange(val: string) {
     setUsernameState(userInput(validator, val));
@@ -103,6 +104,11 @@ export default function NxFormExample() {
     }
   }
 
+  const setColor = (setter: () => void) => () => {
+    setter();
+    setIsFieldsetPristine(false);
+  };
+
   return (
     <NxStatefulForm loading={loading}
                     doLoad={doLoad}
@@ -117,10 +123,13 @@ export default function NxFormExample() {
       <NxFormGroup label="Hostname">
         <NxTextInput { ...hostnameState } onChange={onHostnameChange} className="nx-text-input--long"/>
       </NxFormGroup>
-      <NxFieldset label="Colors" isRequired>
-        <NxCheckbox onChange={toggleRed} isChecked={redChecked}>Red</NxCheckbox>
-        <NxCheckbox onChange={toggleBlue} isChecked={blueChecked}>Blue</NxCheckbox>
-        <NxCheckbox onChange={toggleGreen} isChecked={greenChecked}>Green</NxCheckbox>
+      <NxFieldset label="Colors"
+                  isRequired
+                  isPristine={isFieldsetPristine}
+                  validationErrors={checkboxValidationErrors}>
+        <NxCheckbox onChange={setColor(toggleRed)} isChecked={redChecked}>Red</NxCheckbox>
+        <NxCheckbox onChange={setColor(toggleBlue)} isChecked={blueChecked}>Blue</NxCheckbox>
+        <NxCheckbox onChange={setColor(toggleGreen)} isChecked={greenChecked}>Green</NxCheckbox>
       </NxFieldset>
       <NxFieldset label="Primary Color" sublabel="Pick a single color">
         <NxRadio name="color"

--- a/gallery/src/components/NxForm/NxFormExample.tsx
+++ b/gallery/src/components/NxForm/NxFormExample.tsx
@@ -105,12 +105,12 @@ export default function NxFormExample() {
 
   return (
     <NxStatefulForm loading={loading}
-            doLoad={doLoad}
-            onSubmit={onSubmit}
-            loadError={loadError}
-            submitError={submitError}
-            validationErrors={validationErrors}
-            submitMaskState={submitMaskState}>
+                    doLoad={doLoad}
+                    onSubmit={onSubmit}
+                    loadError={loadError}
+                    submitError={submitError}
+                    validationErrors={validationErrors}
+                    submitMaskState={submitMaskState}>
       <NxFormGroup label="Username" isRequired>
         <NxTextInput { ...usernameState } onChange={onUsernameChange} validatable/>
       </NxFormGroup>

--- a/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useState } from 'react';
 
-import { NxModal, NxFontAwesomeIcon, NxTextInput, NxButton, nxTextInputStateHelpers, NxFormGroup, NxForm }
+import { NxModal, NxFontAwesomeIcon, NxTextInput, NxButton, nxTextInputStateHelpers, NxFormGroup, NxStatefulForm }
   from '@sonatype/react-shared-components';
 import { faAngry } from '@fortawesome/free-solid-svg-icons';
 
@@ -29,7 +29,7 @@ export default function NxModalFormErrorExample() {
         <NxModal id="nx-modal-form-error-example"
                  onCancel={modalCloseHandler}
                  aria-labelledby="modal-form-error-header">
-          <NxForm className="nx-form"
+          <NxStatefulForm className="nx-form"
                   onSubmit={modalCloseHandler}
                   onCancel={modalCloseHandler}
                   submitError={error}>
@@ -51,7 +51,7 @@ export default function NxModalFormErrorExample() {
                              { ...textFieldState }/>
               </NxFormGroup>
             </div>
-          </NxForm>
+          </NxStatefulForm>
         </NxModal>
       }
     </>

--- a/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormErrorExample.tsx
@@ -30,9 +30,9 @@ export default function NxModalFormErrorExample() {
                  onCancel={modalCloseHandler}
                  aria-labelledby="modal-form-error-header">
           <NxStatefulForm className="nx-form"
-                  onSubmit={modalCloseHandler}
-                  onCancel={modalCloseHandler}
-                  submitError={error}>
+                          onSubmit={modalCloseHandler}
+                          onCancel={modalCloseHandler}
+                          submitError={error}>
             <header className="nx-modal-header">
               <h2 className="nx-h2" id="modal-form-error-header">
                 <NxFontAwesomeIcon icon={faAngry} />

--- a/gallery/src/components/NxModal/NxModalFormExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormExample.tsx
@@ -12,11 +12,11 @@ import {
   NxButton,
   NxTextInput,
   NxFormGroup,
-  NxForm,
   nxTextInputStateHelpers,
   NxFieldset,
   NxCheckbox,
-  useToggle
+  useToggle,
+  NxStatefulForm
 } from '@sonatype/react-shared-components';
 import {faAngry} from '@fortawesome/free-solid-svg-icons';
 
@@ -53,7 +53,7 @@ export default function NxModalFormExample() {
       <NxButton onClick={openModal}>Open Modal with Form</NxButton>
       {showModal &&
         <NxModal id="nx-modal-form-example" onCancel={modalCloseHandler} aria-labelledby="modal-form-header">
-          <NxForm className="nx-form"
+          <NxStatefulForm className="nx-form"
                   onSubmit={modalCloseHandler}
                   onCancel={modalCloseHandler}
                   validationErrors={validationErrors}
@@ -90,7 +90,7 @@ export default function NxModalFormExample() {
                 <NxCheckbox onChange={toggleGreen} isChecked={isGreen}>Green</NxCheckbox>
               </NxFieldset>
             </div>
-          </NxForm>
+          </NxStatefulForm>
         </NxModal>
       }
     </>

--- a/gallery/src/components/NxModal/NxModalFormExample.tsx
+++ b/gallery/src/components/NxModal/NxModalFormExample.tsx
@@ -54,16 +54,16 @@ export default function NxModalFormExample() {
       {showModal &&
         <NxModal id="nx-modal-form-example" onCancel={modalCloseHandler} aria-labelledby="modal-form-header">
           <NxStatefulForm className="nx-form"
-                  onSubmit={modalCloseHandler}
-                  onCancel={modalCloseHandler}
-                  validationErrors={validationErrors}
-                  additionalFooterBtns={
-                    <NxButton type="button" onClick={modalCloseHandler} variant="tertiary">
-                      Tertiary
-                    </NxButton>
-                  }
-                  doLoad={() => {}}
-                  loading={loading}>
+                          onSubmit={modalCloseHandler}
+                          onCancel={modalCloseHandler}
+                          validationErrors={validationErrors}
+                          additionalFooterBtns={
+                            <NxButton type="button" onClick={modalCloseHandler} variant="tertiary">
+                              Tertiary
+                            </NxButton>
+                          }
+                          doLoad={() => {}}
+                          loading={loading}>
             <header className="nx-modal-header">
               <h2 className="nx-h2" id="modal-form-header">
                 <NxFontAwesomeIcon icon={faAngry} />

--- a/gallery/src/styles/NxTile/NxTileFormErrorExample.tsx
+++ b/gallery/src/styles/NxTile/NxTileFormErrorExample.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 
-import { NxStatefulTextInput, NxButton, NxFormGroup, NxForm } from '@sonatype/react-shared-components';
+import { NxStatefulTextInput, NxButton, NxFormGroup, NxStatefulForm } from '@sonatype/react-shared-components';
 
 export default function NxTileFormExample() {
   function onSubmit() {
@@ -15,7 +15,7 @@ export default function NxTileFormExample() {
 
   return (
     <section className="nx-tile" aria-label="Example of nx-tile with a form with error">
-      <NxForm onSubmit={onSubmit} doLoad={() => {}} loadError="404 Not Found">
+      <NxStatefulForm onSubmit={onSubmit} doLoad={() => {}} loadError="404 Not Found">
         <header className="nx-tile-header">
           <div className="nx-tile-header__title">
             <h2 className="nx-h2">NX Simple Tile with Form</h2>
@@ -34,7 +34,7 @@ export default function NxTileFormExample() {
             <NxButton variant="primary">Footer Button</NxButton>
           </div>
         </footer>
-      </NxForm>
+      </NxStatefulForm>
     </section>
   );
 }

--- a/gallery/src/styles/NxTile/NxTileFormExample.tsx
+++ b/gallery/src/styles/NxTile/NxTileFormExample.tsx
@@ -4,27 +4,31 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { FormEvent } from 'react';
+import React from 'react';
 
-import { NxStatefulTextInput, NxButton, NxFormGroup } from '@sonatype/react-shared-components';
+import { NxStatefulTextInput, NxButton, NxFormGroup, NxStatefulForm, NxForm } from '@sonatype/react-shared-components';
 
 export default function NxTileFormExample() {
   function validator(val: string) {
     return val.length ? null : 'Must be non-empty';
   }
 
-  function onSubmit(evt: FormEvent) {
-    evt.preventDefault();
+  function onSubmit() {
     alert('Submitted!');
   }
 
   return (
     <section className="nx-tile" aria-label="Example of nx-tile with a form">
-      <form className="nx-form" onSubmit={onSubmit}>
+      <NxStatefulForm onSubmit={onSubmit}>
         <header className="nx-tile-header">
-          <div className="nx-tile-header__title">
-            <h2 className="nx-h2">NX Simple Tile with Form</h2>
-          </div>
+          <hgroup className="nx-tile-header__headings">
+            <div className="nx-tile-header__title">
+              <h2 className="nx-h2">NX Simple Tile with Form</h2>
+            </div>
+            <h3 className="nx-tile-header__subtitle">
+              <NxForm.RequiredFieldNotice />
+            </h3>
+          </hgroup>
         </header>
         <div className="nx-tile-content">
           <NxFormGroup label="Username" isRequired>
@@ -39,7 +43,7 @@ export default function NxTileFormExample() {
             <NxButton variant="primary">Footer Button</NxButton>
           </div>
         </footer>
-      </form>
+      </NxStatefulForm>
     </section>
   );
 }

--- a/gallery/src/styles/NxTile/NxTileFormExample.tsx
+++ b/gallery/src/styles/NxTile/NxTileFormExample.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 
-import { NxStatefulTextInput, NxButton, NxFormGroup, NxStatefulForm, NxForm } from '@sonatype/react-shared-components';
+import { NxStatefulTextInput, NxFormGroup, NxStatefulForm, NxForm } from '@sonatype/react-shared-components';
 
 export default function NxTileFormExample() {
   function validator(val: string) {
@@ -38,11 +38,6 @@ export default function NxTileFormExample() {
             <NxStatefulTextInput/>
           </NxFormGroup>
         </div>
-        <footer className="nx-footer">
-          <div className="nx-btn-bar">
-            <NxButton variant="primary">Footer Button</NxButton>
-          </div>
-        </footer>
       </NxStatefulForm>
     </section>
   );

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -101,4 +101,10 @@
   margin: 0 0 var(--nx-spacing-8x) 0;
   min-inline-size: auto;
   padding: 0;
+
+  // The container-vertical mixin doesn't fully do the job here because the last child is actually the
+  // validation message and we want to remove the bottom margin from the last child _besides_ the validation message
+  > :nth-last-child(2) {
+    margin-bottom: 0;
+  }
 }

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -9,11 +9,64 @@
 
 .nx-form {
   position: relative;
+
+  &__required-field-asterisk {
+    color: var(--nx-swatch-red-40);
+  }
+
+  &__validation-errors {
+    display: none;
+  }
+
+  .invalid {
+    .nx-form__invalid-field-message {
+      display: block;
+    }
+
+    &.pristine {
+      .nx-form__invalid-field-message {
+        display: none;
+      }
+    }
+  }
+
+  &--show-validation-errors {
+    &.nx-form--has-validation-errors {
+      .nx-form__validation-errors {
+        display: flex;
+      }
+
+      .nx-form__submit-btn {
+        display: none;
+      }
+    }
+
+    .nx-form__invalid-field-message {
+      display: block;
+    }
+
+    .invalid {
+      &, &.pristine {
+        .nx-form__invalid-field-message {
+          display: block;
+        }
+      }
+    }
+  }
+
+  &__invalid-field-message {
+    color: var(--nx-color-validation-invalid);
+    display: none;
+    font-size: var(--nx-font-size-xs);
+    line-height: 16px;
+    margin-top: var(--nx-spacing-2x);
+
+    // this positions the invalid message inside the bottom margin of .nx-form-group or .nx-fieldset which allows
+    // us to maintain consistent spacing whether there is validation or not
+    position: absolute;
+  }
 }
 
-.nx-form__required-field-asterisk {
-  color: var(--nx-swatch-red-40);
-}
 
 // Basic form layout
 .nx-form-group {

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -64,6 +64,7 @@
   margin-bottom: var(--nx-spacing-2x);
 
   &::after {
+    color: var(--nx-swatch-red-40);
     content: ' *';
   }
 }

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -62,17 +62,15 @@
   cursor: default;
   display: block;
   margin-bottom: var(--nx-spacing-2x);
+
+  &::after {
+    content: ' *';
+  }
 }
 
 .nx-label--optional, .nx-legend--optional {
   .nx-label__text::after, .nx-legend__text::after {
-    @include nx-text-helpers.regular;
-
-    color: var(--nx-color-text);
-    content: "Optional";
-    font-size: var(--nx-font-size-xs);
-    font-style: italic;
-    margin-left: var(--nx-spacing-2x);
+    display: none;
   }
 }
 

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -11,6 +11,10 @@
   position: relative;
 }
 
+.nx-form__required-field-asterisk {
+  color: var(--nx-swatch-red-40);
+}
+
 // Basic form layout
 .nx-form-group {
   margin-bottom: var(--nx-spacing-8x);
@@ -64,7 +68,7 @@
   margin-bottom: var(--nx-spacing-2x);
 
   &::after {
-    color: var(--nx-swatch-red-40);
+    @extend .nx-form__required-field-asterisk;
     content: ' *';
   }
 }

--- a/lib/src/base-styles/_nx-text-input.scss
+++ b/lib/src/base-styles/_nx-text-input.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  &.invalid {
+  &.invalid:not(.pristine) {
     &:focus-within, &:hover {
       .nx-text-input__box {
         border-color: var(--nx-swatch-red-45);
@@ -36,7 +36,7 @@
     }
   }
 
-  &.valid {
+  &.valid:not(.pristine) {
     &:focus-within, &:hover {
       .nx-text-input__box {
         border-color: var(--nx-swatch-green-30);

--- a/lib/src/components/NxFieldset/NxFieldset.tsx
+++ b/lib/src/components/NxFieldset/NxFieldset.tsx
@@ -4,24 +4,44 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useContext } from 'react';
 import classnames from 'classnames';
 
 import { Props, propTypes } from './types';
+import { getFirstValidationError, hasValidationErrors } from '../../util/validationUtil';
+import { useUniqueId } from '../../util/idUtil';
+import { FormPristineContext } from '../NxForm/contexts';
 export { Props };
 
 const NxFieldset = forwardRef<HTMLFieldSetElement, Props>(
-    function NxFieldset({ className, label, sublabel, children, isRequired, ...attrs }, ref) {
-      const classNames = classnames('nx-fieldset', className),
-          legendClassnames = classnames('nx-legend', { 'nx-legend--optional': !isRequired });
+    function NxFieldset(props, ref) {
+      const {
+            className,
+            label,
+            sublabel,
+            children,
+            isRequired,
+            validationErrors,
+            isPristine: isPristineProp,
+            ...attrs
+          } = props,
+          isFormPristine = useContext(FormPristineContext),
+          isPristine = isFormPristine && isPristineProp,
+          classNames = classnames('nx-fieldset', className),
+          legendClassnames = classnames('nx-legend', { 'nx-legend--optional': !isRequired }),
+          invalidMessageId = useUniqueId('nx-fieldset-invalid-message'),
+          describedBy = hasValidationErrors(validationErrors) ? invalidMessageId : undefined;
 
       return (
-        <fieldset className={classNames} ref={ref} { ...attrs }>
+        <fieldset className={classNames} ref={ref} aria-describedby={describedBy} { ...attrs }>
           <legend className={legendClassnames}>
             <span className="nx-legend__text">{label}</span>
           </legend>
           { sublabel && <div className="nx-sub-label">{sublabel}</div> }
           {children}
+          <div id={invalidMessageId} role="alert" className="nx-text-input__invalid-message">
+            {!isPristine && getFirstValidationError(validationErrors)}
+          </div>
         </fieldset>
       );
     }

--- a/lib/src/components/NxFieldset/NxFieldset.tsx
+++ b/lib/src/components/NxFieldset/NxFieldset.tsx
@@ -4,13 +4,12 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { forwardRef, useContext } from 'react';
+import React, { forwardRef } from 'react';
 import classnames from 'classnames';
 
 import { Props, propTypes } from './types';
 import { getFirstValidationError, hasValidationErrors } from '../../util/validationUtil';
 import { useUniqueId } from '../../util/idUtil';
-import { FormPristineContext } from '../NxForm/contexts';
 export { Props };
 
 const NxFieldset = forwardRef<HTMLFieldSetElement, Props>(
@@ -22,12 +21,15 @@ const NxFieldset = forwardRef<HTMLFieldSetElement, Props>(
             children,
             isRequired,
             validationErrors,
-            isPristine: isPristineProp,
+            isPristine,
             ...attrs
           } = props,
-          isFormPristine = useContext(FormPristineContext),
-          isPristine = isFormPristine && isPristineProp,
-          classNames = classnames('nx-fieldset', className),
+          isValid = hasValidationErrors(validationErrors),
+          classNames = classnames('nx-fieldset', className, {
+            pristine: isPristine,
+            valid: isValid,
+            invalid: !isValid
+          }),
           legendClassnames = classnames('nx-legend', { 'nx-legend--optional': !isRequired }),
           invalidMessageId = useUniqueId('nx-fieldset-invalid-message'),
           describedBy = hasValidationErrors(validationErrors) ? invalidMessageId : undefined;
@@ -39,8 +41,8 @@ const NxFieldset = forwardRef<HTMLFieldSetElement, Props>(
           </legend>
           { sublabel && <div className="nx-sub-label">{sublabel}</div> }
           {children}
-          <div id={invalidMessageId} role="alert" className="nx-text-input__invalid-message">
-            {!isPristine && getFirstValidationError(validationErrors)}
+          <div id={invalidMessageId} role="alert" className="nx-form__invalid-field-message">
+            {getFirstValidationError(validationErrors)}
           </div>
         </fieldset>
       );

--- a/lib/src/components/NxFieldset/types.ts
+++ b/lib/src/components/NxFieldset/types.ts
@@ -6,15 +6,20 @@
  */
 import { HTMLAttributes, ReactNode } from 'react';
 import * as PropTypes from 'prop-types';
+import { ValidationErrors } from '../../util/validationUtil';
 
 export interface Props extends HTMLAttributes<HTMLFieldSetElement> {
   label: Exclude<ReactNode, null | undefined>;
   sublabel?: ReactNode | null;
   isRequired?: boolean | null;
+  validationErrors?: ValidationErrors;
+  isPristine?: boolean | null;
 }
 
 export const propTypes: PropTypes.ValidationMap<Props> = {
   label: PropTypes.node.isRequired,
   sublabel: PropTypes.node,
-  isRequired: PropTypes.bool
+  isRequired: PropTypes.bool,
+  validationErrors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string.isRequired), PropTypes.string]),
+  isPristine: PropTypes.bool
 };

--- a/lib/src/components/NxForm/NxForm.tsx
+++ b/lib/src/components/NxForm/NxForm.tsx
@@ -18,7 +18,16 @@ import { FormPristineContext } from './contexts';
 import { getFirstValidationError, hasValidationErrors } from '../../util/validationUtil';
 import { NxErrorAlert } from '../NxAlert/NxAlert';
 
-const NxForm = forwardRef<HTMLFormElement, Props>(
+function RequiredFieldNotice() {
+  return (
+    <span className="nx-form__required-field-notice">
+      <span className="nx-form__required-field-asterisk">*</span>
+      {' '}Required fields are marked with an asterisk
+    </span>
+  );
+}
+
+const _NxForm = forwardRef<HTMLFormElement, Props>(
     function NxForm(props, ref) {
       const {
             className,
@@ -105,7 +114,7 @@ const NxForm = forwardRef<HTMLFormElement, Props>(
     }
 );
 
-NxForm.propTypes = propTypes;
+const NxForm = Object.assign(_NxForm, { propTypes, RequiredFieldNotice });
 
 export default NxForm;
 export { Props, propTypes };

--- a/lib/src/components/NxForm/NxForm.tsx
+++ b/lib/src/components/NxForm/NxForm.tsx
@@ -57,7 +57,7 @@ const NxForm = forwardRef<HTMLFormElement, Props>(
       const renderForm = () => {
         return (
           <form ref={ref} className={formClasses} onSubmit={onSubmit} { ...formAttrs }>
-            <FormPristineContext.Provider value={isPristine || true}>
+            <FormPristineContext.Provider value={isPristine}>
               {getChildren()}
               <footer className="nx-footer">
                 { submitError &&

--- a/lib/src/components/NxForm/NxForm.tsx
+++ b/lib/src/components/NxForm/NxForm.tsx
@@ -16,6 +16,7 @@ import NxSubmitMask from '../NxSubmitMask/NxSubmitMask';
 import { Props, propTypes } from './types';
 import { FormPristineContext } from './contexts';
 import { getFirstValidationError, hasValidationErrors } from '../../util/validationUtil';
+import { NxErrorAlert } from '../NxAlert/NxAlert';
 
 const NxForm = forwardRef<HTMLFormElement, Props>(
     function NxForm(props, ref) {
@@ -66,9 +67,10 @@ const NxForm = forwardRef<HTMLFormElement, Props>(
                                retryHandler={onSubmitProp} />
                 }
                 { !submitError && formHasValidationErrors && !isPristine &&
-                  <NxLoadError titleMessage="There were validation errors."
-                               error={getFirstValidationError(validationErrors)}
-                               retryHandler={onSubmitProp} />
+                  <NxErrorAlert>
+                    There were validation errors.
+                    {getFirstValidationError(validationErrors)}
+                  </NxErrorAlert>
                 }
                 <div className="nx-btn-bar">
                   { additionalFooterBtns }

--- a/lib/src/components/NxForm/contexts.ts
+++ b/lib/src/components/NxForm/contexts.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2019-present Sonatype, Inc.
- * This program and the accompanying materials are made available under
- * the terms of the Eclipse Public License 2.0 which accompanies this
- * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
- */
-import React from 'react';
-
-export const FormPristineContext = React.createContext(true);

--- a/lib/src/components/NxForm/contexts.ts
+++ b/lib/src/components/NxForm/contexts.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+
+export const FormPristineContext = React.createContext(true);

--- a/lib/src/components/NxForm/stateful/NxStatefulForm.tsx
+++ b/lib/src/components/NxForm/stateful/NxStatefulForm.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React, { forwardRef, useEffect, useState } from 'react';
+import { hasValidationErrors } from '../../../util/validationUtil';
+import NxForm from '../NxForm';
+
+import { StatefulProps as Props } from '../types';
+
+export { Props };
+
+const NxStatefulForm = forwardRef<HTMLFormElement, Props>(function NxStatefulForm(props, ref) {
+  const { onSubmit: onSubmitProp, ...otherProps } = props,
+      [isPristine, setIsPristine] = useState(true);
+
+  function onSubmit() {
+    setIsPristine(false);
+
+    if (!hasValidationErrors(props.validationErrors)) {
+      onSubmitProp();
+    }
+  }
+
+  useEffect(function() {
+    if (props.submitMaskState === null) {
+      // reset pristine state after successful submission
+      setIsPristine(true);
+    }
+  }, [props.submitMaskState]);
+
+  return <NxForm ref={ref} { ...otherProps } onSubmit={onSubmit} isPristine={isPristine} />;
+});
+
+export default NxStatefulForm;

--- a/lib/src/components/NxForm/stateful/NxStatefulForm.tsx
+++ b/lib/src/components/NxForm/stateful/NxStatefulForm.tsx
@@ -12,6 +12,7 @@ import { StatefulProps as Props } from '../types';
 
 export { Props };
 
+/* eslint-disable react/prop-types */
 const NxStatefulForm = forwardRef<HTMLFormElement, Props>(function NxStatefulForm(props, ref) {
   const { onSubmit: onSubmitProp, ...otherProps } = props,
       [isPristine, setIsPristine] = useState(true);

--- a/lib/src/components/NxForm/types.ts
+++ b/lib/src/components/NxForm/types.ts
@@ -24,7 +24,10 @@ export interface Props extends FormHTMLAttributes<HTMLFormElement> {
   submitMaskSuccessMessage?: string | null;
   children: ReactNode | (() => ReactNode);
   additionalFooterBtns?: ReactNode | null;
+  isPristine: boolean;
 }
+
+export type StatefulProps = Omit<Props, 'isPristine'>;
 
 export const propTypes: ValidationMap<Props> = {
   loading: PropTypes.bool,

--- a/lib/src/components/NxForm/types.ts
+++ b/lib/src/components/NxForm/types.ts
@@ -24,10 +24,10 @@ export interface Props extends FormHTMLAttributes<HTMLFormElement> {
   submitMaskSuccessMessage?: string | null;
   children: ReactNode | (() => ReactNode);
   additionalFooterBtns?: ReactNode | null;
-  isPristine: boolean;
+  showValidationErrors: boolean;
 }
 
-export type StatefulProps = Omit<Props, 'isPristine'>;
+export type StatefulProps = Omit<Props, 'showValidationErrors'>;
 
 export const propTypes: ValidationMap<Props> = {
   loading: PropTypes.bool,

--- a/lib/src/components/NxTextInput/NxTextInput.scss
+++ b/lib/src/components/NxTextInput/NxTextInput.scss
@@ -20,28 +20,15 @@
   .nx-icon--valid {
     color: var(--nx-color-validation-valid);
   }
+}
+
+// validation messages should be shown in these cases
+.nx-form--show-validation-errors .nx-text-input, .nx-text-input:not(.pristine) {
+  &.valid {
+    @include nx-form-validation-helpers.valid;
+  }
 
   &.invalid {
     @include nx-form-validation-helpers.invalid;
   }
-
-  &.pristine, &.pristine.valid {
-    .nx-icon--invalid, .nx-icon--valid {
-      display: none;
-    }
-  }
-
-  &.valid {
-    @include nx-form-validation-helpers.valid;
-  }
-}
-
-.nx-text-input__invalid-message {
-  color: var(--nx-color-validation-invalid);
-  font-size: var(--nx-font-size-xs);
-  line-height: 16px;
-  margin-top: var(--nx-spacing-2x);
-  // this positions the invalid message inside the bottom padding of .nx-form-group which allows
-  // us to maintain consistent spacing whether there is validation or not
-  position: absolute;
 }

--- a/lib/src/components/NxTextInput/NxTextInput.tsx
+++ b/lib/src/components/NxTextInput/NxTextInput.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { forwardRef, FormEvent, KeyboardEvent, useRef, MutableRefObject } from 'react';
+import React, { forwardRef, FormEvent, KeyboardEvent, useRef, MutableRefObject, useContext } from 'react';
 import classnames from 'classnames';
 import { omit } from 'ramda';
 import { faExclamationCircle, faCheck } from '@fortawesome/free-solid-svg-icons';
@@ -15,6 +15,7 @@ import NxFontAwesomeIcon from '../NxFontAwesomeIcon/NxFontAwesomeIcon';
 import { Props, PublicProps, propTypes, TextInputElement } from './types';
 import { hasValidationErrors, getFirstValidationError } from '../../util/validationUtil';
 import { useUniqueId } from '../../util/idUtil';
+import { FormPristineContext } from '../NxForm/contexts';
 export { Props, PublicProps, StateProps, propTypes, inputTypes } from './types';
 
 /*
@@ -26,7 +27,7 @@ export const PrivateNxTextInput = forwardRef<HTMLDivElement, Props>(
     function PrivateNxTextInput(props, forwardedRef) {
       const {
         type,
-        isPristine,
+        isPristine: isPristineProp,
         validatable,
         validationErrors,
         onChange,
@@ -50,6 +51,8 @@ export const PrivateNxTextInput = forwardRef<HTMLDivElement, Props>(
           typeAttr = isTextArea ? undefined : (type || 'text'),
           isInvalid = validatable && hasValidationErrors(validationErrors),
           firstValidationError = validatable && getFirstValidationError(validationErrors),
+          formPristine = useContext(FormPristineContext),
+          isPristine = isPristineProp && formPristine,
           internalClassName = classnames('nx-text-input', className, {
             pristine: isPristine,
             invalid: !isPristine && validatable && isInvalid,

--- a/lib/src/components/NxTextInput/NxTextInput.tsx
+++ b/lib/src/components/NxTextInput/NxTextInput.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { forwardRef, FormEvent, KeyboardEvent, useRef, MutableRefObject, useContext } from 'react';
+import React, { forwardRef, FormEvent, KeyboardEvent, useRef, MutableRefObject } from 'react';
 import classnames from 'classnames';
 import { omit } from 'ramda';
 import { faExclamationCircle, faCheck } from '@fortawesome/free-solid-svg-icons';
@@ -15,7 +15,6 @@ import NxFontAwesomeIcon from '../NxFontAwesomeIcon/NxFontAwesomeIcon';
 import { Props, PublicProps, propTypes, TextInputElement } from './types';
 import { hasValidationErrors, getFirstValidationError } from '../../util/validationUtil';
 import { useUniqueId } from '../../util/idUtil';
-import { FormPristineContext } from '../NxForm/contexts';
 export { Props, PublicProps, StateProps, propTypes, inputTypes } from './types';
 
 /*
@@ -27,7 +26,7 @@ export const PrivateNxTextInput = forwardRef<HTMLDivElement, Props>(
     function PrivateNxTextInput(props, forwardedRef) {
       const {
         type,
-        isPristine: isPristineProp,
+        isPristine,
         validatable,
         validationErrors,
         onChange,
@@ -51,12 +50,10 @@ export const PrivateNxTextInput = forwardRef<HTMLDivElement, Props>(
           typeAttr = isTextArea ? undefined : (type || 'text'),
           isInvalid = validatable && hasValidationErrors(validationErrors),
           firstValidationError = validatable && getFirstValidationError(validationErrors),
-          formPristine = useContext(FormPristineContext),
-          isPristine = isPristineProp && formPristine,
           internalClassName = classnames('nx-text-input', className, {
             pristine: isPristine,
-            invalid: !isPristine && validatable && isInvalid,
-            valid: !isPristine && validatable && !isInvalid,
+            invalid: validatable && isInvalid,
+            valid: validatable && !isInvalid,
             disabled: disabled,
             'nx-text-input--textarea': isTextArea
           });
@@ -106,8 +103,8 @@ export const PrivateNxTextInput = forwardRef<HTMLDivElement, Props>(
             <NxFontAwesomeIcon icon={faCheck} className="nx-icon nx-icon--valid"/>
             <NxFontAwesomeIcon icon={faExclamationCircle} className="nx-icon nx-icon--invalid"/>
           </div>
-          <div id={invalidMessageId} role="alert" className="nx-text-input__invalid-message">
-            {!isPristine && firstValidationError}
+          <div id={invalidMessageId} role="alert" className="nx-form__invalid-field-message">
+            {firstValidationError}
           </div>
         </div>
       );

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -184,6 +184,10 @@ export {
   default as NxForm,
   Props as NxFormProps
 } from './components/NxForm/NxForm';
+export {
+  default as NxStatefulForm,
+  Props as NxStatefulFormProps
+} from './components/NxForm/stateful/NxStatefulForm';
 
 export * from './util/threatLevels';
 export * from './util/validationUtil';


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1064

This spike demonstrates how the design changes around required fields in forms can be implemented.  These are breaking changes that add a new required prop to `NxForm`. That prop is strictly checked at runtime to ensure its use and thus ensure that downstream code code does in fact upgrade all of their forms to the new logic.  Or at least, all of their forms that are build on `NxForm`.

The requirements are as follows:
1. Submit button is no longer disabled when the form is invalid overall
2. If a submit is attempted while the form is invalid, an error message will appear in the form footer telling the user what is wrong (i.e. the same message currently used as the submit button tooltip) and all individual field validation errors will become visible.
3. The error in the footer will disappear as soon as all field are corrected

To accomplish the above, this PR does a few major things:
1. Adds an `isPristine` prop to `NxForm` that behaves similarly to the `isPristine` prop on individual fields: it suppresses validation messages when true.  Upon clicking submit, this prop should be set to false which not only allows the form's overall validation message to appear but also, via a React context, overrides the `isPristine` state on all children, causing all of them to show any applicable validation messages.
2. Adds `isPristine` and `validationErrors` props to `NxFieldset`.  This is intended for cases where a fieldset contains a group of checkboxes, at least one of which must be selected.  This is one of the types of messages that we want to show when the submission is attempted
3. Adds `NxStatefulForm` to encapsulate the `isPristine` logic for `NxForm`.  Note that this component can only be used "single submit" forms.  Forms that can be saved and then remain present for further modification should not use this component as the `isPristine` flag does not get reset on submission.

Additionally, this PR changes the required field styling as prescribed by design.  Optional fields are no longer called out with the italic "Optional" text, and instead required fields are called out with an asterisk ~~(black at this moment, to be updated to red shortly to match the latest mockups)~~

~~One thing this PR does not do, and about which I don't think there's a whole lot we can do, is add the label that design has prescribed for the tops of forms which indicates that the red asterisks shows required fields.  `NxForm` doesn't have any control or special awareness around any header it might contain, and so cannot automatically add such a message.  One thing that could be done would be to add a React component that just hard codes that message~~

This PR also adds a component to encapsulate the standard message that should be included at the tops of forms to define the asterisk.  Note that `NxForm` cannot include this message automatically as it has no knowledge of its header structure.  So instead we just provide a component which contains the appropriate text and require forms to include that component.  In this PR, that is demonstrated on the `nx-tile` form example, though note that that example is not fully fleshed out in other ways (such as actual validation logic).  Making all examples more consistent would be desired when moving this spike to production readiness.