### PR TITLE
Improvement Day: Silence Overflow Tooltip Test Warnings

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "12.10.12",
+  "version": "12.10.13",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "12.10.12",
+  "version": "12.10.13",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
NxOveflowTooltip prints out some warnings if it receives unexpected (non-px) values from some `getComputedStyle` properties.  The purpose of these warnings is so that if this ever happens in a real browser we can investigate and try to mitigate.  However, we also know that JSDOM always triggers this condition, since it doesn't have a real layout engine.  We don't need these warnings in that case, and they clutter up the test logs.  This PR silences the warnings in JSDOM only.