### PR TITLE
Dark Mode: System Notice - RSC-1042

### DIFF
--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -905,6 +905,16 @@ const CssVariablesPage = () => {
             <ColorDocRow colorVar="--nx-color-small-threat-counter-zero-text">
               The text color of the <NxCode>NxSmallThreatCounter</NxCode> with a value of 0.
             </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-system-notice-background">
+              The default background color for <NxCode>NxSystemNotice</NxCode>.
+            </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-system-notice-background-alert">
+              The background color for <NxCode>NxSystemNotice</NxCode>s using
+              the <NxCode>nx-system-notice--alert</NxCode> class.
+            </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-system-notice-text">
+              The text color for <NxCode>NxSystemNotice</NxCode>.
+            </ColorDocRow>
           </NxTable.Body>
         </NxTable>
       </GalleryTile>

--- a/gallery/visualtests/__image_snapshots_dark__/nx-system-notice-js-nx-system-notice-with-traditional-page-layout-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-system-notice-js-nx-system-notice-with-traditional-page-layout-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1d233751ad24d41f5b92de845c9f93b75eaacbd1af5044a48839e2cc9767af0
+size 106612

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-page-scrolling-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-page-scrolling-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:929cc87c8cccd97dd7dac8010566aa332d5473f6459d7d34dff41f4d63b87ffa
+size 18399

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-page-scrolling-looks-right-2-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-page-scrolling-looks-right-2-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfef506ae0c4cdf147ee1f18350f017174866ba5e3d8d384fe0f69cf17a58f83
+size 32280

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-section-scrolling-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-section-scrolling-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:929cc87c8cccd97dd7dac8010566aa332d5473f6459d7d34dff41f4d63b87ffa
+size 18399

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-section-scrolling-looks-right-2-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-nx-load-wrapper-in-legacy-page-layout-with-system-notice-and-section-scrolling-looks-right-2-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfef506ae0c4cdf147ee1f18350f017174866ba5e3d8d384fe0f69cf17a58f83
+size 32280

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-sidebar-system-notice-and-page-scrolling-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-sidebar-system-notice-and-page-scrolling-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f0105decda0ca3b5b06ba642d8f009478e34bcdf60a823827e2f5fed35f0802
+size 356509

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-sidebar-system-notice-and-section-scrolling-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-sidebar-system-notice-and-section-scrolling-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f0105decda0ca3b5b06ba642d8f009478e34bcdf60a823827e2f5fed35f0802
+size 356509

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-system-notice-and-page-scrolling-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-system-notice-and-page-scrolling-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7de07d58a812c55e6045d5a630d032377c3943abe1cf44748bb12158dc737a1
+size 193598

--- a/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-system-notice-and-section-scrolling-looks-right-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/page-layouts-js-page-layout-legacy-page-layout-with-system-notice-and-section-scrolling-looks-right-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7de07d58a812c55e6045d5a630d032377c3943abe1cf44748bb12158dc737a1
+size 193598

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -279,6 +279,10 @@
   --nx-color-status-indicator-error-icon-background: var(--nx-swatch-red-65);
   --nx-color-status-indicator-error-icon-border: var(--nx-color-alert-error);
 
+  --nx-color-system-notice-background: var(--nx-swatch-indigo-95);
+  --nx-color-system-notice-background-alert: var(--nx-swatch-orange-95);
+  --nx-color-system-notice-text: var(--nx-color-text);
+
   @include nx-dark-mode-helpers.dark-mode {
     --nx-color-disabled: var(--nx-swatch-indigo-40);
 
@@ -539,6 +543,10 @@
     --nx-color-status-indicator-error-text: var(--nx-swatch-indigo-10);
     --nx-color-status-indicator-error-icon-background: var(--nx-swatch-red-40);
     --nx-color-status-indicator-error-icon-border: var(--nx-color-status-indicator-error-icon-background);
+
+    --nx-color-system-notice-background: var(--nx-swatch-indigo-30);
+    --nx-color-system-notice-background-alert: var(--nx-swatch-pink-30);
+    --nx-color-system-notice-text: var(--nx-swatch-indigo-95);
   }
 
   // Deprecated variables

--- a/lib/src/base-styles/_nx-system-notice.scss
+++ b/lib/src/base-styles/_nx-system-notice.scss
@@ -15,10 +15,11 @@
   @include nx-text-helpers.truncate-ellipsis;
   @include nx-container-helpers.container-horizontal;
 
-  background-color: var(--nx-swatch-indigo-95);
+  background-color: var(--nx-color-system-notice-background);
+  color: var(--nx-color-system-notice-text);
   padding: var(--nx-spacing-3x) var(--nx-spacing-6x);
 }
 
 .nx-system-notice--alert {
-  background-color: var(--nx-swatch-orange-95);
+  background-color: var(--nx-color-system-notice-background-alert);
 }


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1042

Note: Many visual tests that include NxSystemNotice also include NxGlobalSidebar and so cannot be committed yet.  Unfortunately, this includes the one with the `--alert` styling.