### PR TITLE
Re-enable aria-required-children test on NxCollapsible*Select - RSC-1328

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "12.9.2",
+  "version": "12.9.3",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "12.10.1",
+  "version": "12.10.2",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/visualtests/nxCollapsibleMultiSelect.js
+++ b/gallery/visualtests/nxCollapsibleMultiSelect.js
@@ -21,7 +21,7 @@ describe('NxCollapsibleMultiSelect', function() {
   });
 
   describe('NxCollapsibleMultiSelect checkbox', function() {
-    const checkboxSelector = selector + ' .nx-collapsible-items__child:nth-child(2) .nx-radio-checkbox__input';
+    const checkboxSelector = selector + ' .nx-collapsible-items__child:first-child .nx-radio-checkbox__input';
     it('has an offsetted blue outer border outline and glow when focused', focusTest(selector, checkboxSelector));
   });
 

--- a/gallery/visualtests/nxCollapsibleMultiSelect.js
+++ b/gallery/visualtests/nxCollapsibleMultiSelect.js
@@ -25,6 +25,5 @@ describe('NxCollapsibleMultiSelect', function() {
     it('has an offsetted blue outer border outline and glow when focused', focusTest(selector, checkboxSelector));
   });
 
-  // TODO: Fix aria-required-children in RSC-1328
-  it('passes a11y checks', a11yTest(builder => builder.disableRules('aria-required-children')));
+  it('passes a11y checks', a11yTest());
 });

--- a/gallery/visualtests/nxCollapsibleRadioSelect.js
+++ b/gallery/visualtests/nxCollapsibleRadioSelect.js
@@ -14,7 +14,7 @@ describe('NxCollapsibleRadioSelect', function() {
   it('looks right', simpleTest(selector));
 
   describe('NxCollapsibleRadioSelect radio', function() {
-    const radioSelector = selector + ' .nx-collapsible-items__child:nth-child(3) .nx-radio-checkbox__input';
+    const radioSelector = selector + ' .nx-collapsible-items__child:nth-child(2) .nx-radio-checkbox__input';
     it('has an offsetted blue outer border outline and glow when focused', focusTest(selector, radioSelector));
   });
 

--- a/gallery/visualtests/nxCollapsibleRadioSelect.js
+++ b/gallery/visualtests/nxCollapsibleRadioSelect.js
@@ -18,6 +18,5 @@ describe('NxCollapsibleRadioSelect', function() {
     it('has an offsetted blue outer border outline and glow when focused', focusTest(selector, radioSelector));
   });
 
-  // TODO: Fix aria-required-children in RSC-1328
-  it('passes a11y checks', a11yTest(builder => builder.disableRules('aria-required-children')));
+  it('passes a11y checks', a11yTest());
 });

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "12.9.2",
+  "version": "12.9.3",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "12.10.1",
+  "version": "12.10.2",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/components/NxCheckbox/NxCheckbox.tsx
+++ b/lib/src/components/NxCheckbox/NxCheckbox.tsx
@@ -66,10 +66,13 @@ const NxCheckbox = forwardRef<HTMLLabelElement, Props>(
                  onChange={onChange || undefined}
                  { ...otherInputAttributes } />
           <span className="nx-radio-checkbox__control nx-checkbox__box">
-            {/* Put a space in the box if not checked,
-              * in order to provide a consistent vertical-align baseline
-              */}
-            { isChecked ? <FontAwesomeIcon icon={faCheck} /> : '\u00A0' }
+            { isChecked ?
+                // The undefined aria attrs are to work around an issue with the axe a11y checker in
+                // NxCollapsibleMultiSelect
+                <FontAwesomeIcon role={undefined} aria-hidden={undefined} icon={faCheck} /> :
+                // Put a space in the box if not checked, in order to provide a consistent vertical-align baseline
+                '\u00A0'
+            }
           </span>
           { content &&
             (overflowTooltip !== false ? <NxOverflowTooltip>{content}</NxOverflowTooltip> : content)

--- a/lib/src/components/NxCheckbox/NxCheckbox.tsx
+++ b/lib/src/components/NxCheckbox/NxCheckbox.tsx
@@ -67,11 +67,11 @@ const NxCheckbox = forwardRef<HTMLLabelElement, Props>(
                  { ...otherInputAttributes } />
           <span className="nx-radio-checkbox__control nx-checkbox__box">
             { isChecked ?
-                // The undefined aria attrs are to work around an issue with the axe a11y checker in
-                // NxCollapsibleMultiSelect
-                <FontAwesomeIcon role={undefined} aria-hidden={undefined} icon={faCheck} /> :
-                // Put a space in the box if not checked, in order to provide a consistent vertical-align baseline
-                '\u00A0'
+              // The undefined aria attrs are to work around an issue with the axe a11y checker in
+              // NxCollapsibleMultiSelect
+              <FontAwesomeIcon role={undefined} aria-hidden={undefined} icon={faCheck} /> :
+              // Put a space in the box if not checked, in order to provide a consistent vertical-align baseline
+              '\u00A0'
             }
           </span>
           { content &&

--- a/lib/src/components/NxCollapsibleItems/NxCollapsibleItems.scss
+++ b/lib/src/components/NxCollapsibleItems/NxCollapsibleItems.scss
@@ -27,6 +27,19 @@ $-form-child-left-padding: calc(#{$-trigger-side-padding} + #{$-triangle-box-wid
     // adjacent treeviews should be 16px apart rather than the 24 that they are from everything else
     margin-top: calc(0px - var(--nx-spacing-2x));
   }
+
+  .nx-text-input {
+    box-sizing: border-box;
+    border: none;
+    margin: 0;
+    padding:
+      var(--nx-spacing-3x)
+      var(--nx-spacing-2x)
+      var(--nx-spacing-3x)
+      $-form-child-left-padding;
+
+    width: 100%;
+  }
 }
 
 .nx-collapsible-items--expanded > .nx-collapsible-items__header {
@@ -170,21 +183,6 @@ $-form-child-left-padding: calc(#{$-trigger-side-padding} + #{$-triangle-box-wid
       var(--nx-spacing-2x)
       var(--nx-spacing-base)
       $-form-child-left-padding;
-  }
-}
-
-.nx-collapsible-items__children {
-  .nx-text-input {
-    box-sizing: border-box;
-    border: none;
-    margin: 0;
-    padding:
-      var(--nx-spacing-3x)
-      var(--nx-spacing-2x)
-      var(--nx-spacing-3x)
-      $-form-child-left-padding;
-
-    width: 100%;
   }
 }
 

--- a/lib/src/components/NxCollapsibleItems/NxCollapsibleItems.tsx
+++ b/lib/src/components/NxCollapsibleItems/NxCollapsibleItems.tsx
@@ -10,21 +10,21 @@ import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 
 import NxTooltip from '../NxTooltip/NxTooltip';
 import { useUniqueId } from '../../util/idUtil';
-import { Props, NxCollapsibleItemsChildProps, propTypes, childPropTypes } from './types';
+import { Props, PublicProps, NxCollapsibleItemsChildProps, propTypes, childPropTypes } from './types';
 import NxFontAwesomeIcon from '../NxFontAwesomeIcon/NxFontAwesomeIcon';
 
-export { Props, NxCollapsibleItemsChildProps } from './types';
+export { Props, PublicProps, NxCollapsibleItemsChildProps } from './types';
 
 import './NxCollapsibleItems.scss';
 import { ensureStartEndElements } from '../../util/reactUtil';
 
 type NxCollapsibleItemsFC =
-  FC<Props> &
+  FC<PublicProps> &
   {
     Child: React.ForwardRefExoticComponent<NxCollapsibleItemsChildProps & React.RefAttributes<Element>>
   };
 
-const NxCollapsibleItems: NxCollapsibleItemsFC = function NxCollapsibleItems(props: Props) {
+function PrivateNxCollapsibleItems(props: Props) {
   const {
     onToggleCollapse,
     isOpen,
@@ -35,6 +35,7 @@ const NxCollapsibleItems: NxCollapsibleItemsFC = function NxCollapsibleItems(pro
     actionContent,
     className,
     role,
+    contentBeforeChildren,
     ...otherProps
   } = props;
 
@@ -63,10 +64,7 @@ const NxCollapsibleItems: NxCollapsibleItemsFC = function NxCollapsibleItems(pro
       ),
       triggerTooltipProps = typeof triggerTooltip === 'string' ? { title: triggerTooltip } : triggerTooltip;
 
-  // There is a bug in role-supports-aria-props that it restricts aria-disabled even though it shouldn't.
-  // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/805
   return (
-    /* eslint-disable-next-line jsx-a11y/role-supports-aria-props */
     <div className={treeViewClasses}
          role="group"
          { ...otherProps }>
@@ -87,14 +85,13 @@ const NxCollapsibleItems: NxCollapsibleItemsFC = function NxCollapsibleItems(pro
         </div>
         )}
       </div>
+      {contentBeforeChildren}
       <div className="nx-collapsible-items__children" role={treeViewChildrenRole} id={treeViewChildrenId}>
         {children}
       </div>
     </div>
   );
-};
-
-NxCollapsibleItems.propTypes = propTypes;
+}
 
 /**
  * All individual treeview children should be wrapped in this component. When the child is an element,
@@ -122,10 +119,13 @@ const NxCollapsibleItemsChild = forwardRef<Element, NxCollapsibleItemsChildProps
     }
 );
 
-NxCollapsibleItemsChild.propTypes = childPropTypes;
+const NxCollapsibleItems: NxCollapsibleItemsFC = Object.assign(PrivateNxCollapsibleItems, {
+  Child: NxCollapsibleItemsChild,
+  propTypes: propTypes
+});
 
-NxCollapsibleItems.Child = NxCollapsibleItemsChild;
+NxCollapsibleItemsChild.propTypes = childPropTypes;
 
 export default NxCollapsibleItems;
 
-export { NxCollapsibleItemsChild };
+export { NxCollapsibleItemsChild, PrivateNxCollapsibleItems };

--- a/lib/src/components/NxCollapsibleItems/types.ts
+++ b/lib/src/components/NxCollapsibleItems/types.ts
@@ -9,7 +9,7 @@ import * as PropTypes from 'prop-types';
 
 import { TooltipConfigProps, tooltipPropTypesShape } from '../../util/tooltipUtils';
 
-export interface Props extends HTMLAttributes<HTMLDivElement> {
+export interface PublicProps extends HTMLAttributes<HTMLDivElement> {
   onToggleCollapse?: (() => void) | null;
   isOpen: boolean;
   disabled?: boolean | null;
@@ -19,12 +19,16 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
 }
 
+export interface Props extends PublicProps {
+  contentBeforeChildren?: ReactNode;
+}
+
 // NxCollapsibleItemsChild takes exactly one child element
 export interface NxCollapsibleItemsChildProps extends HTMLAttributes<Element> {
   children: ReactChild;
 }
 
-export const propTypes: PropTypes.ValidationMap<Props> = {
+export const propTypes: PropTypes.ValidationMap<PublicProps> = {
   onToggleCollapse: PropTypes.func,
   isOpen: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,

--- a/lib/src/components/NxCollapsibleItemsSelect/AbstractCollapsibleItemsSelect.tsx
+++ b/lib/src/components/NxCollapsibleItemsSelect/AbstractCollapsibleItemsSelect.tsx
@@ -8,7 +8,7 @@
 import React, { ReactElement } from 'react';
 
 import { Option } from './commonTypes';
-import NxCollapsibleItems from '../NxCollapsibleItems/NxCollapsibleItems';
+import NxCollapsibleItems, { PrivateNxCollapsibleItems } from '../NxCollapsibleItems/NxCollapsibleItems';
 import NxTooltip from '../NxTooltip/NxTooltip';
 import NxFilterInput from '../NxFilterInput/NxFilterInput';
 import { TooltipConfigProps } from '../../util/tooltipUtils';
@@ -110,19 +110,19 @@ function AbstractCollapsibleItemsSelect<T extends Option>(props: Props<T>) {
   };
 
   return (
-    <NxCollapsibleItems onToggleCollapse={onToggleCollapse}
-                        isOpen={isOpen && options.length > 0}
-                        id={id}
-                        role="menu"
-                        triggerContent={triggerWithCounter}
-                        triggerTooltip={getTriggerTooltip()}
-                        disabled={disabled}
-                        className="nx-collapsible-items--select"
-                        aria-describedby={counter && counter.props.id}>
-      {filterContent}
+    <PrivateNxCollapsibleItems onToggleCollapse={onToggleCollapse}
+                               isOpen={isOpen && options.length > 0}
+                               contentBeforeChildren={filterContent}
+                               id={id}
+                               role="menu"
+                               triggerContent={triggerWithCounter}
+                               triggerTooltip={getTriggerTooltip()}
+                               disabled={disabled}
+                               className="nx-collapsible-items--select"
+                               aria-describedby={counter && counter.props.id}>
       { selectAllOption && <NxCollapsibleItems.Child>{selectAllOption}</NxCollapsibleItems.Child> }
       {renderedOptions}
-    </NxCollapsibleItems>
+    </PrivateNxCollapsibleItems>
   );
 }
 

--- a/lib/src/components/NxCollapsibleItemsSelect/__tests__/AbstractCollapsibleItemsSelect.test.tsx
+++ b/lib/src/components/NxCollapsibleItemsSelect/__tests__/AbstractCollapsibleItemsSelect.test.tsx
@@ -10,7 +10,8 @@ import {times} from 'ramda';
 import {getShallowComponent} from '../../../__testutils__/enzymeUtils';
 import AbstractCollapsibleItemsSelect, {Props} from '../AbstractCollapsibleItemsSelect';
 import {Option} from '../commonTypes';
-import NxCollapsibleItems from '../../NxCollapsibleItems/NxCollapsibleItems';
+import NxCollapsibleItems, { PrivateNxCollapsibleItems } from '../../NxCollapsibleItems/NxCollapsibleItems';
+import { shallow } from 'enzyme';
 
 describe('AbstractCollapsibleItemsSelect', function() {
   const requiredProps: Props = {
@@ -33,7 +34,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
       expect(shallowRender).toHaveClassName('nx-collapsible-items--select');
 
       // test NxCollapsibleItems props
-      const nxCollapsibleItems = shallowRender.find('NxCollapsibleItems');
+      const nxCollapsibleItems = shallowRender.find('PrivateNxCollapsibleItems');
       expect(nxCollapsibleItems).toHaveProp('isOpen', false);
       expect(nxCollapsibleItems).toHaveProp('disabled', false);
       expect(nxCollapsibleItems).toHaveProp('triggerTooltip', null);
@@ -59,7 +60,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
     const getShallow = getShallowComponent<Props>(AbstractCollapsibleItemsSelect, requiredProps);
 
     it('wraps children in <span> if provided children is string', function () {
-      expect(getShallow().find('NxCollapsibleItems')).toHaveProp('triggerContent', <span>Foobar</span>);
+      expect(getShallow().find('PrivateNxCollapsibleItems')).toHaveProp('triggerContent', <span>Foobar</span>);
     });
 
     it('does not wrap children in <span> if provided children is react node', function () {
@@ -67,7 +68,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
         children: <b>Foobar</b>
       });
 
-      expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerContent', <b>Foobar</b>);
+      expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerContent', <b>Foobar</b>);
     });
   });
 
@@ -80,7 +81,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
         onToggleCollapse: onToggleCollapseSpy
       });
       expect(onToggleCollapseSpy).not.toHaveBeenCalled();
-      shallowRender.find('NxCollapsibleItems').simulate('toggleCollapse');
+      shallowRender.find('PrivateNxCollapsibleItems').simulate('toggleCollapse');
       expect(onToggleCollapseSpy).toHaveBeenCalled();
     });
   });
@@ -103,19 +104,19 @@ describe('AbstractCollapsibleItemsSelect', function() {
       it('renders filter input if filterThreshold is less than amount of options', function () {
         const shallowRender = getShallow();
 
-        const nxCollapsibleItems = shallowRender.find('NxCollapsibleItems');
-        expect(nxCollapsibleItems.children().length).toBe(4);
+        const nxCollapsibleItems = shallowRender.find('PrivateNxCollapsibleItems');
+        expect(nxCollapsibleItems.children().length).toBe(3);
 
-        const filterInput = nxCollapsibleItems.childAt(0);
+        const filterInput = shallow(<div>{nxCollapsibleItems.prop('contentBeforeChildren')}</div>).children();
         expect(filterInput).toHaveDisplayName('ForwardRef(NxFilterInput)');
         expect(filterInput).toHaveProp('id', 'nx-collapsible-items-select-foobar-filter-input');
       });
 
       it('sets the aria-controls on the filter to the collapsible items id', function() {
         const shallowRender = getShallow(),
-            nxCollapsibleItems = shallowRender.find(NxCollapsibleItems),
+            nxCollapsibleItems = shallowRender.find(PrivateNxCollapsibleItems),
             id = nxCollapsibleItems.prop('id'),
-            filterInput = nxCollapsibleItems.childAt(0);
+            filterInput = shallow(<div>{nxCollapsibleItems.prop('contentBeforeChildren')}</div>).children();
 
         expect(id).toBeTruthy();
         expect(filterInput).toHaveProp('aria-controls', id);
@@ -126,7 +127,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           filterThreshold: 3
         });
 
-        const nxCollapsibleItems = shallowRender.find('NxCollapsibleItems');
+        const nxCollapsibleItems = shallowRender.find('PrivateNxCollapsibleItems');
         expect(nxCollapsibleItems.children().length).toBe(3);
         expect(nxCollapsibleItems.childAt(0)).toMatchSelector(NxCollapsibleItems.Child);
         expect(nxCollapsibleItems.childAt(0)).toContainReact(<span>Foo</span>);
@@ -141,10 +142,10 @@ describe('AbstractCollapsibleItemsSelect', function() {
             options: times<Option>(generateOption, 11)
           });
 
-          const nxCollapsibleItems = shallowRender.find('NxCollapsibleItems');
-          expect(nxCollapsibleItems.children().length).toBe(12);
+          const nxCollapsibleItems = shallowRender.find('PrivateNxCollapsibleItems');
+          expect(nxCollapsibleItems.children().length).toBe(11);
 
-          const filterInput = nxCollapsibleItems.childAt(0);
+          const filterInput = shallow(<div>{nxCollapsibleItems.prop('contentBeforeChildren')}</div>).children();
           expect(filterInput).toHaveDisplayName('ForwardRef(NxFilterInput)');
           expect(filterInput).toHaveProp('id', 'nx-collapsible-items-select-foobar-filter-input');
         });
@@ -156,7 +157,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
                 options: times<Option>(generateOption, 10)
               });
 
-              const nxCollapsibleItems = shallowRender.find('NxCollapsibleItems');
+              const nxCollapsibleItems = shallowRender.find('PrivateNxCollapsibleItems');
               expect(nxCollapsibleItems.children().length).toBe(10);
               expect(nxCollapsibleItems.childAt(0)).toMatchSelector(NxCollapsibleItems.Child);
               expect(nxCollapsibleItems.childAt(0)).toContainReact(<span>0</span>);
@@ -174,7 +175,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           onFilterChange: onChangeSpy
         });
 
-        const filterInput = shallowRender.find('ForwardRef(NxFilterInput)');
+        const filterInput = shallow(<div>{shallowRender.prop('contentBeforeChildren')}</div>).children();
         expect(onChangeSpy).not.toHaveBeenCalled();
         filterInput.simulate('change', 'bla');
         expect(onChangeSpy).toHaveBeenCalledWith('bla');
@@ -189,11 +190,14 @@ describe('AbstractCollapsibleItemsSelect', function() {
           filter: 'ba'
         });
 
-        expect(shallowRender.find('ForwardRef(NxFilterInput)')).toHaveProp('value', 'ba');
+        const filterInput = shallow(<div>{shallowRender.prop('contentBeforeChildren')}</div>).children();
+
+        expect(filterInput).toHaveProp('value', 'ba');
       });
 
       it('defaults to empty string', function () {
-        expect(getShallow().find('ForwardRef(NxFilterInput)')).toHaveProp('value', '');
+        const filterInput = shallow(<div>{getShallow().prop('contentBeforeChildren')}</div>).children();
+        expect(filterInput).toHaveProp('value', '');
       });
     });
 
@@ -205,11 +209,14 @@ describe('AbstractCollapsibleItemsSelect', function() {
           filterPlaceholder: 'options filter'
         });
 
-        expect(shallowRender.find('ForwardRef(NxFilterInput)')).toHaveProp('placeholder', 'options filter');
+        const filterInput = shallow(<div>{shallowRender.prop('contentBeforeChildren')}</div>).children();
+
+        expect(filterInput).toHaveProp('placeholder', 'options filter');
       });
 
       it('defaults to "filter"', function () {
-        expect(getShallow().find('ForwardRef(NxFilterInput)')).toHaveProp('placeholder', 'filter');
+        const filterInput = shallow(<div>{getShallow().prop('contentBeforeChildren')}</div>).children();
+        expect(filterInput).toHaveProp('placeholder', 'filter');
       });
     });
 
@@ -228,11 +235,10 @@ describe('AbstractCollapsibleItemsSelect', function() {
         const shallowRender = getShallow();
 
         const options = shallowRender.children();
-        expect(options.length).toBe(3);
+        expect(options.length).toBe(2);
 
-        // first one is the filter itself
-        expect(options.at(1)).toHaveText('Bar');
-        expect(options.at(2)).toHaveText('Baz');
+        expect(options.at(0)).toHaveText('Bar');
+        expect(options.at(1)).toHaveText('Baz');
       });
 
       it('renders all options if filteredOptions prop is not provided', function () {
@@ -241,12 +247,11 @@ describe('AbstractCollapsibleItemsSelect', function() {
         });
 
         const options = shallowRender.children();
-        expect(options.length).toBe(4);
+        expect(options.length).toBe(3);
 
-        // first one is the filter itself
-        expect(options.at(1)).toHaveText('Foo');
-        expect(options.at(2)).toHaveText('Bar');
-        expect(options.at(3)).toHaveText('Baz');
+        expect(options.at(0)).toHaveText('Foo');
+        expect(options.at(1)).toHaveText('Bar');
+        expect(options.at(2)).toHaveText('Baz');
       });
     });
   });
@@ -279,7 +284,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           <div>Counter</div>
         </>
       );
-      expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerContent', expectedTriggerContent);
+      expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerContent', expectedTriggerContent);
     });
   });
 
@@ -287,7 +292,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
     const getShallow = getShallowComponent<Props>(AbstractCollapsibleItemsSelect, requiredProps);
 
     it('defaults to false if disabled prop is not provided', function () {
-      expect(getShallow().find('NxCollapsibleItems')).toHaveProp('disabled', false);
+      expect(getShallow().find('PrivateNxCollapsibleItems')).toHaveProp('disabled', false);
     });
 
     it('disables NxCollapsibleItems', function () {
@@ -295,7 +300,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
         disabled: true
       });
 
-      expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('disabled', true);
+      expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('disabled', true);
     });
 
     it('does not disable options filter', function () {
@@ -305,7 +310,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
         filterThreshold: 1
       });
 
-      expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('disabled', true);
+      expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('disabled', true);
       expect(shallowRender.find('.nx-collapsible-items__filter input')).not.toHaveProp('disabled');
     });
 
@@ -315,7 +320,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           disabledTooltip: 'Disabled Tooltip Test'
         });
 
-        expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerTooltip', null);
+        expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerTooltip', null);
       });
 
       it('does not render tooltip if component is disabled but disabledTooltip prop is not provided', function () {
@@ -323,7 +328,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           disabled: true
         });
 
-        expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerTooltip', null);
+        expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerTooltip', null);
       });
 
       it('renders tooltip if disabledTooltip prop is provided and component is disabled', function () {
@@ -332,7 +337,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           disabledTooltip: 'Disabled Tooltip Test'
         });
 
-        expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerTooltip', {
+        expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerTooltip', {
           title: 'Disabled Tooltip Test',
           placement: 'top'
         });
@@ -345,7 +350,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           tooltipModifierClass: 'test-tooltip-modifier'
         });
 
-        expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerTooltip', {
+        expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerTooltip', {
           title: 'Disabled Tooltip Test',
           placement: 'top',
           className: 'test-tooltip-modifier'
@@ -361,11 +366,11 @@ describe('AbstractCollapsibleItemsSelect', function() {
       const shallowRender = getShallow({
         isOpen: true
       });
-      expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('isOpen', true);
+      expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('isOpen', true);
     });
 
     it('defaults to false', function () {
-      expect(getShallow().find('NxCollapsibleItems')).toHaveProp('isOpen', false);
+      expect(getShallow().find('PrivateNxCollapsibleItems')).toHaveProp('isOpen', false);
     });
   });
 
@@ -376,12 +381,12 @@ describe('AbstractCollapsibleItemsSelect', function() {
       const shallowRender = getShallow({
         id: 'someid'
       });
-      expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('id', 'someid');
+      expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('id', 'someid');
     });
 
     it('assigns a random id if not supplied', function() {
-      const id1 = getShallow().find(NxCollapsibleItems).prop('id'),
-          id2 = getShallow().find(NxCollapsibleItems).prop('id');
+      const id1 = getShallow().find(PrivateNxCollapsibleItems).prop('id'),
+          id2 = getShallow().find(PrivateNxCollapsibleItems).prop('id');
 
       expect(id1).toBeTruthy();
       expect(id2).toBeTruthy();
@@ -436,7 +441,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
     const getShallow = getShallowComponent<Props>(AbstractCollapsibleItemsSelect, props);
 
     it('disables NxCollapsibleItems when there are no options', function () {
-      expect(getShallow().find('NxCollapsibleItems')).toHaveProp('disabled', true);
+      expect(getShallow().find('PrivateNxCollapsibleItems')).toHaveProp('disabled', true);
     });
 
     it('disables NxCollapsibleItems when there are no options even if you pass disabled = false',
@@ -444,16 +449,16 @@ describe('AbstractCollapsibleItemsSelect', function() {
           const shallowRender = getShallow({
             disabled: false
           });
-          expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('disabled', true);
+          expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('disabled', true);
         }
     );
 
     it('collapses NxCollapsibleItems when there are no options', function () {
-      expect(getShallow().find('NxCollapsibleItems')).toHaveProp('isOpen', false);
+      expect(getShallow().find('PrivateNxCollapsibleItems')).toHaveProp('isOpen', false);
     });
 
     it('generates trigger tooltip using name prop when there are no options', function () {
-      expect(getShallow().find('NxCollapsibleItems')).toHaveProp('triggerTooltip', {
+      expect(getShallow().find('PrivateNxCollapsibleItems')).toHaveProp('triggerTooltip', {
         title: 'There are no foobar options',
         placement: 'top'
       });
@@ -464,7 +469,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           const shallowRender = getShallow({
             disabledTooltip: 'disabled tooltip'
           });
-          expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerTooltip', {
+          expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerTooltip', {
             title: 'disabled tooltip',
             placement: 'top'
           });
@@ -476,7 +481,7 @@ describe('AbstractCollapsibleItemsSelect', function() {
           const shallowRender = getShallow({
             tooltipModifierClass: 'test-tooltip-modifier'
           });
-          expect(shallowRender.find('NxCollapsibleItems')).toHaveProp('triggerTooltip', {
+          expect(shallowRender.find('PrivateNxCollapsibleItems')).toHaveProp('triggerTooltip', {
             title: 'There are no foobar options',
             placement: 'top',
             className: 'test-tooltip-modifier'

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -82,13 +82,13 @@ export { default as NxTabPanel, NxTabPanelProps } from './components/NxTabs/NxTa
 export {
   default as NxTreeView,
   NxCollapsibleItemsChild as NxTreeViewChild,
-  Props as NxTreeViewProps,
+  PublicProps as NxTreeViewProps,
   NxCollapsibleItemsChildProps as NxTreeViewChildProps
 } from './components/NxCollapsibleItems/NxCollapsibleItems';
 
 export {
   default as NxCollapsibleItems,
-  Props as NxCollapsibleItemsProps,
+  PublicProps as NxCollapsibleItemsProps,
   NxCollapsibleItemsChildProps
 } from './components/NxCollapsibleItems/NxCollapsibleItems';
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1328

The main issue here was that the filter input needed to be pulled out of the element that had the `menu` role