### PR TITLE
RSC-1095 Add awaits for NxSearchDropdown visual test

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "10.2.2",
+  "version": "10.2.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/visualtests/nxSearchDropdown.js
+++ b/gallery/visualtests/nxSearchDropdown.js
@@ -280,7 +280,7 @@ describe('NxSearchDropdown', function() {
       await waitAndGetElements(`${basicExampleSelector} .nx-dropdown-button:first-child`);
 
       // check pressing esc on the text input
-      page.keyboard.press('Escape');
+      await page.keyboard.press('Escape');
       expect(await isFocused(input)).toBe(true);
       expect(await input.evaluate(el => el.value)).toBe('');
 
@@ -289,7 +289,7 @@ describe('NxSearchDropdown', function() {
       await firstBtn.focus();
 
       // check pressing esc on a dropdown button
-      page.keyboard.press('Escape');
+      await page.keyboard.press('Escape');
       expect(await isFocused(input)).toBe(true);
       expect(await input.evaluate(el => el.value)).toBe('');
 
@@ -300,7 +300,7 @@ describe('NxSearchDropdown', function() {
       await errorRetryBtn.focus();
 
       // check pressing esc on error Retry button
-      page.keyboard.press('Escape');
+      await page.keyboard.press('Escape');
       expect(await isFocused(errorInput)).toBe(true);
       expect(await errorInput.evaluate(el => el.value)).toBe('');
     });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "10.2.2",
+  "version": "10.2.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1095

Took a look through all the visual tests inside gallery, and the NxSearchDropdown test appears to be the only one missing awaits