### PR TITLE
Cleanup nx-form-group--hide-optional and nx-form-select usages and examples - RSC-1280 RSC-1281

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "12.5.19",
+  "version": "12.5.20",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/components/NxDrawer/NxDrawerWithNxFormExample.tsx
+++ b/gallery/src/components/NxDrawer/NxDrawerWithNxFormExample.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   NxDrawer,
@@ -19,7 +19,8 @@ import {
   NxFieldset,
   NxCheckbox,
   useToggle,
-  NxStatefulTextInput
+  NxStatefulTextInput,
+  NxFormSelect
 } from '@sonatype/react-shared-components';
 
 export default function NxDrawerWithNxFormExample() {
@@ -27,7 +28,8 @@ export default function NxDrawerWithNxFormExample() {
       [showDrawerOverflowing, toggleDrawerOverflowing] = useToggle(false),
       [isRed, toggleRed] = useToggle(false),
       [isBlue, toggleBlue] = useToggle(false),
-      [isGreen, toggleGreen] = useToggle(false);
+      [isGreen, toggleGreen] = useToggle(false),
+      [country, setCountry] = useState('');
 
   return (
     <>
@@ -51,13 +53,13 @@ export default function NxDrawerWithNxFormExample() {
               <NxStatefulTextInput />
             </NxFormGroup>
             <NxFormGroup label="Country" sublabel="Pick your favorite from the list">
-              <select className="nx-form-select">
+              <NxFormSelect value={country} onChange={evt => setCountry(evt.target.value)}>
                 <option value="">Pick a Country</option>
                 <option value="USA">USA</option>
                 <option value="GER">Canada</option>
                 <option value="CAN">Germany</option>
                 <option value="COL">Colombia</option>
-              </select>
+              </NxFormSelect>
             </NxFormGroup>
             <NxFormGroup label="Hostname">
               <NxStatefulTextInput/>

--- a/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
+++ b/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
@@ -68,9 +68,8 @@ const NxFormGroupPage = () =>
               <NxTable.Cell>No</NxTable.Cell>
               <NxTable.Cell>false</NxTable.Cell>
               <NxTable.Cell>
-                Sets whether the input should display the optional flag – the flag is present by default and
-                setting <NxCode>isRequired</NxCode> to true removes the flag. Also sets
-                the <NxCode>aria-required</NxCode> prop on the child if not already present.
+                Sets whether the input should display a red asterisk indicating that the field is required.
+                Also sets the <NxCode>aria-required</NxCode> prop on the child if not already present.
               </NxTable.Cell>
             </NxTable.Row>
             <NxTable.Row>
@@ -119,7 +118,7 @@ const NxFormGroupPage = () =>
                         liveExample={NxFormGroupRequiredExample}
                         codeExamples={nxFormGroupRequiredExampleCode}>
       An example of an <NxCode>NxFormGroup</NxCode> wrapping
-      an <NxCode>NxTextInput</NxCode> which uses the isRequired flag to remove the "Optional"
+      an <NxCode>NxTextInput</NxCode> which uses the isRequired flag to add the red asterisk
       indicator.
     </GalleryExampleTile>
 

--- a/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
+++ b/gallery/src/components/NxFormGroup/NxFormGroupPage.tsx
@@ -106,31 +106,6 @@ const NxFormGroupPage = () =>
           </NxTable.Body>
         </NxTable>
       </NxTile.Subsection>
-      <NxTile.Subsection>
-        <NxTile.SubsectionHeader>
-          <NxH3>Style Variations</NxH3>
-        </NxTile.SubsectionHeader>
-        <NxTable>
-          <NxTable.Head>
-            <NxTable.Row>
-              <NxTable.Cell>Class</NxTable.Cell>
-              <NxTable.Cell>Description</NxTable.Cell>
-            </NxTable.Row>
-          </NxTable.Head>
-          <NxTable.Body>
-            <NxTable.Row>
-              <NxTable.Cell><NxCode>nx-form-group--hide-optional</NxCode></NxTable.Cell>
-              <NxTable.Cell>
-                Hides the "optional" text <strong>even on optional labels</strong>. This is intended for cases where
-                the field is in fact optional yet the optional flag does not need to be displayed. The more
-                typical <NxCode>isRequired</NxCode> prop is inappropriate in this case. An example of when to use this
-                class is when constructing a label for an <NxCode>NxFilterDropdown</NxCode> – as a filter it does not
-                need to be explicitly shown as "optional".
-              </NxTable.Cell>
-            </NxTable.Row>
-          </NxTable.Body>
-        </NxTable>
-      </NxTile.Subsection>
     </GalleryDescriptionTile>
 
     <GalleryExampleTile title="Basic Example"

--- a/gallery/src/components/NxFormGroup/NxFormGroupRichLabelExample.tsx
+++ b/gallery/src/components/NxFormGroup/NxFormGroupRichLabelExample.tsx
@@ -8,7 +8,7 @@ import React, { useState, ChangeEvent } from 'react';
 
 import { faGlobeEurope, faFlag } from '@fortawesome/free-solid-svg-icons';
 
-import { NxFormGroup, NxFontAwesomeIcon } from '@sonatype/react-shared-components';
+import { NxFormGroup, NxFontAwesomeIcon, NxFormSelect } from '@sonatype/react-shared-components';
 
 export default function NxFormGroupRichLabelExample() {
   const [val, setVal] = useState('');
@@ -33,13 +33,13 @@ export default function NxFormGroupRichLabelExample() {
 
   return (
     <NxFormGroup { ...{ label, sublabel } }>
-      <select className="nx-form-select" value={val} onChange={onChange}>
+      <NxFormSelect value={val} onChange={onChange}>
         <option value="">Pick a Country</option>
         <option value="USA">USA</option>
         <option value="GER">Canada</option>
         <option value="CAN">Germany</option>
         <option value="COL">Colombia</option>
-      </select>
+      </NxFormSelect>
     </NxFormGroup>
   );
 }

--- a/gallery/src/components/NxFormGroup/NxFormGroupSublabelExample.tsx
+++ b/gallery/src/components/NxFormGroup/NxFormGroupSublabelExample.tsx
@@ -6,7 +6,7 @@
  */
 import React, { useState, ChangeEvent } from 'react';
 
-import { NxFormGroup } from '@sonatype/react-shared-components';
+import { NxFormGroup, NxFormSelect } from '@sonatype/react-shared-components';
 
 export default function NxFormGroupSublabelExample() {
   const [val, setVal] = useState('');
@@ -17,13 +17,13 @@ export default function NxFormGroupSublabelExample() {
 
   return (
     <NxFormGroup label="Country" sublabel="Pick your favorite from the list">
-      <select className="nx-form-select" value={val} onChange={onChange}>
+      <NxFormSelect value={val} onChange={onChange}>
         <option value="">Pick a Country</option>
         <option value="USA">USA</option>
         <option value="GER">Canada</option>
         <option value="CAN">Germany</option>
         <option value="COL">Colombia</option>
-      </select>
+      </NxFormSelect>
     </NxFormGroup>
   );
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "12.5.19",
+  "version": "12.5.20",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -121,12 +121,6 @@
   }
 }
 
-.nx-form-group--hide-optional {
-  .nx-label--optional .nx-label__text::after {
-    display: none;
-  }
-}
-
 .nx-sub-label {
   @include nx-container-helpers.container-horizontal;
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1280
https://issues.sonatype.org/browse/RSC-1281

This PR fixes two gallery cleanup issues that are only inter-related because they happened to affect the same page.

The first issue is that there were still a few gallery examples that used `<select className="nx-form-select">` rather than `<NxFormSelect>`.  Two of these appeared on the `NxFormGroup` doc page, and I found another on a Drawer example.

The second issue is that much of the `NxFormGroup` documentation around optional and required indicators was still written for the pre-RSC-12 behavior where an "optional" indicator was shown rather than the required indicator.  These incorrect docs included the `nx-form-group--hide-optional` class which no longer does anything at all.  That class' implementation has been removed along with its documentation.