### PR TITLE
NxFileUpload and Textarea validation - RSC 1173

### DIFF
--- a/gallery/src/components/NxFileUpload/NxFileUploadPage.tsx
+++ b/gallery/src/components/NxFileUpload/NxFileUploadPage.tsx
@@ -85,9 +85,8 @@ const NxTextInputPage = () =>
               <NxTable.Cell>false</NxTable.Cell>
               <NxTable.Cell>false</NxTable.Cell>
               <NxTable.Cell>
-                Only relevant when <NxCode>isRequired</NxCode> is true, this prop sets whether the input is currently
-                pristine (has not yet had its value adjusted by the user), in which case the validation error is not
-                shown.
+                Should be set to true when <NxCode>isRequired</NxCode> is true, but <NxCode>NxFileUpload</NxCode>
+                {' '}has not yet been modified by the user.
               </NxTable.Cell>
             </NxTable.Row>
             <NxTable.Row>

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
@@ -99,7 +99,7 @@ export default function NxFormLayoutExample() {
           colorValidationError,
           selectState.validationErrors,
           tagColorState.validationErrors,
-          !files?.length && !isFilePristine ? 'A file is required' : null
+          !files?.length ? 'A file is required' : null
       ) ? 'Required fields are missing' : null;
 
   function onSubmit() {

--- a/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
+++ b/gallery/src/styles/NxFormLayout/NxFormLayoutExample.tsx
@@ -95,6 +95,7 @@ export default function NxFormLayoutExample() {
   const formValidationErrors =
       hasValidationErrors(
           textInputState.validationErrors,
+          commentState.validationErrors,
           colorValidationError,
           selectState.validationErrors,
           tagColorState.validationErrors,


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1173

There appeared to be two issues within the formValidationErrors variable. The validationErrors of the textarea was not included, and the string 'A file is required' for NxFileUpload was only being read when isPristine was set to false. However, I assume inside a form, leaving NxFileUpload blank upon form submission should register an error and prevent the form from being submitted, whether isPristine is set to true or false. 

If this is the case, then we may need to reword the gallery docs for isPristine: 
"Only relevant when isRequired is true, this prop sets whether the input is currently pristine (has not yet had its value adjusted by the user), in which case the validation error is not shown."