### PR TITLE
Fix NxToast a11yTest - RSC-1164

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
@@ -39,15 +39,19 @@ const sidebarLogoPath = require('../../assets/images/logo-plaid-villain-text.png
 
 interface ToastModel {
   id: number;
-  alertComponent: ComponentType;
+  alertComponent: ComponentType<alertComponentProps>;
   message: string;
 }
+
+type alertComponentProps = {
+  role?:string;
+};
 
 export default function NxToastComplexLayoutExample() {
   const [toastIdInc, setToastIdInc] = useState<number>(0);
   const [toasts, setToasts] = useState<ToastModel[]>([]);
 
-  const addToast = (alertComponent: ComponentType, message: string) => {
+  const addToast = (alertComponent: ComponentType<alertComponentProps>, message: string) => {
     const toastId = toastIdInc + 1;
     setToastIdInc(toastId);
     setToasts([
@@ -70,7 +74,11 @@ export default function NxToastComplexLayoutExample() {
             return (
               <NxToast key={id}
                        onClose={()=> removeToast(id)}>
-                <ToastAlert>{message}</ToastAlert>
+                {
+                  ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
+                    <ToastAlert role= 'status'>{message}</ToastAlert> :
+                    <ToastAlert>{message}</ToastAlert>
+                }
               </NxToast>
             );
           })

--- a/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
@@ -39,11 +39,11 @@ const sidebarLogoPath = require('../../assets/images/logo-plaid-villain-text.png
 
 interface ToastModel {
   id: number;
-  alertComponent: ComponentType<alertComponentProps>;
+  alertComponent: ComponentType<AlertComponentProps>;
   message: string;
 }
 
-type alertComponentProps = {
+type AlertComponentProps = {
   role?: string;
 };
 
@@ -51,7 +51,7 @@ export default function NxToastComplexLayoutExample() {
   const [toastIdInc, setToastIdInc] = useState<number>(0);
   const [toasts, setToasts] = useState<ToastModel[]>([]);
 
-  const addToast = (alertComponent: ComponentType<alertComponentProps>, message: string) => {
+  const addToast = (alertComponent: ComponentType<AlertComponentProps>, message: string) => {
     const toastId = toastIdInc + 1;
     setToastIdInc(toastId);
     setToasts([

--- a/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
@@ -75,7 +75,7 @@ export default function NxToastComplexLayoutExample() {
               <NxToast key={id}
                        onClose={()=> removeToast(id)}>
                 {
-                  ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
+                  ToastAlert === NxInfoAlert ?
                     <ToastAlert role="status">{message}</ToastAlert> :
                     <ToastAlert>{message}</ToastAlert>
                 }

--- a/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastComplexLayoutExample.tsx
@@ -44,7 +44,7 @@ interface ToastModel {
 }
 
 type alertComponentProps = {
-  role?:string;
+  role?: string;
 };
 
 export default function NxToastComplexLayoutExample() {
@@ -76,7 +76,7 @@ export default function NxToastComplexLayoutExample() {
                        onClose={()=> removeToast(id)}>
                 {
                   ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
-                    <ToastAlert role= 'status'>{message}</ToastAlert> :
+                    <ToastAlert role="status">{message}</ToastAlert> :
                     <ToastAlert>{message}</ToastAlert>
                 }
               </NxToast>

--- a/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
@@ -12,8 +12,9 @@ import {
   NxP,
   NxPageSidebar,
   NxPageMain,
+  NxPageTitle,
   NxTile,
-  NxH2,
+  NxH1,
   NxButton,
   NxButtonBar,
   NxBackButton,
@@ -99,12 +100,10 @@ export default function NxToastLegacyLayoutExample() {
           </NxP>
         </NxPageSidebar>
         <NxPageMain>
+          <NxPageTitle>
+            <NxH1>Lorem Ipsum</NxH1>
+          </NxPageTitle>
           <NxTile>
-            <NxTile.Header>
-              <NxTile.HeaderTitle>
-                <NxH2>Lorem Ipsum</NxH2>
-              </NxTile.HeaderTitle>
-            </NxTile.Header>
             <NxTile.Content>
               <NxP>Scroll Down to Find Toast Buttons</NxP>
               <NxBackButton href="#/pages/Toast" targetPageTitle="Documentation" />

--- a/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
@@ -30,11 +30,10 @@ interface ToastModel {
   id: number;
   alertComponent: ComponentType<alertComponentProps>;
   message: string;
-  role?:string;
 }
 
 type alertComponentProps = {
-  role?:string;
+  role?: string;
 };
 
 export default function NxToastLegacyLayoutExample() {
@@ -64,7 +63,7 @@ export default function NxToastLegacyLayoutExample() {
                        onClose={()=> removeToast(id)}>
                 {
                   ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
-                    <ToastAlert role= 'status'>{message}</ToastAlert> :
+                    <ToastAlert role="status">{message}</ToastAlert> :
                     <ToastAlert>{message}</ToastAlert>
                 }
               </NxToast>

--- a/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
@@ -27,15 +27,20 @@ import {
 
 interface ToastModel {
   id: number;
-  alertComponent: ComponentType;
+  alertComponent: ComponentType<alertComponentProps>;
   message: string;
+  role?:string;
 }
+
+type alertComponentProps = {
+  role?:string;
+};
 
 export default function NxToastLegacyLayoutExample() {
   const [toastIdInc, setToastIdInc] = useState<number>(0);
   const [toasts, setToasts] = useState<ToastModel[]>([]);
 
-  const addToast = (alertComponent: ComponentType, message: string) => {
+  const addToast = (alertComponent: ComponentType<alertComponentProps>, message: string) => {
     const toastId = toastIdInc + 1;
     setToastIdInc(toastId);
     setToasts([
@@ -56,7 +61,11 @@ export default function NxToastLegacyLayoutExample() {
             return (
               <NxToast key={id}
                        onClose={()=> removeToast(id)}>
-                <ToastAlert>{message}</ToastAlert>
+                {
+                  ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
+                    <ToastAlert role= 'status'>{message}</ToastAlert> :
+                    <ToastAlert>{message}</ToastAlert>
+                }
               </NxToast>
             );
           })

--- a/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastLegacyLayoutExample.tsx
@@ -28,19 +28,15 @@ import {
 
 interface ToastModel {
   id: number;
-  alertComponent: ComponentType<alertComponentProps>;
+  alertComponent: ComponentType;
   message: string;
 }
-
-type alertComponentProps = {
-  role?: string;
-};
 
 export default function NxToastLegacyLayoutExample() {
   const [toastIdInc, setToastIdInc] = useState<number>(0);
   const [toasts, setToasts] = useState<ToastModel[]>([]);
 
-  const addToast = (alertComponent: ComponentType<alertComponentProps>, message: string) => {
+  const addToast = (alertComponent: ComponentType, message: string) => {
     const toastId = toastIdInc + 1;
     setToastIdInc(toastId);
     setToasts([
@@ -61,11 +57,7 @@ export default function NxToastLegacyLayoutExample() {
             return (
               <NxToast key={id}
                        onClose={()=> removeToast(id)}>
-                {
-                  ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
-                    <ToastAlert role="status">{message}</ToastAlert> :
-                    <ToastAlert>{message}</ToastAlert>
-                }
+                <ToastAlert>{message}</ToastAlert>
               </NxToast>
             );
           })

--- a/gallery/src/components/NxToast/NxToastPage.tsx
+++ b/gallery/src/components/NxToast/NxToastPage.tsx
@@ -112,13 +112,7 @@ const NxToastPage = () =>
                 </NxP>
                 <NxP>
                   <NxCode>Nx*Alert</NxCode>s as children of <NxCode>NxToast</NxCode> will be assigned a default role
-                  of <NxCode>alert</NxCode>. The role can be updated to either <NxCode>status</NxCode> or
-                  {' '}<NxCode>log</NxCode>. One of these three {' '}
-                  <NxTextLink external href="https://www.w3.org/TR/wai-aria/#live_region_roles">
-                    Live Region
-                  </NxTextLink>
-                  {' '}roles must be provided to ensure the content inside <NxCode>NxToast</NxCode> will be read
-                  immediately by screenreaders when rendered on the page.
+                  of <NxCode>alert</NxCode>, which can be overridden if necessary.
                 </NxP>
               </NxTable.Cell>
             </NxTable.Row>
@@ -180,8 +174,8 @@ const NxToastPage = () =>
         <NxP>
           A complex full page layout example. With the inclusion of <NxCode>NxGlobalHeader</NxCode>, the toasts
           will be positioned on the right side of the viewport, underneath the header. Extra content is provided
-          to be able to view the positioning of the toasts with scrolling behavior. The role for NxInfoAlert has
-          also been updated to <NxCode>status</NxCode>.
+          to be able to view the positioning of the toasts with scrolling behavior. The role for
+          {' '}<NxCode>NxInfoAlert</NxCode> has also been updated to <NxCode>status</NxCode>.
         </NxP>
         <NxP>
           <NxTextLink href="#/NxToastComplexLayoutExample">

--- a/gallery/src/components/NxToast/NxToastPage.tsx
+++ b/gallery/src/components/NxToast/NxToastPage.tsx
@@ -100,24 +100,26 @@ const NxToastPage = () =>
               <NxTable.Cell>React Element</NxTable.Cell>
               <NxTable.Cell>Yes</NxTable.Cell>
               <NxTable.Cell>
-                A single <NxCode>ReactElement</NxCode> which accepts an <NxCode>onClose</NxCode> prop and which
-                ultimately renders an <NxCode>NxAlert</NxCode> (or one of its variants such as
-                {' '}<NxCode>NxSuccessAlert</NxCode>). Most commonly, this would just be one of the RSC
-                {' '}<NxCode>Nx*Alert</NxCode> components themselves, but custom wrapping components are also permitted.
-                Note that the calling code should not specify the <NxCode>onClose</NxCode> prop for the alert; it will
-                be set up internally by <NxCode>NxToast</NxCode>. Calling code should instead use the
-                {' '}<NxCode>onClose</NxCode> prop of <NxCode>NxToast</NxCode> itself. Additionally, note that the alert
-                text content should be brief: only one rendered line of text per toast is supported.
-                <NxWarningAlert>
-                  <NxCode>Nx*Alert</NxCode>s must be passed a {' '}
+                <NxP>
+                  A single <NxCode>ReactElement</NxCode> which accepts an <NxCode>onClose</NxCode> prop and which
+                  ultimately renders an <NxCode>NxAlert</NxCode> (or one of its variants such as
+                  {' '}<NxCode>NxSuccessAlert</NxCode>). Most commonly, this would just be one of the RSC
+                  {' '}<NxCode>Nx*Alert</NxCode> components themselves, but custom wrapping components are also
+                  permitted. Note that the calling code should not specify the <NxCode>onClose</NxCode> prop for the
+                  alert; it will be set up internally by <NxCode>NxToast</NxCode>. Calling code should instead use the
+                  {' '}<NxCode>onClose</NxCode> prop of <NxCode>NxToast</NxCode> itself. Additionally, note that the
+                  alert text content should be brief: only one rendered line of text per toast is supported.
+                </NxP>
+                <NxP>
+                  <NxCode>Nx*Alert</NxCode>s as children of <NxCode>NxToast</NxCode> will be assigned a default role
+                  of <NxCode>alert</NxCode>. The role can be updated to either <NxCode>status</NxCode> or
+                  {' '}<NxCode>log</NxCode>. One of these three {' '}
                   <NxTextLink external href="https://www.w3.org/TR/wai-aria/#live_region_roles">
                     Live Region
                   </NxTextLink>
-                  {' '}role if not already provided (see
-                  {' '}<NxCode><NxTextLink href="#/pages/Alert">NxAlert</NxTextLink></NxCode>
-                  for more information about default roles). Without a designated role, the content inside
-                  {' '}<NxCode>NxToast</NxCode> will not be immediately read by screenreaders when rendered on the page.
-                </NxWarningAlert>
+                  {' '}roles must be provided to ensure the content inside <NxCode>NxToast</NxCode> will be read
+                  immediately by screenreaders when rendered on the page.
+                </NxP>
               </NxTable.Cell>
             </NxTable.Row>
             <NxTable.Row>

--- a/gallery/src/components/NxToast/NxToastPage.tsx
+++ b/gallery/src/components/NxToast/NxToastPage.tsx
@@ -180,7 +180,8 @@ const NxToastPage = () =>
         <NxP>
           A complex full page layout example. With the inclusion of <NxCode>NxGlobalHeader</NxCode>, the toasts
           will be positioned on the right side of the viewport, underneath the header. Extra content is provided
-          to be able to view the positioning of the toasts with scrolling behavior.
+          to be able to view the positioning of the toasts with scrolling behavior. The role for NxInfoAlert has
+          also been updated to <NxCode>status</NxCode>.
         </NxP>
         <NxP>
           <NxTextLink href="#/NxToastComplexLayoutExample">

--- a/gallery/src/components/NxToast/NxToastPage.tsx
+++ b/gallery/src/components/NxToast/NxToastPage.tsx
@@ -108,6 +108,16 @@ const NxToastPage = () =>
                 be set up internally by <NxCode>NxToast</NxCode>. Calling code should instead use the
                 {' '}<NxCode>onClose</NxCode> prop of <NxCode>NxToast</NxCode> itself. Additionally, note that the alert
                 text content should be brief: only one rendered line of text per toast is supported.
+                <NxWarningAlert>
+                  <NxCode>Nx*Alert</NxCode>s must be passed a {' '}
+                  <NxTextLink external href="https://www.w3.org/TR/wai-aria/#live_region_roles">
+                    Live Region
+                  </NxTextLink>
+                  {' '}role if not already provided (see
+                  {' '}<NxCode><NxTextLink href="#/pages/Alert">NxAlert</NxTextLink></NxCode>
+                  for more information about default roles). Without a designated role, the content inside
+                  {' '}<NxCode>NxToast</NxCode> will not be immediately read by screenreaders when rendered on the page.
+                </NxWarningAlert>
               </NxTable.Cell>
             </NxTable.Row>
             <NxTable.Row>

--- a/gallery/src/components/NxToast/NxToastSimpleLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastSimpleLayoutExample.tsx
@@ -42,7 +42,7 @@ interface ToastModel {
 }
 
 type alertComponentProps = {
-  role?:string;
+  role?: string;
 };
 
 export default function NxToastSimpleLayoutExample() {
@@ -71,7 +71,7 @@ export default function NxToastSimpleLayoutExample() {
                        onClose={()=> removeToast(id)}>
                 {
                   ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
-                    <ToastAlert role= 'status'>{message}</ToastAlert> :
+                    <ToastAlert role="status">{message}</ToastAlert> :
                     <ToastAlert>{message}</ToastAlert>
                 }
               </NxToast>

--- a/gallery/src/components/NxToast/NxToastSimpleLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastSimpleLayoutExample.tsx
@@ -37,19 +37,15 @@ const sidebarLogoPath = require('../../assets/images/logo-plaid-villain-text.png
 
 interface ToastModel {
   id: number;
-  alertComponent: ComponentType<alertComponentProps>;
+  alertComponent: ComponentType;
   message: string;
 }
-
-type alertComponentProps = {
-  role?: string;
-};
 
 export default function NxToastSimpleLayoutExample() {
   const [toastIdInc, setToastIdInc] = useState<number>(0);
   const [toasts, setToasts] = useState<ToastModel[]>([]);
 
-  const addToast = (alertComponent: ComponentType<alertComponentProps>, message: string) => {
+  const addToast = (alertComponent: ComponentType, message: string) => {
     const toastId = toastIdInc + 1;
     setToastIdInc(toastId);
     setToasts([
@@ -69,11 +65,7 @@ export default function NxToastSimpleLayoutExample() {
             return (
               <NxToast key={id}
                        onClose={()=> removeToast(id)}>
-                {
-                  ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
-                    <ToastAlert role="status">{message}</ToastAlert> :
-                    <ToastAlert>{message}</ToastAlert>
-                }
+                <ToastAlert>{message}</ToastAlert>
               </NxToast>
             );
           })

--- a/gallery/src/components/NxToast/NxToastSimpleLayoutExample.tsx
+++ b/gallery/src/components/NxToast/NxToastSimpleLayoutExample.tsx
@@ -37,15 +37,19 @@ const sidebarLogoPath = require('../../assets/images/logo-plaid-villain-text.png
 
 interface ToastModel {
   id: number;
-  alertComponent: ComponentType;
+  alertComponent: ComponentType<alertComponentProps>;
   message: string;
 }
+
+type alertComponentProps = {
+  role?:string;
+};
 
 export default function NxToastSimpleLayoutExample() {
   const [toastIdInc, setToastIdInc] = useState<number>(0);
   const [toasts, setToasts] = useState<ToastModel[]>([]);
 
-  const addToast = (alertComponent: ComponentType, message: string) => {
+  const addToast = (alertComponent: ComponentType<alertComponentProps>, message: string) => {
     const toastId = toastIdInc + 1;
     setToastIdInc(toastId);
     setToasts([
@@ -65,7 +69,11 @@ export default function NxToastSimpleLayoutExample() {
             return (
               <NxToast key={id}
                        onClose={()=> removeToast(id)}>
-                <ToastAlert>{message}</ToastAlert>
+                {
+                  ToastAlert === NxWarningAlert || ToastAlert === NxInfoAlert ?
+                    <ToastAlert role= 'status'>{message}</ToastAlert> :
+                    <ToastAlert>{message}</ToastAlert>
+                }
               </NxToast>
             );
           })

--- a/gallery/visualtests/__image_snapshots__/nx-toast-js-nx-toast-with-legacy-layout-and-page-scrolling-is-positioned-correctly-1-snap.png
+++ b/gallery/visualtests/__image_snapshots__/nx-toast-js-nx-toast-with-legacy-layout-and-page-scrolling-is-positioned-correctly-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c6fdf55b3d980730345d16307bf2ee81d5dc1357940af4c874cb13f18313ce4
-size 383796
+oid sha256:745684f3997012167df1dcf9ba5a6f959233d7fbc894df5d69efff8609c33df6
+size 385760

--- a/gallery/visualtests/nxToast.js
+++ b/gallery/visualtests/nxToast.js
@@ -45,7 +45,7 @@ describe('NxToast', function() {
 
       it('passes a11y checks', async function() {
         await launchToastsFromPage();
-        a11yTest();
+        await a11yTest(null, true)();
       });
     });
   };

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxToast/NxToast.tsx
+++ b/lib/src/components/NxToast/NxToast.tsx
@@ -40,7 +40,7 @@ const NxToast = (props: NxToastProps) => {
   const validChild = React.Children.only(children),
       childrenWithProps = React.cloneElement(validChild, {
         onClose: handleClose,
-        role: children.props.role ?? 'alert'
+        role: validChild.props.role ?? 'alert'
       });
 
   const classes = classnames('nx-toast', className, {

--- a/lib/src/components/NxToast/NxToast.tsx
+++ b/lib/src/components/NxToast/NxToast.tsx
@@ -38,8 +38,10 @@ const NxToast = (props: NxToastProps) => {
   };
 
   const validChild = React.Children.only(children),
-      childrenWithProps = React.cloneElement(validChild,
-          { onClose: handleClose, role: children.props.role ? children.props.role : 'alert' });
+      childrenWithProps = React.cloneElement(validChild, {
+        onClose: handleClose,
+        role: children.props.role ?? 'alert'
+      });
 
   const classes = classnames('nx-toast', className, {
     'nx-toast--closing': isClosing

--- a/lib/src/components/NxToast/NxToast.tsx
+++ b/lib/src/components/NxToast/NxToast.tsx
@@ -38,7 +38,8 @@ const NxToast = (props: NxToastProps) => {
   };
 
   const validChild = React.Children.only(children),
-      childrenWithProps = React.cloneElement(validChild, { onClose: handleClose });
+      childrenWithProps = React.cloneElement(validChild,
+          { onClose: handleClose, role: children.props.role ? children.props.role : 'alert' });
 
   const classes = classnames('nx-toast', className, {
     'nx-toast--closing': isClosing


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1164

Visual testing was failing on the a11yTest with the following error: “Ensure all page content is contained by landmarks”. 

This was firing because `NxToastContainer` is positioned outside of any landmark elements (outside of header/aside/main/footer etc). It seems as though by supplying roles for all four variations of `NxAlert` (`NxWarningAlert` and `NxInfoAlert` do not have a pre-assigned role), this eliminated the error. There isn't any documentation that explicitly lays out why, but I believe this is because  “Live Regions” (in this case role=alert or role=status) will automatically move the screenreader to the content within the alert. Without roles defined (and outside of a landmark role), the screenreader may not jump to the content inside of the NxAlert. 