### PR TITLE
NxThreatIndicator & NxThreatIndicatorLegend dark mode - RSC-1049 & RSC-1050

### DIFF
--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -387,6 +387,12 @@ const CssVariablesPage = () => {
             <ColorDocRow colorVar="--nx-color-code-text">
               The text color used on the <NxCode>NxCode</NxCode>.
             </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-threat-indicator-legend-header-text">
+              The text color used on the <NxCode>NxThreatIndicatorLegend</NxCode> header.
+            </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-threat-indicator-legend-item-text">
+              The text color used on the <NxCode>NxThreatIndicatorLegend</NxCode> items.
+            </ColorDocRow>
           </NxTable.Body>
         </NxTable>
       </GalleryTile>

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ac58e64b5c45bf9bfe566989bc04a250ef51fa219c523af845a54af6a46df1f
+size 16672

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-in-a-list-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-in-a-list-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:943142c6c16950377ffb4d79cffb3922ed8829fcf683ac31c5eb7413dff53699
+size 82646

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-in-a-table-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-in-a-table-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78fe24a1466ea3d753a84740fcabcbd92b5cb88c1971675d833efe73390489a2
+size 9267

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-when-policy-threat-level-prop-is-provided-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-js-nx-threat-indicator-looks-right-when-policy-threat-level-prop-is-provided-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8259f6e5aca6f36f41bb4fd084aee15fe3651e64f23b11b6f86d3bbe8025919e
+size 20215

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-horizontal-orientation-and-all-category-level-threats-shown-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-horizontal-orientation-and-all-category-level-threats-shown-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:727d7eb3f7cd9e318ccd85794c02caece248837e656438a7f7a5e564e1540322
+size 11117

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-horizontal-orientation-and-only-some-category-level-threats-shown-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-horizontal-orientation-and-only-some-category-level-threats-shown-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6da34c445198d0510a2252f79d4bd90c4b48c72012582038a6cc9e730ffabef4
+size 8562

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-vertical-orientation-and-all-category-level-threats-shown-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-vertical-orientation-and-all-category-level-threats-shown-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e066570c2f245458cf9123249e7b7a902b54e7e7939bc019d4841c3923746601
+size 13525

--- a/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-vertical-orientation-and-only-some-category-level-threats-shown-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-threat-indicator-legend-js-nx-threat-indicator-legend-looks-correct-with-vertical-orientation-and-only-some-category-level-threats-shown-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcf658902e81741128a179f8eadceff8a31054d62a945764c1631186726ad34d
+size 9563

--- a/lib/src/base-styles/_nx-color-swatches.scss
+++ b/lib/src/base-styles/_nx-color-swatches.scss
@@ -19,6 +19,7 @@
   --nx-swatch-blue-50: hsl(var(--nx-swatch-blue-hs), 50%);
   --nx-swatch-blue-60: hsl(var(--nx-swatch-blue-hs), 60%);
   --nx-swatch-blue-70: hsl(var(--nx-swatch-blue-hs), 70%);
+  --nx-swatch-blue-75: hsl(var(--nx-swatch-blue-hs), 75%);
   --nx-swatch-blue-80: hsl(var(--nx-swatch-blue-hs), 80%);
   --nx-swatch-blue-90: hsl(var(--nx-swatch-blue-hs), 90%);
   --nx-swatch-blue-95: hsl(var(--nx-swatch-blue-hs), 95%);
@@ -190,6 +191,7 @@
   --nx-swatch-indigo-40: hsl(var(--nx-swatch-indigo-hs), 40%);
   --nx-swatch-indigo-50: hsl(var(--nx-swatch-indigo-hs), 50%);
   --nx-swatch-indigo-60: hsl(var(--nx-swatch-indigo-hs), 60%);
+  --nx-swatch-indigo-65: hsl(var(--nx-swatch-indigo-hs), 65%);
   --nx-swatch-indigo-70: hsl(var(--nx-swatch-indigo-hs), 70%);
   --nx-swatch-indigo-80: hsl(var(--nx-swatch-indigo-hs), 80%);
   --nx-swatch-indigo-90: hsl(var(--nx-swatch-indigo-hs), 90%);

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -42,6 +42,8 @@
   --nx-color-threat-moderate: var(--nx-swatch-yellow-60);
   --nx-color-threat-severe: var(--nx-swatch-orange-50);
   --nx-color-threat-critical: var(--nx-swatch-red-40);
+  --nx-color-threat-indicator-legend-header-text: var(--nx-color-text-stark);
+  --nx-color-threat-indicator-legend-item-text: var(--nx-color-text);
 
   --nx-color-validation-valid: var(--nx-swatch-green-25);
   --nx-color-validation-invalid: var(--nx-swatch-red-40);
@@ -105,6 +107,16 @@
     --nx-color-page-header-divider: var(--nx-swatch-indigo-25);
     --nx-color-page-header-product-name-text: var(--nx-color-text-stark);
     --nx-color-page-header-link: var(--nx-color-link);
+
+    //NxThreatIndicator variables
+    --nx-color-threat-unspecified: var(--nx-swatch-grey-60);
+    --nx-color-threat-none: var(--nx-swatch-indigo-65);
+    --nx-color-threat-low: var(--nx-swatch-blue-75);
+    --nx-color-threat-moderate: var(--nx-swatch-yellow-65);
+    --nx-color-threat-severe: var(--nx-swatch-orange-55);
+    --nx-color-threat-critical: var(--nx-swatch-red-65);
+    --nx-color-threat-indicator-legend-header-text: var(--nx-swatch-indigo-95);
+    --nx-color-threat-indicator-legend-item-text: var(--nx-swatch-indigo-95);
 
     //NxTooltip variables
     --nx-color-tooltip-background: var(--nx-swatch-indigo-80);

--- a/lib/src/components/NxThreatIndicator/NxThreatIndicator.scss
+++ b/lib/src/components/NxThreatIndicator/NxThreatIndicator.scss
@@ -4,7 +4,8 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-
+ @use '../../scss-shared/nx-dark-mode-helpers';
+ 
 // eyeballed, assumes $nx-font-size surrounding text
 $-vertical-alignment: -0.1em;
 

--- a/lib/src/components/NxThreatIndicatorLegend/NxThreatIndicatorLegend.scss
+++ b/lib/src/components/NxThreatIndicatorLegend/NxThreatIndicatorLegend.scss
@@ -6,6 +6,7 @@
  */
 @use '../../scss-shared/nx-container-helpers';
 @use '../../scss-shared/nx-text-helpers';
+@use '../../scss-shared/nx-dark-mode-helpers';
 
 .nx-threat-indicator-legend {
   $max-grid-columns: 6;
@@ -18,13 +19,14 @@
 
   .nx-threat-indicator-legend__header {
     @include nx-text-helpers.bold;
-    color: var(--nx-color-text-dark);
+    color: var(--nx-color-threat-indicator-legend-header-text);
     grid-column: span $max-grid-columns;
   }
 
   .nx-threat-indicator-legend__threat-container {
     @include nx-container-helpers.container-horizontal;
     @include nx-text-helpers.semi-bold;
+    color: var(--nx-color-threat-indicator-legend-item-text);
   }
 }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1049
https://issues.sonatype.org/browse/RSC-1050

I consulted with Jenni re: the label & text colours in NxThreatIndicatorLegend, and it is a design choice to make the colours brighter than `--nx-color-stark` (`--nx-swatch-indigo-95` instead of `--nx-swatch-indigo-90`). Therefore, new colour variables have been created for the header & item text.