### PR TITLE
NxTable sort icons interaction states - RSC-1646

### DIFF
--- a/gallery/src/styles/CssVariables/CssVariablesPage.tsx
+++ b/gallery/src/styles/CssVariables/CssVariablesPage.tsx
@@ -816,6 +816,12 @@ const CssVariablesPage = () => {
             <ColorDocRow colorVar="--nx-color-table-header-background">
               The background color of the <NxCode>NxTable</NxCode> header.
             </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-table-header-button-background-hover">
+              The background color of the <NxCode>NxTable</NxCode> header button when hovered.
+            </ColorDocRow>
+            <ColorDocRow colorVar="--nx-color-table-header-button-background-active">
+              The background color of the <NxCode>NxTable</NxCode> header button when clicked.
+            </ColorDocRow>
             <ColorDocRow colorVar="--nx-color-table-row-background-hover">
               The background color of an <NxCode>NxTable</NxCode> row on hover.
             </ColorDocRow>

--- a/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-looks-right-with-an-active-sort-column-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-looks-right-with-an-active-sort-column-1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5f26546140911bafe3879907523f170fe76109013a000b88595470e776348f0
-size 11067

--- a/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-clicked-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-clicked-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dcb4b0be88744f28ad5a6393ee82d89f67a62f75db4c3c854cde31d01033436
+size 11268

--- a/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3ab211b5396de6622cf7eadf88068c27f040e4ad4ed67bc60719bb2809930a3
+size 11240

--- a/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-and-hovered-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-and-hovered-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37d73dfcb00a9a19b22bfe23ccb9dd75dc67a5607b03214a07370e028e639527
+size 11414

--- a/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-hovered-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-when-hovered-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:775a63f2b31e2bbdd56055e75bb20d5246782e452e902ee57f24a2b61704614c
+size 11303

--- a/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-with-an-active-sort-column-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-table-js-nx-table-sortable-columns-looks-right-with-an-active-sort-column-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5351fd2caf5d7c3fad9b1a023a0c6e5b6f4040a4358d7c63ee552776d0f9bb33
+size 11078

--- a/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-looks-right-with-an-active-sort-column-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-looks-right-with-an-active-sort-column-1-dark.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a0731e5eecab8fad3f4a9f34e962133fb44565a31f0cd2b20c3a12cd8d71010
-size 11211

--- a/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-clicked-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-clicked-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:388ff509aaecb6203b11350f8a229225e7f3783097413d20f401927ca73f9410
+size 11519

--- a/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b571e5fd2458194013c7014f88201a74c4aa8703f78a412fd262e5dc889c6ff8
+size 11386

--- a/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-and-hovered-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-focused-and-hovered-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16b02ab97c015774c5ac36bf388b42b87b4ce60e5e17736c24ba6692fc762327
+size 11644

--- a/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-hovered-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-when-hovered-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f48858eed88e4bdc7395d7140de6efa62b8a4f52d1447484a9971e06a30ce0a9
+size 11533

--- a/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-with-an-active-sort-column-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-table-js-nx-table-sortable-columns-looks-right-with-an-active-sort-column-1-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fece60b2eebce5fb68527b5a131974f19635209b72472049c10dfbca17fa8a8f
+size 11230

--- a/gallery/visualtests/nxTable.js
+++ b/gallery/visualtests/nxTable.js
@@ -9,6 +9,11 @@ const { setupBrowser } = require('./testUtils');
 describe('NxTable', function() {
   const {
     simpleTest,
+    focusTest,
+    focusAndHoverTest,
+    hoverTest,
+    blurElement,
+    moveMouseAway,
     waitAndGetElements,
     checkScreenshot,
     getPage,
@@ -53,12 +58,20 @@ describe('NxTable', function() {
 
   it('looks right with a custom clickable row icon', simpleTest(clickableCustomIconTableSelector));
 
-  it('looks right with an active sort column', async function() {
-    const columnSelector = `${sortableTableSelector} thead th:first-child`,
-        [table, columnHeader] = await waitAndGetElements(sortableTableSelector, columnSelector);
+  describe('Sortable Columns', function() {
+    const columnSelector = `${sortableTableSelector} thead th:first-child .nx-cell__sort-btn`;
+    it('looks right when hovered', hoverTest(sortableTableSelector, columnSelector));
+    it('looks right when focused', focusTest(sortableTableSelector, columnSelector));
+    it('looks right when focused and hovered', focusAndHoverTest(sortableTableSelector, columnSelector));
+    it('looks right when clicked', clickTest(sortableTableSelector, columnSelector));
+    it('looks right with an active sort column', async function() {
+      const [table, columnHeader] = await waitAndGetElements(sortableTableSelector, columnSelector);
 
-    await columnHeader.click();
-    await checkScreenshot(table);
+      await columnHeader.click();
+      await blurElement(columnHeader);
+      await moveMouseAway();
+      await checkScreenshot(table);
+    });
   });
 
   it('looks right when loading', async function() {

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -225,6 +225,8 @@
   --nx-color-table-header-background: var(--nx-swatch-indigo-80);
   --nx-color-table-row-background-hover: var(--nx-color-interactive-background-hover);
   --nx-color-table-sort-icon-active: var(--nx-swatch-blue-40);
+  --nx-color-table-header-button-background-hover: var(--nx-swatch-indigo-70);
+  --nx-color-table-header-button-background-active: var(--nx-swatch-indigo-90);
 
   // NxTransferList
   --nx-color-transfer-list-item-list-background: var(--nx-color-site-background);
@@ -544,6 +546,8 @@
     --nx-color-table-header-background: var(--nx-swatch-indigo-35);
     --nx-color-table-row-background-hover: var(--nx-swatch-indigo-15);
     --nx-color-table-sort-icon-active: var(--nx-swatch-purple-80);
+    --nx-color-table-interactive-header-background-hover: var(--nx-swatch-indigo-25);
+    --nx-color-table-interactive-header-background-active: var(--nx-swatch-indigo-45);
 
     // NxList
     --nx-color-list-background-hover: var(--nx-color-site-background);

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -546,8 +546,8 @@
     --nx-color-table-header-background: var(--nx-swatch-indigo-35);
     --nx-color-table-row-background-hover: var(--nx-swatch-indigo-15);
     --nx-color-table-sort-icon-active: var(--nx-swatch-purple-80);
-    --nx-color-table-interactive-header-background-hover: var(--nx-swatch-indigo-25);
-    --nx-color-table-interactive-header-background-active: var(--nx-swatch-indigo-45);
+    --nx-color-table-header-button-background-hover: var(--nx-swatch-indigo-25);
+    --nx-color-table-header-button-background-active: var(--nx-swatch-indigo-45);
 
     // NxList
     --nx-color-list-background-hover: var(--nx-color-site-background);

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -367,6 +367,41 @@
 
 .nx-cell__sort-btn {
   height: nx-table-variables.$table-cell-header-height;
+  position: relative;
+
+  > * {
+    position: relative;
+  }
+
+  &::before {
+    box-sizing: border-box;
+    border-radius: 4px;
+    content: '';
+    // offset by 1px on top and 2px on the bottom
+    height: calc(100% - 3px);
+    position: absolute;
+    left: 0;
+    top: 1px;
+    // the button is already 1px narrower than the <th> element, so width set to the full 100%
+    width: 100%;
+  }
+
+  &:hover {
+    &::before {
+      background-color: var(--nx-color-table-header-button-background-hover);
+    }
+  }
+  &:focus {
+    &::before {
+      border: var(--nx-focus-outline-width) solid var(--nx-color-interactive-border-focus);
+    }
+  }
+  &:active {
+    &::before {
+      background-color: var(--nx-color-table-header-button-background-active);
+      border: none;
+    }
+  }
 }
 
 // adjust button sizing for ends of rows, where padding is different and there are borders


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/RSC-1646

Figma: https://www.figma.com/file/SMeWSFCKTQbyarldXKVzro/Kaleido-V2?type=design&node-id=0-24636&mode=design&t=BUCp81dCupSxf0Ce-0

After speaking to Jason, they confirmed that the full table mocks are currently incorrect and still need to be updated, so refer to the new 'Sort Function Interaction States' section for proper implementation of the table's outer border (an outer border around the entire table, with no border line between the header & body, which is the current implementation in the gallery)