### PR TITLE
RSC-998 donut chart docs

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "10.1.6",
+  "version": "10.1.7",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.scss
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.scss
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+
+ .gallery-binary-donut-chart-custom {
+    display: block;
+    height: 45px;
+  }
+  

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.scss
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.scss
@@ -8,5 +8,8 @@
  .gallery-binary-donut-chart-custom {
     display: block;
     height: 45px;
+    .nx-binary-donut-chart__arc {
+      stroke: var(--nx-swatch-purple-70);
+    }
   }
   

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.scss
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.scss
@@ -12,4 +12,3 @@
       stroke: var(--nx-swatch-purple-70);
     }
   }
-  

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.tsx
@@ -10,12 +10,24 @@ import { NxBinaryDonutChart } from '@sonatype/react-shared-components';
 export default function NxBinaryDonutChartCustomExample() {
   return (
     <>
-      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={0} aria-label="0 out of 100 components identified" />
-      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={15} aria-label="15 out of 100 components identified" />
-      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={25} aria-label="25 out of 100 components identified" />
-      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={50} aria-label="50 out of 100 components identified" />
-      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={90} aria-label="90 out of 100 components identified" />
-      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={100} aria-label="100 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom"
+                          percent={0}
+                          aria-label="0 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom"
+                          percent={15}
+                          aria-label="15 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom"
+                          percent={25}
+                          aria-label="25 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom"
+                          percent={50}
+                          aria-label="50 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom"
+                          percent={90}
+                          aria-label="90 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom"
+                          percent={100}
+                          aria-label="100 out of 100 components identified" />
     </>
   );
 }

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import React from 'react';
+import { NxBinaryDonutChart } from '@sonatype/react-shared-components';
+
+export default function NxBinaryDonutChartCustomExample() {
+  return (
+    <>
+      <NxBinaryDonutChart percent={0} aria-label="0 out of 100 components identified" />
+      <NxBinaryDonutChart percent={15} role="presentation" />
+      <NxBinaryDonutChart percent={25} role="presentation" />
+      <NxBinaryDonutChart percent={50} aria-label="50 out of 100 components identified" />
+      <NxBinaryDonutChart percent={90} role="presentation" />
+      <NxBinaryDonutChart percent={100} aria-label="100 out of 100 components identified" />
+    </>
+  );
+}

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartCustomExample.tsx
@@ -10,12 +10,12 @@ import { NxBinaryDonutChart } from '@sonatype/react-shared-components';
 export default function NxBinaryDonutChartCustomExample() {
   return (
     <>
-      <NxBinaryDonutChart percent={0} aria-label="0 out of 100 components identified" />
-      <NxBinaryDonutChart percent={15} role="presentation" />
-      <NxBinaryDonutChart percent={25} role="presentation" />
-      <NxBinaryDonutChart percent={50} aria-label="50 out of 100 components identified" />
-      <NxBinaryDonutChart percent={90} role="presentation" />
-      <NxBinaryDonutChart percent={100} aria-label="100 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={0} aria-label="0 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={15} aria-label="15 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={25} aria-label="25 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={50} aria-label="50 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={90} aria-label="90 out of 100 components identified" />
+      <NxBinaryDonutChart className="gallery-binary-donut-chart-custom" percent={100} aria-label="100 out of 100 components identified" />
     </>
   );
 }

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -23,6 +23,7 @@ const nxBinaryDonutChartNoHoleExample = require('./NxBinaryDonutChartNoHoleExamp
 const nxBinaryDonutChartLargeHoleExample = require('./NxBinaryDonutChartLargeHoleExample?raw');
 const nxBinaryDonutChartBackgroundColorExample = require('./NxBinaryDonutChartBackgroundColorExample?raw');
 const nxBinaryDonutChartCustomExample = require('./NxBinaryDonutChartCustomExample?raw');
+const nxBinaryDonutChartCustomExampleScss = require('./NxBinaryDonutChartCustomExample.scss?raw');
 
 const NxBinaryDonutChartPage = () =>
   <>
@@ -137,7 +138,8 @@ const NxBinaryDonutChartPage = () =>
 
     <GalleryExampleTile title="Example with Custom CSS Properties"
                         id="nx-binary-donut-chart-custom-examples"
-                        codeExamples={nxBinaryDonutChartCustomExample}
+                        codeExamples={[nxBinaryDonutChartCustomExample,
+                          { content: nxBinaryDonutChartCustomExampleScss, language: 'scss' }]}
                         liveExample={NxBinaryDonutChartCustomExample}>
       An example of <NxCode>NxBinaryDonutChart</NxCode>s with customized CSS properties. The example shows
       the display property set to block, the height set to 45px, and a custom color.

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -27,6 +27,18 @@ const NxBinaryDonutChartPage = () =>
       <NxP>
         <NxCode>NxBinaryDonutChart</NxCode> represents a binary donut chart.
       </NxP>
+      <NxP>
+        The <NxCode>NxBinaryDonutChart</NxCode> accepts a default height of 30px (without padding or margin), which
+        can be modified by accessing the CSS height property on the <NxCode>.nx-binary-donut-chart</NxCode> class.
+      </NxP>
+      <NxP>
+        By default the CSS property of <NxCode>NxBinaryDonutChart</NxCode> is set to a value of
+        inline. <NxCode>Display:inline</NxCode> will not generate any line breaks to maintain the flow of the
+        container, and situate preceding / proceeding elements of the same display property next to one another. The
+        chart's display property can be overridden to block, which will generate a line break both before and after
+        the element to create vertical stacking within the parent container. This can be done by
+        adding <NxCode>display:block</NxCode> to the <NxCode>.nx-binary-donut-chart</NxCode> class.
+      </NxP>
       <NxTable>
         <NxTable.Head>
           <NxTable.Row>

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -16,6 +16,7 @@ import NxBinaryDonutChartBackgroundColorExample from './NxBinaryDonutChartBackgr
 import NxBinaryDonutChartCustomExample from './NxBinaryDonutChartCustomExample';
 
 import './NxBinaryDonutChartBackgroundColorExample.scss';
+import './NxBinaryDonutChartCustomExample.scss'
 
 const nxBinaryDonutChartMinimalExampleCode = require('./NxBinaryDonutChartMinimalExample?raw');
 const nxBinaryDonutChartNoHoleExample = require('./NxBinaryDonutChartNoHoleExample?raw');

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -21,6 +21,7 @@ const nxBinaryDonutChartMinimalExampleCode = require('./NxBinaryDonutChartMinima
 const nxBinaryDonutChartNoHoleExample = require('./NxBinaryDonutChartNoHoleExample?raw');
 const nxBinaryDonutChartLargeHoleExample = require('./NxBinaryDonutChartLargeHoleExample?raw');
 const nxBinaryDonutChartBackgroundColorExample = require('./NxBinaryDonutChartBackgroundColorExample?raw');
+const nxBinaryDonutChartCustomExample = require('./NxBinaryDonutChartCustomExample?raw');
 
 const NxBinaryDonutChartPage = () =>
   <>
@@ -131,6 +132,14 @@ const NxBinaryDonutChartPage = () =>
       Examples of <NxCode>NxBinaryDonutChart</NxCode>s on containers that have background colors which match parts
       of the chart. This example shows that the chart is still discernable in this case due to the white borders
       on the inside and outside of the donut.
+    </GalleryExampleTile>
+
+    <GalleryExampleTile title="Example with Custom CSS Properties"
+                        id="nx-binary-donut-chart-custom-examples"
+                        codeExamples={nxBinaryDonutChartCustomExample}
+                        liveExample={NxBinaryDonutChartCustomExample}>
+      An example of <NxCode>NxBinaryDonutChart</NxCode>s with customized CSS properties. The example shows
+      the display property set to block, and the height property set to 45px.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -140,7 +140,7 @@ const NxBinaryDonutChartPage = () =>
                         codeExamples={nxBinaryDonutChartCustomExample}
                         liveExample={NxBinaryDonutChartCustomExample}>
       An example of <NxCode>NxBinaryDonutChart</NxCode>s with customized CSS properties. The example shows
-      the display property set to block, and the height property set to 45px.
+      the display property set to block, the height set to 45px, and a custom color.
     </GalleryExampleTile>
   </>;
 

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -29,15 +29,15 @@ const NxBinaryDonutChartPage = () =>
       </NxP>
       <NxP>
         The <NxCode>NxBinaryDonutChart</NxCode> accepts a default height of 30px (without padding or margin), which
-        can be modified by accessing the CSS height property on the <NxCode>.nx-binary-donut-chart</NxCode> class.
+        can be modified by applying a new class to the element with the height property and preferred value defined.
       </NxP>
       <NxP>
-        By default the CSS property of <NxCode>NxBinaryDonutChart</NxCode> is set to a value of
-        inline. <NxCode>Display:inline</NxCode> will not generate any line breaks to maintain the flow of the
+        By default the CSS display property of <NxCode>NxBinaryDonutChart</NxCode> is set to a value of
+        inline. <NxCode>display:inline</NxCode> will not generate any line breaks to maintain the flow of the
         container, and situate preceding / proceeding elements of the same display property next to one another. The
         chart's display property can be overridden to block, which will generate a line break both before and after
-        the element to create vertical stacking within the parent container. This can be done by
-        adding <NxCode>display:block</NxCode> to the <NxCode>.nx-binary-donut-chart</NxCode> class.
+        the element to create vertical stacking within the parent container. This can be done by applying a new class
+        to the element with the display property's value set to block.
       </NxP>
       <NxTable>
         <NxTable.Head>

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -13,6 +13,7 @@ import NxBinaryDonutChartMinimalExample from './NxBinaryDonutChartMinimalExample
 import NxBinaryDonutChartNoHoleExample from './NxBinaryDonutChartNoHoleExample';
 import NxBinaryDonutChartLargeHoleExample from './NxBinaryDonutChartLargeHoleExample';
 import NxBinaryDonutChartBackgroundColorExample from './NxBinaryDonutChartBackgroundColorExample';
+import NxBinaryDonutChartCustomExample from './NxBinaryDonutChartCustomExample';
 
 import './NxBinaryDonutChartBackgroundColorExample.scss';
 

--- a/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
+++ b/gallery/src/components/NxBinaryDonutChart/NxBinaryDonutChartPage.tsx
@@ -16,7 +16,7 @@ import NxBinaryDonutChartBackgroundColorExample from './NxBinaryDonutChartBackgr
 import NxBinaryDonutChartCustomExample from './NxBinaryDonutChartCustomExample';
 
 import './NxBinaryDonutChartBackgroundColorExample.scss';
-import './NxBinaryDonutChartCustomExample.scss'
+import './NxBinaryDonutChartCustomExample.scss';
 
 const nxBinaryDonutChartMinimalExampleCode = require('./NxBinaryDonutChartMinimalExample?raw');
 const nxBinaryDonutChartNoHoleExample = require('./NxBinaryDonutChartNoHoleExample?raw');

--- a/gallery/visualtests/__image_snapshots__/nx-binary-donut-chart-js-nx-binary-donut-chart-nx-binary-donut-chart-donut-with-large-hole-looks-right-1-snap.png
+++ b/gallery/visualtests/__image_snapshots__/nx-binary-donut-chart-js-nx-binary-donut-chart-nx-binary-donut-chart-donut-with-large-hole-looks-right-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24a5c6a2833d1ac6cd986abe8dec814652eb502cb4d64fea9fbeb065d4bac350
-size 1690
+oid sha256:7217a5d3a6864e0e2c643924e2b7415fb44fe31bf6a10964de4359513d24a679
+size 1691

--- a/gallery/visualtests/__image_snapshots__/nx-binary-donut-chart-js-nx-binary-donut-chart-nx-binary-donut-chart-donut-with-large-hole-looks-right-1-snap.png
+++ b/gallery/visualtests/__image_snapshots__/nx-binary-donut-chart-js-nx-binary-donut-chart-nx-binary-donut-chart-donut-with-large-hole-looks-right-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3eb364d4d01e0abc75cf74ab52d503e29c8c6dd6fc66c0d33322f63f0282d9ef
-size 1696
+oid sha256:24a5c6a2833d1ac6cd986abe8dec814652eb502cb4d64fea9fbeb065d4bac350
+size 1690

--- a/gallery/visualtests/__image_snapshots__/nx-binary-donut-chart-js-nx-binary-donut-chart-nx-binary-donut-chart-with-custom-properties-has-custom-properties-1-snap.png
+++ b/gallery/visualtests/__image_snapshots__/nx-binary-donut-chart-js-nx-binary-donut-chart-nx-binary-donut-chart-with-custom-properties-has-custom-properties-1-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b888969e3339b99543cac0696958ea14b13d91499408df26409aefe48484ec64
+size 8761

--- a/gallery/visualtests/nxBinaryDonutChart.js
+++ b/gallery/visualtests/nxBinaryDonutChart.js
@@ -29,5 +29,10 @@ describe('NxBinaryDonutChart', function() {
     it('has visible borders', simpleTest(simpleDonutSelector));
   });
 
+  describe('NxBinaryDonutChart with custom properties', function() {
+    const simpleDonutSelector = '#nx-binary-donut-chart-custom-examples .gallery-example-live';
+    it('has custom properties', simpleTest(simpleDonutSelector));
+  });
+
   it('passes a11y checks', a11yTest());
 });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "10.1.6",
+  "version": "10.1.7",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/__tests__/SimpleComponents.test.tsx
+++ b/lib/src/components/__tests__/SimpleComponents.test.tsx
@@ -264,7 +264,7 @@ describe('NxPageTitle', function() {
 
 describe('NxPageTitle.Headings', function() {
   it('makes a <hgroup> tag with an nx-page-title__headings class', function() {
-    expect(shallow(<NxPageTitle.Headings/>)).toMatchSelector('div.nx-page-title__headings');
+    expect(shallow(<NxPageTitle.Headings/>)).toMatchSelector('hgroup.nx-page-title__headings');
   });
 });
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-998

Update the description tile inside of the gallery to provide information on the default behaviours of CSS height and display properties, and the options to override the defaults. 