### PR TITLE
Draft: Adding searchable tags to page config

### DIFF
--- a/gallery/src/GalleryNav/GalleryNav.tsx
+++ b/gallery/src/GalleryNav/GalleryNav.tsx
@@ -110,7 +110,8 @@ function GalleryNav() {
       [openTreeViews, setOpenTreeViews] = useState(initialOpenTreeViews),
       isFiltering = !!filter,
       filteredConfig: PageConfig = isFiltering ? pipe<[PageConfig], PageConfig, PageConfig>(
-          map<PageConfig, PageConfig>(pickBy<PageMapping>((_, pageName) => matchesFilter(filter, pageName))),
+          map<PageConfig, PageConfig>(pickBy<PageMapping>((pageInfo, pageName) =>
+            matchesFilter(filter, pageName, pageInfo.tags))),
           pickBy(complement(isEmpty))
       )(pageConfig) : pageConfig,
       filteredCategories = pipe<[PageConfig], [string, PageMapping][], ReactNode[]>(

--- a/gallery/src/filterUtil.tsx
+++ b/gallery/src/filterUtil.tsx
@@ -4,7 +4,7 @@
  * the terms of the Eclipse Public License 2.0 which accompanies this
  * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
  */
-import { reduce, head, tail, toLower, isEmpty, splitAt, drop, join } from 'ramda';
+import {reduce, head, tail, toLower, isEmpty, splitAt, drop, join, map} from 'ramda';
 import React, { ReactNode } from 'react';
 
 /**
@@ -67,14 +67,22 @@ export function markByFilter(filter: string | undefined, text: string): ReactNod
 /**
  * @return true if the pageName contains every character present in the filter in the same order, case insensitive
  */
-export function matchesFilter(filter: string, pageName: string) {
+export function matchesFilter(filter: string, pageName: string, tags: string[] = []): boolean {
+  const matchesPageName = isStringIncludedInSecondStringCaseInsensitive(filter, pageName);
+  const matchesAnyTags: boolean = map((tag: string) => {
+    return isStringIncludedInSecondStringCaseInsensitive(filter, tag);
+  }, tags).reduce((acc, val) => acc || val, false);
+
+  return matchesPageName || matchesAnyTags;
+}
+
+function isStringIncludedInSecondStringCaseInsensitive(search: string, fullValue: string): boolean {
   const unmatchedFilterChars = reduce(
       (remainingFilter, pageNameChar) =>
         head(remainingFilter) === pageNameChar ? tail(remainingFilter) : remainingFilter,
-      Array.from(toLower(filter)),
-      Array.from(toLower(pageName))
+      Array.from(toLower(search)),
+      Array.from(toLower(fullValue))
   );
 
   return isEmpty(unmatchedFilterChars);
 }
-

--- a/gallery/src/pageConfig.ts
+++ b/gallery/src/pageConfig.ts
@@ -161,9 +161,9 @@ import DarkModeMixinPage from './styles/DarkMode/DarkModeMixinPage';
 
 const pageConfig: PageConfig = {
   'Alerts and Indicators': {
-    'Alert': { content: NxAlertComponentsPage, type: 'react' },
-    'Stateful Alert': { content: NxStatefulAlertComponentsPage, type: 'react' },
-    'Counter': { content: NxCounterPage, type: 'html' },
+    'Alert': { content: NxAlertComponentsPage, type: 'react', tags: ['NxAlert'] },
+    'Stateful Alert': { content: NxStatefulAlertComponentsPage, type: 'react', tags: ['NxStatefulAlert'] },
+    'Counter': { content: NxCounterPage, type: 'html', tags: ['NxCounter'] },
     'Load Error': { content: NxLoadErrorPage, type: 'react' },
     'Load Wrapper': { content: NxLoadWrapperPage, type: 'react' },
     'Loading Spinner': { content: NxLoadingSpinnerPage, type: 'react' },
@@ -282,7 +282,7 @@ const pageConfig: PageConfig = {
     'Code': { content: NxCodePage, type: 'html' },
     'Font Awesome Icon': { content: NxFontAwesomeIconPage, type: 'react' },
     'H*': { content: NxHPage, type: 'html' },
-    'P': { content: NxPPage, type: 'html' },
+    'P': { content: NxPPage, type: 'html', tags: ['NxP'] },
     'Pre': { content: NxPrePage, type: 'html' }
   },
   'HTML Variants': {

--- a/gallery/src/pageConfigTypes.ts
+++ b/gallery/src/pageConfigTypes.ts
@@ -21,6 +21,8 @@ export type PageType = typeof PAGE_TYPES[number];
 export interface PageContentDescription {
   content: ComponentType;
   type: PageType;
+
+  tags?: string []
 }
 
 export type PageConfig = Record<string, PageMapping>;


### PR DESCRIPTION
This will allow the component filter to better surface pages, for example a page called Alert that discusses the NxAlert component, could match on NxAlert as well as Alert.


Note: This is not quite ready yet, but pushing it up for discussion