### PR TITLE
Dark Mode: Card Footer Border - RSC-1177

### DIFF
--- a/lib/src/base-styles/_nx-color-swatches.scss
+++ b/lib/src/base-styles/_nx-color-swatches.scss
@@ -185,6 +185,7 @@
   --nx-swatch-indigo-15: hsl(var(--nx-swatch-indigo-hs), 15%);
   --nx-swatch-indigo-20: hsl(var(--nx-swatch-indigo-hs), 20%);
   --nx-swatch-indigo-30: hsl(var(--nx-swatch-indigo-hs), 30%);
+  --nx-swatch-indigo-35: hsl(var(--nx-swatch-indigo-hs), 35%);
   --nx-swatch-indigo-40: hsl(var(--nx-swatch-indigo-hs), 40%);
   --nx-swatch-indigo-50: hsl(var(--nx-swatch-indigo-hs), 50%);
   --nx-swatch-indigo-60: hsl(var(--nx-swatch-indigo-hs), 60%);

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -56,6 +56,8 @@
   --nx-color-text-dark: var(--nx-color-text-stark);
 
   @include nx-dark-mode-helpers.dark-mode {
+    --nx-color-border: var(--nx-swatch-indigo-35);
+
     --nx-color-component-background: var(--nx-swatch-indigo-20);
 
     --nx-color-site-background: var(--nx-swatch-indigo-15);


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1177

In effect, this will change many of the borders in dark mode