### PR TITLE
Fail CI on ESLint Warnings - RSC-1149

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ dockerizedBuildPipeline(
 
         cd lib
         yarn install --registry "\${registry}" --frozen-lockfile
-        yarn test
+        yarn ci-test
         yarn build
         cd dist
         npm pack
@@ -93,7 +93,7 @@ dockerizedBuildPipeline(
         cd gallery
         yarn install --registry "\${registry}" --frozen-lockfile
 
-        yarn test
+        yarn ci-test
         yarn build
         cd ..
 

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "11.5.11",
+  "version": "11.5.12",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "11.5.14",
+  "version": "11.5.15",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -5,13 +5,16 @@
   "main": "src/main.ts",
   "scripts": {
     "start": "npm-run-all lint webpack-dev-server",
-    "build": "npm-run-all lint webpack copy-assets",
+    "build": "npm-run-all ci-lint webpack copy-assets",
     "copy-assets": "cpx \"{src/index.html,src/assets/images/favicon*}\" dist",
     "lint": "eslint \"./src/**/*.{js,ts}{,x}\"",
+    "ci-lint": "eslint \"./src/**/*.{js,ts}{,x}\" --max-warnings=0",
     "lint-tests": "eslint --no-eslintrc -c .eslintrc-tests \"visualtests/*.js\"",
+    "ci-lint-tests": "eslint --no-eslintrc -c .eslintrc-tests \"visualtests/*.js\" --max-warnings=0",
     "webpack": "webpack --env production --mode=production",
     "webpack-dev-server": "webpack serve",
     "test": "npm-run-all check-install lint-tests build jest",
+    "ci-test": "npm-run-all check-install ci-lint-tests build jest",
     "check-install": "yarn install --check-files --frozen-lockfile",
     "jest": "jest --testTimeout=120000",
     "clean": "rimraf dist webpack-modules test-results"

--- a/gallery/visualtests/nxTextInput.js
+++ b/gallery/visualtests/nxTextInput.js
@@ -67,8 +67,6 @@ describe('NxTextInput', function() {
       await inputElement.press('Backspace');
       await inputElement.press('Backspace');
 
-      const { x, y } = await targetElement.boundingBox();
-
       await checkScreenshot(targetElement, 300, 74);
     });
   });
@@ -117,7 +115,6 @@ describe('NxTextInput', function() {
       await inputElement.press('Backspace');
       await inputElement.press('Backspace');
 
-      const { x, y } = await targetElement.boundingBox();
       await checkScreenshot(targetElement, 300, 300);
     });
   });

--- a/lib/.eslintrc-base
+++ b/lib/.eslintrc-base
@@ -76,7 +76,7 @@
     "no-unused-vars": "off",
     "strict": "error",
     "no-mixed-spaces-and-tabs": "error",
-    "no-multiple-empty-lines": ["error", { "max": 1}],
+    "no-multiple-empty-lines": ["warn", { "max": 1}],
     "no-multi-spaces": "error",
     "no-nested-ternary": "off",
     "padded-blocks": "off",
@@ -114,8 +114,8 @@
       "error",
       "never"
     ],
-    "no-trailing-spaces": "error",
-    "eol-last": "error",
+    "no-trailing-spaces": "warn",
+    "eol-last": "warn",
     "semi": "off",
     "@typescript-eslint/semi": [
       "error",

--- a/lib/.eslintrc-base
+++ b/lib/.eslintrc-base
@@ -34,7 +34,7 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-inferrable-types": ["error", { "ignoreParameters": true }],
     "@typescript-eslint/indent": [
-      "error",
+      "warn",
       2,
       {
         "SwitchCase": 1,
@@ -135,13 +135,13 @@
       "error",
       "never"
     ],
-    "no-console": ["error", { "allow": ["warn", "error"] }],
-    "no-debugger": "error",
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
+    "no-debugger": "warn",
     "array-bracket-spacing": ["error", "never"],
     "object-property-newline": ["error", { "allowMultiplePropertiesPerLine": true }],
     "brace-style": ["error", "stroustrup", { "allowSingleLine": true }],
-    "react/jsx-indent": ["error", 2],
-    "react/jsx-indent-props": ["error", "first"],
+    "react/jsx-indent": ["warn", 2],
+    "react/jsx-indent-props": ["warn", "first"],
     "react/jsx-first-prop-new-line": ["error", "never"],
     "react/jsx-max-props-per-line": ["error", { "maximum": 1, "when": "multiline" }],
     "react/jsx-closing-tag-location": ["error"],

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "11.5.11",
+  "version": "11.5.12",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "11.5.14",
+  "version": "11.5.15",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -9,10 +9,12 @@
     "directory": "lib"
   },
   "scripts": {
-    "build": "npm-run-all -p lint compile-ts compile-scss copy-scss copy-package-json copy-assets",
+    "build": "npm-run-all -p ci-lint compile-ts compile-scss copy-scss copy-package-json copy-assets",
     "watch": "npm-run-all -p lint compile-ts-watch compile-scss-watch copy-scss-watch copy-package-json-watch copy-assets-watch",
     "lint": "eslint --ignore-pattern __tests__ --ignore-pattern __mocks__ --ignore-pattern __testutils__ \"./src/**/*.{js,ts}{,x}\"",
+    "ci-lint": "eslint --ignore-pattern __tests__ --ignore-pattern __mocks__ --ignore-pattern __testutils__ \"./src/**/*.{js,ts}{,x}\" --max-warnings=0",
     "lint-tests": "eslint --no-eslintrc -c .eslintrc-tests \"./src/**/{__tests__,__mocks__,__testutils__}/**/*.{js,ts}{,x}\"",
+    "ci-lint-tests": "eslint --no-eslintrc -c .eslintrc-tests \"./src/**/{__tests__,__mocks__,__testutils__}/**/*.{js,ts}{,x}\" --max-warnings=0",
     "compile-ts": "tsc --project tsconfig.build.json",
     "compile-scss": "webpack-cli --config=webpack.config.styles.js",
     "copy-scss": "cpx \"src/**/*.scss\" dist",
@@ -24,6 +26,7 @@
     "copy-assets-watch": "cpx -w \"src/assets/**/*\" dist/assets",
     "copy-package-json-watch": "cpx -w package.json dist",
     "test": "npm-run-all lint-tests jest",
+    "ci-test": "npm-run-all ci-lint-tests jest",
     "jest": "jest",
     "test-watch": "jest --watch",
     "test-watch-debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watchAll",


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1149

See https://sonatype.slack.com/archives/CJUF9G7T2/p1664900499716919 , where it was decided that in addition to fixing the current warnings, we would be adjusting the CI build (but not typical local builds) to fail on warnings.  Additionally, we are changing some rules which devs are likely to temporarily violate from errors into warnings.  When reviewing, please give any feedback that you have on my choices of which rules to change into warnings.