### PR TITLE
Setup dark mode visual testing - RSC-1170

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,19 @@ You can execute the tests within the Docker container based on that image by run
 ```
 docker run --rm -it -w /home/jenkins/gallery -v $PWD:/home/jenkins rsc-visualtesting yarn test
 ```
+
+Note that by running this command, all visual tests will run in both light (default) and dark modes. To run tests for light mode only, run:
+
+```
+docker run --rm -it -w /home/jenkins/gallery -v $PWD:/home/jenkins rsc-visualtesting yarn jest test
+```
+
+To run tests for dark mode only, run: 
+
+```
+docker run --rm -it -w /home/jenkins/gallery -v $PWD:/home/jenkins rsc-visualtesting yarn jest-dark test
+```
+
 On some computers, visual testing may take more than 20 minutes, so let the tests run in the background. Note that the
 `yarn test` command will (re-)install the gallery dependencies, ensuring that puppeteer downloads the correct version
 of Chromium before running the gallery build and tests.
@@ -245,9 +258,14 @@ specifics of your system. If seemingly spurious diffs are detected, try running 
 ### Updating Visual Test Screenshots
 
 If running the tests results in differences that are expected/intended based on new changes to the library, then the
-baseline screenshots may be updated by running the following command:
+baseline screenshots may be updated. To update light mode screenshots, run the following command:
 ```
 docker run --rm -it -w /home/jenkins/gallery -v $PWD:/home/jenkins rsc-visualtesting yarn jest -u
+```
+
+To update dark mode screenshots, run the following command:
+```
+docker run --rm -it -w /home/jenkins/gallery -v $PWD:/home/jenkins rsc-visualtesting yarn jest-dark -u
 ```
 
 The command above ensures you update the screenshots within the Docker container. The updates need be run within the

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -11,9 +11,10 @@
     "lint-tests": "eslint --no-eslintrc -c .eslintrc-tests \"visualtests/*.js\"",
     "webpack": "webpack --env production --mode=production",
     "webpack-dev-server": "webpack serve",
-    "test": "npm-run-all check-install lint-tests build jest",
+    "test": "npm-run-all check-install lint-tests build jest jest-dark",
     "check-install": "yarn install --check-files --frozen-lockfile",
     "jest": "jest --testTimeout=120000",
+    "jest-dark": "THEME=DARK jest --testTimeout=120000",
     "clean": "rimraf dist webpack-modules test-results"
   },
   "repository": {

--- a/gallery/setupTests.js
+++ b/gallery/setupTests.js
@@ -12,7 +12,8 @@ jest.retryTimes(3);
 
 const toMatchImageSnapshot = configureToMatchImageSnapshot({
   customDiffDir: path.join(__dirname, 'test-results'),
-  customSnapshotIdentifier: ({ defaultIdentifier }) => defaultIdentifier
+  // eslint-disable-next-line no-undef
+  customSnapshotIdentifier: ({ defaultIdentifier }) => defaultIdentifier + (process.env.THEME === 'DARK' ? '-dark' : '')
 });
 
 expect.extend({ toMatchImageSnapshot });

--- a/gallery/visualtests/testUtils.js
+++ b/gallery/visualtests/testUtils.js
@@ -56,6 +56,12 @@ module.exports = {
 
     beforeEach(async function() {
       page = await browser.newPage();
+
+      // eslint-disable-next-line no-undef
+      if (process.env.THEME === 'DARK') {
+        await page.emulateMediaFeatures([{name: 'prefers-color-scheme', value: 'dark'}]);
+      }
+
       await page.goto(pageUrl + pageFragmentIdentifier);
 
       if (ignoreVersionNumber) {

--- a/gallery/visualtests/testUtils.js
+++ b/gallery/visualtests/testUtils.js
@@ -272,5 +272,11 @@ module.exports = {
         };
       }
     };
+  },
+
+  describeIf(envCondition) {
+    return (
+      envCondition ? describe : describe.skip
+    );
   }
 };

--- a/gallery/visualtests/themeSettingsModal.js
+++ b/gallery/visualtests/themeSettingsModal.js
@@ -5,9 +5,13 @@
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
 
-const { setupBrowser } = require('./testUtils');
+const { setupBrowser, describeIf } = require('./testUtils');
 
-describe('ThemeSettingsModal', function() {
+// Tests for ThemeSettingsModal are only testing the functionality of the modal itself, so
+// it is unnecessary to run these tests in both light and dark modes
+
+// eslint-disable-next-line no-undef
+describeIf(process.env.THEME !== 'DARK')('ThemeSettingsModal', function() {
   const { waitAndGetElements, wait, getPage, checkFullPageScreenshot } = setupBrowser('#/');
 
   const openModalBtn = '.gallery-page-header__theme-settings-button',
@@ -60,5 +64,4 @@ describe('ThemeSettingsModal', function() {
   it('changes display theme to light when light mode radio is selected', async function() {
     await selectModeChoice(lightModeRadio);
   });
-
 });

--- a/gallery/visualtests/themeSettingsModal.js
+++ b/gallery/visualtests/themeSettingsModal.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+
+const { setupBrowser } = require('./testUtils');
+
+describe('ThemeSettingsModal', function() {
+  const { waitAndGetElements, wait, getPage, checkFullPageScreenshot } = setupBrowser('#/');
+
+  const openModalBtn = '.gallery-page-header__theme-settings-button',
+      themeSettingsModal = '.gallery-theme-settings-modal',
+      enableChangesToggle = `${themeSettingsModal} .nx-form-group label:nth-of-type(2)`,
+      darkModeRadio = `${themeSettingsModal} .nx-radio:nth-of-type(2)`,
+      lightModeRadio = `${themeSettingsModal} .nx-radio:nth-of-type(3)`;
+
+  async function openThemeSettingsModal() {
+    const [targetElement] = await waitAndGetElements(openModalBtn);
+    await targetElement.click();
+    await waitAndGetElements(themeSettingsModal);
+  }
+
+  async function selectModeChoice(radioElement) {
+    await openThemeSettingsModal();
+
+    const [targetElement] = await waitAndGetElements(radioElement);
+    targetElement.click();
+    await wait(400);
+
+    await checkFullPageScreenshot();
+  }
+
+  beforeEach(async function() {
+    await getPage().setViewport({ width: 1366, height: 1000 });
+  });
+
+  it('disallows any theme changes by default', async function() {
+    await openThemeSettingsModal();
+    await checkFullPageScreenshot();
+  });
+
+  it('enables radios when opted in to theme changes',
+      async function() {
+        await openThemeSettingsModal();
+
+        const [toggle] = await waitAndGetElements(enableChangesToggle);
+        toggle.click();
+        await wait(400);
+
+        await checkFullPageScreenshot();
+      }
+  );
+
+  it('changes display theme to dark when dark mode radio is selected', async function() {
+    await selectModeChoice(darkModeRadio);
+  });
+
+  it('changes display theme to light when light mode radio is selected', async function() {
+    await selectModeChoice(lightModeRadio);
+  });
+
+});


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1170

Visual tests are set up to run jest twice, once in its default (light), then in a dark mode environment. Visual tests have also been added for the `themeSettingsModal`, which will not run in dark mode (since these tests are testing the functionality of the modal, and not how the modal appears in light and dark mode). 

To define dark mode, `process.env.THEME` is used, but throws a 'process is not defined' lintr error.  It seems that a possible solution could be to implement `"process": true` under `globals` or `"node":true` under `env` in the eslintrc file
https://stackoverflow.com/questions/50894000/eslint-process-is-not-defined

