### PR TITLE
Links in NxDropdown - RSC-1093

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "11.1.4",
+  "version": "11.1.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxDropdown/NxDropdownLinksExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownLinksExample.tsx
@@ -25,14 +25,14 @@ function NxDropdownActionsExample() {
         <span>Go somewhere else</span>
         <NxFontAwesomeIcon icon={faExternalLinkAlt}/>
       </a>
-      <a href="https://www.google.com/" className="nx-dropdown-link disabled">
+      <a href="https://www.google.com/" className="nx-dropdown-link disabled" onClick={evt => evt.preventDefault()}>
         <span>Can't go here though</span>
         <NxFontAwesomeIcon icon={faExternalLinkAlt}/>
       </a>
       <a href="#/" className="nx-dropdown-link">
         <span>Go to homepage</span>
       </a>
-      <a href="#/" className="nx-dropdown-link disabled">
+      <a href="#/" className="nx-dropdown-link disabled" onClick={evt => evt.preventDefault()}>
         <span>Can't go here either</span>
       </a>
     </NxDropdown>

--- a/gallery/src/components/NxDropdown/NxDropdownLinksExample.tsx
+++ b/gallery/src/components/NxDropdown/NxDropdownLinksExample.tsx
@@ -17,17 +17,23 @@ function NxDropdownActionsExample() {
                 className="extra-class"
                 isOpen={isOpen}
                 onToggleCollapse={onToggleCollapse}>
-      <a href="https://www.google.com/" className="nx-dropdown-link disabled">
-        <NxFontAwesomeIcon icon={faExternalLinkAlt}/>
+      <a href="https://www.google.com/" className="nx-dropdown-link">
         <span>Go somewhere</span>
+        <NxFontAwesomeIcon icon={faExternalLinkAlt}/>
       </a>
       <a href="https://www.sonatype.com/" className="nx-dropdown-link">
-        <NxFontAwesomeIcon icon={faExternalLinkAlt}/>
         <span>Go somewhere else</span>
-      </a>
-      <a href="https://developer.mozilla.org/en-US/docs/Web" className="nx-dropdown-link">
         <NxFontAwesomeIcon icon={faExternalLinkAlt}/>
-        <span>Go yet another place</span>
+      </a>
+      <a href="https://www.google.com/" className="nx-dropdown-link disabled">
+        <span>Can't go here though</span>
+        <NxFontAwesomeIcon icon={faExternalLinkAlt}/>
+      </a>
+      <a href="#/" className="nx-dropdown-link">
+        <span>Go to homepage</span>
+      </a>
+      <a href="#/" className="nx-dropdown-link disabled">
+        <span>Can't go here either</span>
       </a>
     </NxDropdown>
   );

--- a/gallery/visualtests/__image_snapshots__/nx-dropdown-js-nx-dropdown-nx-dropdown-links-has-links-that-look-right-1-snap.png
+++ b/gallery/visualtests/__image_snapshots__/nx-dropdown-js-nx-dropdown-nx-dropdown-links-has-links-that-look-right-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8dae5ecf35a1c884eca2a1a8c78299120e6ab553331a3cb0c11c756bb9c15aa
-size 10411
+oid sha256:2d6ce268e5c27be5e20c0d1620535deee9a6b2a20565ce4b07e722623faf2ac5
+size 13857

--- a/gallery/visualtests/nxDropdown.js
+++ b/gallery/visualtests/nxDropdown.js
@@ -67,7 +67,7 @@ describe('NxDropdown', function() {
 
       await moveMouseAway();
 
-      await checkScreenshot(targetElement, 251, 153);
+      await checkScreenshot(targetElement, 251, 218);
     });
   });
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "11.1.4",
+  "version": "11.1.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxDropdown/NxDropdown.scss
+++ b/lib/src/components/NxDropdown/NxDropdown.scss
@@ -136,7 +136,6 @@
     &, &:hover, &:focus {
       color: var(--nx-color-link-disabled);
       cursor: default;
-      pointer-events: none;
       text-decoration: none;
     }
   }

--- a/lib/src/components/NxDropdown/NxDropdown.scss
+++ b/lib/src/components/NxDropdown/NxDropdown.scss
@@ -136,6 +136,7 @@
     &, &:hover, &:focus {
       color: var(--nx-color-link-disabled);
       cursor: default;
+      pointer-events: none;
       text-decoration: none;
     }
   }


### PR DESCRIPTION
https://www.sketch.com/s/2393264e-1233-4909-99c8-a7dda02588cd/a/9Pm3pGz
https://issues.sonatype.org/browse/RSC-1093

Styling of links has been updated in the NxDropdownLinksExample inside of NxDropdown. 
