### PR TITLE
Fix eslint Indent Conflict RSC-1162 

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "11.5.14",
+  "version": "11.5.15",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "11.5.16",
+  "version": "11.5.17",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/.eslintrc-base
+++ b/lib/.eslintrc-base
@@ -48,6 +48,7 @@
 
         // handled by jsx-indent and jsx-indent-props
         "ignoredNodes": [
+          "JSXFragment",
           "JSXElement",
           "JSXElement > *",
           "JSXAttribute",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "11.5.14",
+  "version": "11.5.15",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "11.5.16",
+  "version": "11.5.17",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxDescriptionList/__tests__/NxDescriptionListButtonItem.test.tsx
+++ b/lib/src/components/NxDescriptionList/__tests__/NxDescriptionListButtonItem.test.tsx
@@ -228,9 +228,6 @@ describe('NxDescriptionList.ButtonItem', function() {
   });
 
   it('has the first button as its only tabstop', async function() {
-    // We apparently have two different eslint indentation rules, which happen to contradict
-    // one another about this statement for some reason. Disabling the one I disagree with.
-    /* eslint-disable @typescript-eslint/indent */
     const component = render(
       <>
         <button data-testid="before">Before</button>

--- a/lib/src/components/NxDescriptionList/__tests__/NxDescriptionListLinkItem.test.tsx
+++ b/lib/src/components/NxDescriptionList/__tests__/NxDescriptionListLinkItem.test.tsx
@@ -205,9 +205,6 @@ describe('NxDescriptionList.LinkItem', function() {
   });
 
   it('has the first link as its only tabstop', async function() {
-    // We apparently have two different eslint indentation rules, which happen to contradict
-    // one another about this statement for some reason. Disabling the one I disagree with.
-    /* eslint-disable @typescript-eslint/indent */
     const component = render(
       <>
         <button data-testid="before">Before</button>

--- a/lib/src/components/NxToast/__tests__/NxToastContainer.test.tsx
+++ b/lib/src/components/NxToast/__tests__/NxToastContainer.test.tsx
@@ -70,7 +70,6 @@ describe('NxToastContainer', function() {
   it('sets focus to previous focused element when the last remaining toast is closed',
       async function() {
         render(
-        /* eslint-disable-next-line @typescript-eslint/indent */
           <>
             <button type="button">Focus Me</button>
             <NxToastContainer>
@@ -78,7 +77,6 @@ describe('NxToastContainer', function() {
                 <NxAlert icon={faEye}>This is an Alert</NxAlert>
               </NxToast>
             </NxToastContainer>
-            {/* eslint-disable-next-line @typescript-eslint/indent */}
           </>
         );
 
@@ -97,13 +95,11 @@ describe('NxToastContainer', function() {
       async function() {
 
         const { rerender } = render(
-        /* eslint-disable-next-line @typescript-eslint/indent */
           <>
             <button type="button">Focus Me</button>
             <NxToastContainer>
               {}
             </NxToastContainer>
-            {/* eslint-disable-next-line @typescript-eslint/indent */}
           </>
         );
         const prevFocusBtn = screen.getByRole('button', {name: 'Focus Me'});
@@ -111,7 +107,6 @@ describe('NxToastContainer', function() {
         prevFocusBtn.focus();
 
         rerender(
-        /* eslint-disable-next-line @typescript-eslint/indent */
           <>
             <button type="button">Focus Me</button>
             <NxToastContainer>
@@ -119,7 +114,6 @@ describe('NxToastContainer', function() {
                 <NxAlert icon={faEye}>This is an Alert</NxAlert>
               </NxToast>
             </NxToastContainer>
-            {/* eslint-disable-next-line @typescript-eslint/indent */}
           </>
         );
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1162

There were two issues, one of which still exists but is very minor.

1. JSX that started with a fragment (`<>`) was not being ignored by the typescript indentation plugin.  It turns out these nodes have a unique identity in the AST that needed to be added to the `ignoredNodes` list.  This is what this PR fixes.
2. The react indentation rules do not appear to be able to handle the case where you have a series of variable assignments in a single expression, one of which is a function call that receives multi-line JSX as its argument.  For instance the following:

```
const foo = render(
      <div>
        <span>asdfasdf</span>
      </div>
    ),
    bar = 1;
 ```
 
 It doesn't understand the expectation that everything beyond the first line have an extra two levels of indentation.  So as a workaround, we must continue to break up such declarations into multiple statements, avoiding the double indentation.