### PR TITLE
Interaction States Tabs- RSC-1480

### DIFF
--- a/lib/src/base-styles/_nx-color-swatches.scss
+++ b/lib/src/base-styles/_nx-color-swatches.scss
@@ -38,6 +38,7 @@
   --nx-swatch-grey-85: hsl(var(--nx-swatch-grey-hs), 85%);
   --nx-swatch-grey-90: hsl(var(--nx-swatch-grey-hs), 90%);
   --nx-swatch-grey-95: hsl(var(--nx-swatch-grey-hs), 95%);
+  --nx-swatch-grey-97: hsl(var(--nx-swatch-grey-hs), 97%);
   --nx-swatch-white: hsl(var(--nx-swatch-grey-hs), 100%);
 
   // Teals

--- a/lib/src/components/NxTabs/NxTabs.scss
+++ b/lib/src/components/NxTabs/NxTabs.scss
@@ -42,26 +42,58 @@
   margin: 0 var(--nx-spacing-4x) -1px 0;
   // subtract border thickness for consistent spacing
   padding: var(--nx-spacing-4x) var(--nx-spacing-6x) calc(var(--nx-spacing-4x) - 2px) var(--nx-spacing-6x);
+  position: relative;
   text-align: center;
   min-width: 80px;
   max-width: 240px;
+  background-color: transparent;
+  opacity: 99%;
 
   &.active {
     @include nx-text-helpers.semi-bold;
 
-    border-bottom-color: var(--nx-swatch-blue-40);
+    border-bottom: 2px solid var(--nx-swatch-blue-40);
     color: var(--nx-swatch-blue-40);
   }
 
-  &:hover {
+  &:hover:not(.active) {
     @include nx-text-helpers.semi-bold;
+    color: var(--nx-color-text-dark);
+
+    &:before {
+      content: '';
+      position: absolute;
+      top: 4px;
+      left: 0;
+      height: calc(100% - 8px);
+      width: 100%;
+      border-radius: 6px;
+      background-color: var(--nx-swatch-grey-97);
+      z-index: -1;
+    }
   }
 
   &:focus {
-    border-bottom-width: 1px;
-    box-shadow: var(--nx-box-shadow-focus);
-    margin-bottom: 0;
-    outline: solid 1px var(--nx-color-interactive-border-focus);
+    // border-bottom-width: 1px;
+    // box-shadow: var(--nx-box-shadow-focus);
+    // margin-bottom: 0;
+    &:after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -4px;
+      height: 100%;
+      // can't control the outline's offset top/bottom with left/right, so need to make the width
+      // larger so outline-offset meets the element's edge
+      width: calc(100% + 8px);
+      outline: 1px solid var(--nx-swatch-blue-40);
+      outline-offset: -5px;
+      border-radius: 6px;
+    }
+  }
+
+  &:focus-visible {
+    outline: none;
   }
 
   // a hidden copy of the text, always at semi-bold weight, to enfore consistent element width


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1480

Thoughts so far: 

FOCUS STATE:
NxTab is already using border-bottom for the blue underline when active. If we just use an offset outline for the focus state though, we can’t have rounded corners since the bottom border doesn’t use a border-radius. 
Therefore, I tried adding a ::after pseudo element for the outline. Because the outline needs to maintain the same width as the tab, but 48px tall instead of 56px tall, I extended the width of the ::after and then applied outline-offset to make it work. (Not very clean right now clearly).

HOVER STATE:
For the same reason of using the border-bottom for the underline, I think we need to ALSO use a pseudo element for the hover state. The grey background with rounded corners is shorter than the overall height of NxTab. 
Therefore used another pseudo element with a smaller height. The problem I am running into here is how to get it behind `NxTab`. It seems as though the background only shows up when opacity is less than 100%, even if I try to use z-index . Odd, since the background of NxTab is transparent, and reading online it seems as though setting the z-index to -1 should do the trick. 

I feel like there should be a cleaner way to fix this. Also, I noticed that the border-radius of the :before and :after elements are different (which I assume has to do with the fact that the outline is offset )