### PR TITLE
Remove green text from NxRadio example

### DIFF
--- a/gallery/src/components/NxRadio/NxRadioExample.tsx
+++ b/gallery/src/components/NxRadio/NxRadioExample.tsx
@@ -22,9 +22,7 @@ export default function NxRadioExample() {
           Red
         </NxRadio>
         <NxRadio name="color" value="green" onChange={setColor} isChecked={color === 'green'} radioId="color-green">
-          <span style={{color: 'green'}}>Green</span>
-          {' '}
-          <em>(non-text children)</em>
+          Green <em>(non-text children)</em>
         </NxRadio>
         <NxRadio name="color" value="blue" onChange={setColor} isChecked={color === 'blue'} radioId="color-blue">
           Blue - but a very long and verbose blue that makes for a long label, so long that it should trigger ellipsis


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-1698

No visual test updates needed: the only visual test that would have captured this color actually doesn't because it's hidden behind a tooltip