### PR TITLE
Rsc 1128 nx code snippet row consistency

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxCodeSnippet/NxCodeSnippet.scss
+++ b/lib/src/components/NxCodeSnippet/NxCodeSnippet.scss
@@ -42,6 +42,7 @@
   .nx-text-input {
     grid-area: textarea;
     width: 100%;
+    overflow-x: hidden;
 
     .nx-text-input__box {
       border-color: var(--nx-color-form-element-border);


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1128

When testing, Alex noticed that in Firefox on a PC, an extra blank row was added to both textareas in the Single-Line and Complex Examples (when the rows attribute was defined). 
This seems to be a common issue in Firefox : 
https://stackoverflow.com/questions/46746887/textarea-extra-row-in-firefox-browser
https://github.com/necolas/normalize.css/issues/505

Added in overflow-x:hidden, which seems to do the trick in eliminating the extra row. 