### PR TITLE
NxSearchDropdown Selection Fix for Safari - RSC-1153

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "10.5.4",
+  "version": "10.5.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "10.5.4",
+  "version": "10.5.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
+++ b/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
@@ -28,10 +28,20 @@
     text-align: center;
   }
 
-  &--dropdown-showable:focus-within {
-    .nx-search-dropdown__menu {
-      position: absolute;
-      right: initial;
+  &--dropdown-showable {
+    @mixin show-menu {
+      .nx-search-dropdown__menu {
+        position: absolute;
+        right: initial;
+      }
+    }
+
+    &:focus-within {
+      @include show-menu
+    }
+
+    @supports (overflow: -webkit-paged-x) {
+      @include show-menu;
     }
   }
 

--- a/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
+++ b/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
@@ -40,6 +40,12 @@
       @include show-menu
     }
 
+    // Hack to detect Safari. In Safari, focus seems to be intended to strictly be a keyboard nav thing,
+    // and when you click a button, focus does NOT go to that button, it goes to the <body>. This messes up our idea
+    // of only showing the menu when something within the component has focus, because this means that the
+    // component loses focus in the middle of the click, causing the menu to hide while the user is in the middle
+    // of clicking, causing the click not to register at all. As a workaround, in Safari we remove the behavior
+    // where the menu is only visible when the compoent has focus.
     @supports (overflow: -webkit-paged-x) {
       @include show-menu;
     }

--- a/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
+++ b/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
@@ -37,7 +37,7 @@
     }
 
     &:focus-within {
-      @include show-menu
+      @include show-menu;
     }
 
     // Hack to detect Safari. In Safari, focus seems to be intended to strictly be a keyboard nav thing,

--- a/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
+++ b/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
@@ -45,7 +45,7 @@
     // of only showing the menu when something within the component has focus, because this means that the
     // component loses focus in the middle of the click, causing the menu to hide while the user is in the middle
     // of clicking, causing the click not to register at all. As a workaround, in Safari we remove the behavior
-    // where the menu is only visible when the compoent has focus.
+    // where the menu is only visible when the component has focus.
     @supports (overflow: -webkit-paged-x) {
       @include show-menu;
     }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1153

This will need to be tested across all supported browser and operating system combinations, especially focusing on Mac.  