### PR TITLE
Improvement Day: Updated jenkinsfile for future gallery backports deploy to S3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ dockerizedBuildPipeline(
   testResults: ['lib/junit.xml', 'gallery/test-results/junit.xml'],
   onSuccess: {
     githubStatusUpdate('success')
-    if (isMainBranch()) {
+    if (deployBranch.equals(env.BRANCH_NAME.equals)) {
       build job:'/uxui/publish-gallery-with-versions-to-s3', propagate: false, wait: false, parameters: [
         [$class: 'StringParameterValue', name: 'RSC_VERSION', value: "${env.VERSION}"],
         run(name: 'Producer', runId: "${currentBuild.fullProjectName}${currentBuild.displayName}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ dockerizedBuildPipeline(
   testResults: ['lib/junit.xml', 'gallery/test-results/junit.xml'],
   onSuccess: {
     githubStatusUpdate('success')
-    if (deployBranch.equals(env.BRANCH_NAME.equals)) {
+    if (deployBranch.equals(env.BRANCH_NAME)) {
       build job:'/uxui/publish-gallery-with-versions-to-s3', propagate: false, wait: false, parameters: [
         [$class: 'StringParameterValue', name: 'RSC_VERSION', value: "${env.VERSION}"],
         run(name: 'Producer', runId: "${currentBuild.fullProjectName}${currentBuild.displayName}")

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "13.1.5",
+  "version": "13.1.6",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "13.1.5",
+  "version": "13.1.6",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This updates the `Jenkinsfile` on main
so for future backports versioning can reference the Jenkinsfile and simply change the `deployBranch` definition.

Context:
https://sonatype.slack.com/archives/CJUF9G7T2/p1693585838719979

See successful test here:
https://github.com/sonatype/sonatype-react-shared-components/commit/c5fd59ddade9a93f64edd2bb649b032819cf4218
https://gallery.sonatype.dev/versions/12.16.15/#/pages/Drawer

Build:
https://jenkins.ci.sonatype.dev/job/uxui/job/sonatype-react-shared-components/job/iday-backport-version-dropdown/