### PR TITLE
Avoid using JS to remember collapsed icon height - RSC-1557

### DIFF
--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -81,6 +81,7 @@ $-separator-color: var(--nx-swatch-indigo-40);
 .nx-global-sidebar__product-info {
   flex: 1 1 auto;
   display: flex;
+  overflow: hidden;
 
   &:focus-visible {
     outline: none;
@@ -165,6 +166,10 @@ $-separator-color: var(--nx-swatch-indigo-40);
   .nx-global-sidebar__hide-when-collapsed {
     visibility: hidden;
     white-space: nowrap;
+  }
+
+  .nx-global-sidebar__product-info {
+    width: 0;
   }
 
   .nx-global-sidebar__header {

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.tsx
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import React, { FunctionComponent, useRef } from 'react';
+import React, { FunctionComponent } from 'react';
 import classnames from 'classnames';
 
 import NxButton from '../NxButton/NxButton';
@@ -29,8 +29,7 @@ const NxGlobalSidebar: FunctionComponent<Props> = function NxGlobalSidebar(props
     logoLink
   } = props;
 
-  const id = useUniqueId('nx-global-sidebar'),
-      headerRef = useRef<HTMLDivElement>(null);
+  const id = useUniqueId('nx-global-sidebar');
 
   const classes = classnames(className, 'nx-global-sidebar', {
     'open': isOpen,
@@ -56,8 +55,8 @@ const NxGlobalSidebar: FunctionComponent<Props> = function NxGlobalSidebar(props
   return (
     <div className={classes} id={id}>
       <aside aria-label="global sidebar">
-        <div className="nx-global-sidebar__header" ref={headerRef} style={{height: headerRef?.current?.clientHeight}}>
-          <a className="nx-global-sidebar__product-info nx-global-sidebar__expanded-content"
+        <div className="nx-global-sidebar__header">
+          <a className="nx-global-sidebar__product-info"
              href={logoLink}>
             { logo }
           </a>


### PR DESCRIPTION
Fix for https://github.com/sonatype/sonatype-react-shared-components/pull/1078#discussion_r1176855268