### PR TITLE
Dark Mode Main Text and Background Colors - RSC-1000 RSC-1009 RSC-1051 RSC-1059

### DIFF
--- a/gallery/src/components/NxTooltip/NxTooltipExample.scss
+++ b/gallery/src/components/NxTooltip/NxTooltipExample.scss
@@ -4,8 +4,14 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
+@use '~@sonatype/react-shared-components/scss-shared/nx-dark-mode-helpers';
+
 // Tooltip override classes should always be combined with `.nx-tooltip` to overcome the specificity of
 // the tooltip library's built-in styles
 .nx-tooltip.gallery-tooltip-example {
   color: tan;
+
+  @include nx-dark-mode-helpers.dark-mode {
+    color: sienna;
+  }
 }

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -4,6 +4,8 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
+@use '../scss-shared/nx-dark-mode-helpers';
+
 :root {
   --nx-color-border: var(--nx-swatch-indigo-90);
   --nx-color-border-secondary: var(--nx-swatch-indigo-95);
@@ -52,4 +54,13 @@
   // Deprecated variables
   --nx-color-subsection-border: var(--nx-color-border);
   --nx-color-text-dark: var(--nx-color-text-stark);
+
+  @include nx-dark-mode-helpers.dark-mode {
+    --nx-color-text-stark: var(--nx-swatch-indigo-90);
+    --nx-color-text: var(--nx-swatch-indigo-80);
+
+    --nx-color-link: var(--nx-swatch-teal-75);
+
+    --nx-color-validation-invalid: var(--nx-swatch-red-75);
+  }
 }

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -56,6 +56,10 @@
   --nx-color-text-dark: var(--nx-color-text-stark);
 
   @include nx-dark-mode-helpers.dark-mode {
+    --nx-color-component-background: var(--nx-swatch-indigo-20);
+
+    --nx-color-site-background: var(--nx-swatch-indigo-15);
+
     --nx-color-text-stark: var(--nx-swatch-indigo-90);
     --nx-color-text: var(--nx-swatch-indigo-80);
 

--- a/lib/src/components/NxTooltip/NxToolTip.scss
+++ b/lib/src/components/NxTooltip/NxToolTip.scss
@@ -5,6 +5,7 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 @use '../../scss-shared/nx-text-helpers';
+@use '../../scss-shared/nx-dark-mode-helpers';
 
 .nx-tooltip {
   // for specificity
@@ -18,6 +19,10 @@
     line-height: var(--nx-line-height);
     max-width: 600px;
     padding: var(--nx-spacing-2x) var(--nx-spacing-4x);
+
+    @include nx-dark-mode-helpers.dark-mode {
+      color: var(--nx-swatch-indigo-05);
+    }
   }
 
   &.MuiTooltip-tooltipPlacementTop, &.MuiTooltip-tooltipPlacementBottom {


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1000
https://issues.sonatype.org/browse/RSC-1009
https://issues.sonatype.org/browse/RSC-1051
https://issues.sonatype.org/browse/RSC-1059

To test, either use the `prefers-color-scheme` manual override in the Rendering panel of the Chrome Dev Tools, or use a dark OS theme or browser theme.