### PR TITLE
remove deprecated box-shadow on header when focused- RSC-1538

### DIFF
--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -267,9 +267,8 @@
   vertical-align: middle;
 
   &:focus {
-    outline: 1px solid var(--nx-color-interactive-border-focus);
-    outline-offset: -1px;
-    box-shadow: var(--nx-box-shadow-focus);
+    outline: 2px solid var(--nx-color-interactive-border-focus);
+    outline-offset: -2px;
   }
 }
 


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1538

Removing the deprecated `--nx-box-shadow-focus` variable from NxTable, and adjusting the focus outline to 2px. I am leaving the focus state based on the Slack discussion here (https://sonatype.slack.com/archives/CJUF9G7T2/p1679325213978609).