### PR TITLE
Fix sass deprecation warnings - RSC-1767

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -57,7 +57,7 @@
     "puppeteer": "^20.2.1",
     "resolve-url-loader": "^5.0.0",
     "rimraf": "^4.0.0",
-    "sass": "^1.62.1",
+    "sass": "^1.77.8",
     "sass-loader": "^13.2.2",
     "source-map-loader": "^4.0.1",
     "tmp-promise": "^3.0.3",

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "13.1.7",
+  "version": "13.1.8",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/src/main.scss
+++ b/gallery/src/main.scss
@@ -203,8 +203,8 @@
 
 .gallery-icon-description-list {
   .nx-list__term {
-    @include nx-container-helpers.container-horizontal;
-
     width: auto;
+
+    @include nx-container-helpers.container-horizontal;
   }
 }

--- a/gallery/src/styles/NxContainerHelpers/NxContainerHelpersExample.scss
+++ b/gallery/src/styles/NxContainerHelpers/NxContainerHelpersExample.scss
@@ -7,9 +7,10 @@
 @use '~@sonatype/react-shared-components/scss-shared/nx-container-helpers';
 
 .gallery-container-example {
-  @include nx-container-helpers.container-vertical;
   border: 1px solid #ccc;
   padding: 8px;
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .gallery-container-example__child {

--- a/gallery/visualtests/__image_snapshots__/nx-date-input-js-nx-date-input-simple-nx-date-input-has-a-blue-inner-outline-and-darker-border-when-hovered-and-focused-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-date-input-js-nx-date-input-simple-nx-date-input-has-a-blue-inner-outline-and-darker-border-when-hovered-and-focused-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63e512ea67cfa0a942fa06a87aea90277276450435d54730a625c73e58849194
+oid sha256:97c8600bea0924611991fdf539aa617a8abe04ebfc1463daf3ee28e9c81b0ff7
 size 2250

--- a/gallery/visualtests/__image_snapshots__/nx-date-input-js-nx-date-input-simple-nx-date-input-has-a-blue-inner-outline-when-focused-1.png
+++ b/gallery/visualtests/__image_snapshots__/nx-date-input-js-nx-date-input-simple-nx-date-input-has-a-blue-inner-outline-when-focused-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a2d4c92a3936420a978add8d0e80fc2d3bdd951a7fb463782694087fe6df40b
-size 2219
+oid sha256:bc48ad9b8d348a6b27cc81a658a24dde1c7c339ad3d0439c9bb5448eb4b55c4d
+size 2253

--- a/gallery/visualtests/__image_snapshots_dark__/nx-file-upload-js-nx-file-upload-when-a-file-is-selected-file-dismiss-button-has-dark-outline-and-dark-background-when-hovered-1-dark.png
+++ b/gallery/visualtests/__image_snapshots_dark__/nx-file-upload-js-nx-file-upload-when-a-file-is-selected-file-dismiss-button-has-dark-outline-and-dark-background-when-hovered-1-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c33c203ee177037c54159ad21190d22fe18f22bc8dd8685048fa365b3dcdaf84
-size 11901
+oid sha256:c65c30c7e632ac43920f1e37acb7f49dd0542242b5dfea8cfd74ffa4ef53cb8d
+size 10801

--- a/gallery/yarn.lock
+++ b/gallery/yarn.lock
@@ -6878,10 +6878,10 @@ sass-loader@^13.2.2:
     klona "^2.0.6"
     neo-async "^2.6.2"
 
-sass@^1.62.1:
-  version "1.62.1"
-  resolved "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz#caa8d6bf098935bc92fc73fa169fb3790cacd029"
-  integrity sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==
+sass@^1.77.8:
+  version "1.77.8"
+  resolved "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz#9f18b449ea401759ef7ec1752a16373e296b52bd"
+  integrity sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"

--- a/lib/package.json
+++ b/lib/package.json
@@ -61,7 +61,7 @@
     "react-dom": "^18.2.0",
     "resolve-url-loader": "^5.0.0",
     "rimraf": "^4.0.0",
-    "sass": "^1.62.1",
+    "sass": "^1.77.8",
     "sass-loader": "^13.2.2",
     "source-map-loader": "^4.0.1",
     "ts-jest": "^29.1.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "13.1.7",
+  "version": "13.1.8",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-alert.scss
+++ b/lib/src/base-styles/_nx-alert.scss
@@ -12,8 +12,6 @@
 */
 
 .nx-alert {
-  @include nx-container-helpers.container-horizontal;
-
   align-items: first baseline;
   background-color: var(--nx-color-component-background);
   border: 1px solid var(--nx-color-text-stark);
@@ -78,20 +76,20 @@
     content: '\200b';
     margin: var(--nx-spacing-base) 0;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-alert__content-wrap {
-  @include nx-container-helpers.container-horizontal;
-
   align-items: center;
   display: flex;
   flex-grow: 1;
   min-height: 32px;
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-alert__content {
-  @include nx-container-helpers.container-vertical;
-
   flex-grow: 1;
   overflow-wrap: anywhere;
 
@@ -111,6 +109,8 @@
       color: var(--nx-color-alert-link-active);
     }
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 footer, .nx-footer {

--- a/lib/src/base-styles/_nx-btn-bar.scss
+++ b/lib/src/base-styles/_nx-btn-bar.scss
@@ -7,10 +7,10 @@
 @use '../scss-shared/nx-container-helpers';
 
 .nx-btn-bar {
-  @include nx-container-helpers.container-horizontal;
-
   align-items: center;
   display: flex;
   justify-content: flex-end;
   margin: var(--nx-spacing-6x) 0;
+
+  @include nx-container-helpers.container-horizontal;
 }

--- a/lib/src/base-styles/_nx-btn.scss
+++ b/lib/src/base-styles/_nx-btn.scss
@@ -33,7 +33,6 @@
 
 .nx-btn, a.nx-btn {
   @include nx-text-helpers.semi-bold;
-  @include nx-container-helpers.container-horizontal;
 
   background-color: var(--nx-color-secondary-button-background);
   border: var(--nx-border-width-alt) solid var(--nx-color-secondary-button-border);
@@ -104,6 +103,8 @@
       height: 16px;
     }
   }
+  @include nx-container-helpers.container-horizontal;
+
 }
 
 .nx-btn, .nx-segmented-btn, .nx-icon-dropdown {
@@ -129,6 +130,13 @@
   border-color: transparent;
   color: var(--nx-color-text-stark);
 
+  // icon width can vary, just don't bother with padding in this direction and let the centering work it out
+  padding-left: 0;
+  padding-right: 0;
+
+  // essentially, calculate the width the same way that the height is calculated (line height plus padding and border)
+  width: calc(1em * var(--nx-line-height) + 2 * var(--nx-spacing-2x));
+
   &:hover {
     background-color: var(--nx-color-interactive-background-hover);
     color: var(--nx-color-text-stark);
@@ -144,13 +152,6 @@
     border-color: transparent;
     color: var(--nx-color-text-stark);
   }
-
-  // icon width can vary, just don't bother with padding in this direction and let the centering work it out
-  padding-left: 0;
-  padding-right: 0;
-
-  // essentially, calculate the width the same way that the height is calculated (line height plus padding and border)
-  width: calc(1em * var(--nx-line-height) + 2 * var(--nx-spacing-2x));
 
   .nx-icon {
     height: 1em;

--- a/lib/src/base-styles/_nx-card.scss
+++ b/lib/src/base-styles/_nx-card.scss
@@ -20,7 +20,6 @@
 }
 
 .nx-card {
-  @include nx-container-helpers.container-vertical;
   background-color: var(--nx-color-component-background);
   border-radius: var(--nx-border-radius);
   box-sizing: border-box;
@@ -30,18 +29,20 @@
   text-align: center;
   min-width: 230px;
   max-width: 330px;
+  @include nx-container-helpers.container-vertical;
 }
 
 // Safari does not support gap in flex layouts so we need to use this query and margin for Safari.
 @media not all and (min-resolution:.001dpcm) {
   @supports (-webkit-appearance:none) and (display:flow-root) {
     .nx-card-container {
-      @include nx-container-helpers.container-horizontal;
       margin-bottom: 0;
 
       + .nx-card-container {
         margin-top: 0;
       }
+
+      @include nx-container-helpers.container-horizontal;
     }
 
     .nx-card {
@@ -65,18 +66,18 @@
 }
 
 .nx-card__header {
-  @include nx-container-helpers.container-vertical;
   margin-bottom: var(--nx-spacing-4x);
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-card__content {
-  @include nx-container-helpers.container-vertical;
   align-items: center;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   gap: var(--nx-spacing-4x);
   margin-bottom: var(--nx-spacing-6x);
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-card__footer {

--- a/lib/src/base-styles/_nx-colors.scss
+++ b/lib/src/base-styles/_nx-colors.scss
@@ -677,14 +677,16 @@
     --nx-color-page-title-divider: var(--nx-swatch-indigo-25);
   }
 
-  // Deprecated variables
-  --nx-color-subsection-border: var(--nx-color-border);
-  --nx-color-text-dark: var(--nx-color-text-stark);
-  --nx-color-form-element-border: var(--nx-swatch-grey-50); // form - element - border
-  --nx-color-interactive-border-pristine: var(--nx-swatch-indigo-90);
-  --nx-color-interactive-shadow-focus: hsla(var(--nx-swatch-teal-hs), 35%, 0.5);
-  --nx-color-alert-warning: var(--nx-swatch-orange-50);
-  --nx-color-alert-info: var(--nx-swatch-blue-40);
-  --nx-color-alert-success: var(--nx-swatch-green-25);
-  --nx-color-alert-error: var(--nx-swatch-red-40);
+  & {
+    // Deprecated variables
+    --nx-color-subsection-border: var(--nx-color-border);
+    --nx-color-text-dark: var(--nx-color-text-stark);
+    --nx-color-form-element-border: var(--nx-swatch-grey-50); // form - element - border
+    --nx-color-interactive-border-pristine: var(--nx-swatch-indigo-90);
+    --nx-color-interactive-shadow-focus: hsla(var(--nx-swatch-teal-hs), 35%, 0.5);
+    --nx-color-alert-warning: var(--nx-swatch-orange-50);
+    --nx-color-alert-info: var(--nx-swatch-blue-40);
+    --nx-color-alert-success: var(--nx-swatch-green-25);
+    --nx-color-alert-error: var(--nx-swatch-red-40);
+  }
 }

--- a/lib/src/base-styles/_nx-footer.scss
+++ b/lib/src/base-styles/_nx-footer.scss
@@ -7,8 +7,6 @@
 @use '../scss-shared/nx-container-helpers';
 
 .nx-footer {
-  @include nx-container-helpers.container-vertical;
-
   border-top: var(--nx-border-default);
   margin-top: var(--nx-spacing-6x);
   padding-top: var(--nx-spacing-6x);
@@ -16,4 +14,6 @@
   .nx-alert {
     margin-bottom: var(--nx-spacing-6x);
   }
+
+  @include nx-container-helpers.container-vertical;
 }

--- a/lib/src/base-styles/_nx-forms.scss
+++ b/lib/src/base-styles/_nx-forms.scss
@@ -10,8 +10,6 @@
 .nx-form {
   position: relative;
 
-  @include nx-container-helpers.container-vertical;
-
   &__required-field-asterisk {
     color: var(--nx-color-validation-invalid);
   }
@@ -54,6 +52,7 @@
     }
   }
 
+  @include nx-container-helpers.container-vertical;
 }
 
 
@@ -67,7 +66,6 @@
 }
 
 .nx-form-row {
-  @include nx-container-helpers.container-horizontal;
   align-items: flex-end;
   display: flex;
   margin-bottom: var(--nx-spacing-8x);
@@ -81,6 +79,8 @@
     margin-top: 0;
     margin-bottom: 0;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 // labels
@@ -102,7 +102,6 @@
 
 .nx-label__text, .nx-legend__text {
   @include nx-text-helpers.bold;
-  @include nx-container-helpers.container-horizontal;
 
   color: var(--nx-color-text-stark);
   cursor: default;
@@ -113,6 +112,8 @@
     @extend .nx-form__required-field-asterisk;
     content: ' *';
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-label--optional, .nx-legend--optional {
@@ -122,11 +123,11 @@
 }
 
 .nx-sub-label {
-  @include nx-container-helpers.container-horizontal;
-
   display: block;
   font-size: var(--nx-font-size-s);
   font-style: italic;
   margin-bottom: var(--nx-spacing-4x);
   max-width: var(--nx-width-text-wrapping);
+
+  @include nx-container-helpers.container-horizontal;
 }

--- a/lib/src/base-styles/_nx-global-header.scss
+++ b/lib/src/base-styles/_nx-global-header.scss
@@ -27,7 +27,6 @@
 }
 
 .nx-global-header__actions {
-  @include nx-container-helpers.container-horizontal;
   align-items: center;
   border-left: var(--nx-border-default);
   display: flex;
@@ -37,4 +36,6 @@
   .nx-btn--icon-only {
     @include nx-button-helpers.small-icon-btn;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }

--- a/lib/src/base-styles/_nx-globals.scss
+++ b/lib/src/base-styles/_nx-globals.scss
@@ -29,8 +29,8 @@ $-nx-scrollable-default-height: 400px;
 }
 
 .nx-scrollable {
-  @include nx-container-helpers.container-vertical;
   @include nx-container-helpers.vertically-scrollable($-nx-scrollable-default-height);
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-truncate-ellipsis {

--- a/lib/src/base-styles/_nx-grid.scss
+++ b/lib/src/base-styles/_nx-grid.scss
@@ -15,8 +15,6 @@
 }
 
 .nx-grid-col {
-  @include nx-container-helpers.container-vertical;
-
   border-left: var(--nx-border-grid);
   box-sizing: border-box;
   flex: 1 0;
@@ -33,6 +31,8 @@
   &:last-child {
     padding-right: 0;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 @each $percent in (25, 50, 75, 33, 67) {
@@ -50,8 +50,8 @@
 
 // Grid headers
 .nx-grid-header {
-  @include nx-container-helpers.container-vertical;
   margin-bottom: var(--nx-spacing-4x);
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-grid-header__title {
@@ -60,8 +60,8 @@
 }
 
 .nx-grid-col__section {
-  @include nx-container-helpers.container-vertical;
-
   margin-top: var(--nx-spacing-6x);
   margin-bottom: var(--nx-spacing-6x);
+
+  @include nx-container-helpers.container-vertical;
 }

--- a/lib/src/base-styles/_nx-lists.scss
+++ b/lib/src/base-styles/_nx-lists.scss
@@ -75,7 +75,6 @@
 
 .nx-list__text {
   @include nx-text-helpers.semi-bold;
-  @include nx-container-helpers.container-horizontal;
 
   display: block;
   grid-area: list-text;
@@ -91,6 +90,8 @@
     height: calc(var(--nx-line-height) * 1em);
     max-width: unset;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-list__subtext {
@@ -118,8 +119,6 @@
 }
 
 .nx-list__item--error {
-  @include nx-container-helpers.container-vertical;
-
   display: list-item;
   padding-left: 0;
   padding-right: 0;
@@ -128,6 +127,8 @@
     margin-left: auto;
     margin-right: auto;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-list--bulleted, .nx-list--numbered {
@@ -136,8 +137,6 @@
   padding: 0 0 0 26px;
 
   .nx-list__item {
-    @include nx-container-helpers.container-vertical;
-
     border: none;
     display: list-item;
     list-style: disc outside;
@@ -179,6 +178,8 @@
         list-style-type: square;
       }
     }
+
+    @include nx-container-helpers.container-vertical;
   }
 }
 
@@ -278,8 +279,6 @@
 }
 
 .nx-list__actions {
-  @include nx-container-helpers.container-horizontal;
-
   grid-area: actions;
   // list items have 16px of padding, but the buttons are supposed to be 12px from the top
   margin: -4px 0 -4px var(--nx-spacing-4x);
@@ -295,6 +294,8 @@
   .nx-btn--icon-only {
     @include nx-button-helpers.small-icon-btn;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-list--description-list {
@@ -336,12 +337,12 @@
 
 .nx-list__description {
   &, > .nx-list__link, > .nx-list__btn {
-    @include nx-container-helpers.container-vertical;
-
     flex: 1;
     margin: 0;
     padding: var(--nx-spacing-4x) var(--nx-padding-without-border)
       var(--nx-padding-without-border) var(--nx-spacing-6x);
+
+    @include nx-container-helpers.container-vertical;
   }
 
   > .nx-list__link, > .nx-list__btn {

--- a/lib/src/base-styles/_nx-page-header.scss
+++ b/lib/src/base-styles/_nx-page-header.scss
@@ -24,8 +24,6 @@
 }
 
 .nx-page-header__inner {
-  @include nx-container-helpers.container-horizontal;
-
   align-items: flex-start;
   box-sizing: border-box;
   display: flex;
@@ -34,11 +32,13 @@
   padding: 0 var(--nx-spacing-6x);
   width: 100%;
   max-width: var(--nx-width-page-max);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-page-header__links {
-  @include nx-container-helpers.container-horizontal;
   margin: 26px var(--nx-spacing-16x) 0 var(--nx-spacing-16x);
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-page-header__link {
@@ -79,8 +79,6 @@
 }
 
 .nx-page-header__extra-content {
-  @include nx-container-helpers.container-horizontal;
-
   align-items: center;
   align-self: stretch;
   display: flex;
@@ -89,6 +87,8 @@
   .nx-btn--icon-only {
     @include nx-button-helpers.small-icon-btn;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-product {

--- a/lib/src/base-styles/_nx-page-layout.scss
+++ b/lib/src/base-styles/_nx-page-layout.scss
@@ -43,8 +43,6 @@
 }
 
 .nx-page-content {
-  @include nx-container-helpers.container-horizontal;
-
   justify-self: center;
   box-sizing: border-box;
   display: flex;
@@ -54,6 +52,8 @@
   max-width: var(--nx-width-page-max);
   overflow-y: hidden;
   width: 100%;
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-page, .nx-page-content {
@@ -75,8 +75,6 @@
 }
 
 .nx-page-sidebar {
-  @include nx-container-helpers.container-vertical;
-
   background-color: var(--nx-color-site-background);
   box-sizing: border-box;
 
@@ -97,11 +95,11 @@
     // When inner sidebar is present, main should only be in the content area
     grid-area: content;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-page-main {
-  @include nx-container-helpers.container-vertical;
-
   box-sizing: border-box;
   flex: auto;
 
@@ -112,6 +110,8 @@
   overflow-y: auto;
   padding: var(--nx-spacing-6x) var(--nx-spacing-6x);
   white-space: normal;
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-html--page-scrolling {

--- a/lib/src/base-styles/_nx-page.scss
+++ b/lib/src/base-styles/_nx-page.scss
@@ -8,8 +8,6 @@
 @use '../scss-shared/nx-text-helpers';
 
 .nx-page-title {
-  @include nx-container-helpers.container-horizontal;
-  @include nx-container-helpers.container-vertical;
   align-items: center;
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -32,6 +30,9 @@
     grid-area: actions;
     margin: 0 0 0 var(--nx-spacing-6x);
   }
+
+  @include nx-container-helpers.container-horizontal;
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-page-title__headings {
@@ -48,7 +49,6 @@
 }
 
 .nx-page-title__description {
-  @include nx-container-helpers.container-vertical;
   grid-area: description;
   margin-top: var(--nx-spacing-2x);
   max-width: var(--nx-width-text-wrapping);
@@ -56,11 +56,11 @@
   + .nx-page-title__tags {
     margin-top: var(--nx-spacing-4x);
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-page-title__tags {
-  @include nx-container-helpers.container-horizontal;
-
   display: flex;
   flex-wrap: wrap;
   grid-area: tags;
@@ -100,4 +100,6 @@
       margin-left: var(--nx-spacing-6x);
     }
   }
+
+  @include nx-container-helpers.container-horizontal;
 }

--- a/lib/src/base-styles/_nx-radio-checkbox.scss
+++ b/lib/src/base-styles/_nx-radio-checkbox.scss
@@ -12,7 +12,6 @@
 .nx-radio-checkbox {
   $max-width: 562px;
 
-  @include nx-container-helpers.container-horizontal;
   @include nx-text-helpers.regular;
 
   align-items: center;
@@ -65,6 +64,8 @@
       z-index: -1;
     }
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-radio-checkbox--disabled {
@@ -83,8 +84,8 @@
 }
 
 .nx-radio-checkbox__content {
-  @include nx-container-helpers.container-horizontal;
   @include nx-text-helpers.truncate-ellipsis;
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-radio-checkbox__input {

--- a/lib/src/base-styles/_nx-read-only.scss
+++ b/lib/src/base-styles/_nx-read-only.scss
@@ -8,8 +8,8 @@
 @use '../scss-shared/nx-text-helpers';
 
 .nx-read-only {
-  @include nx-container-helpers.container-vertical;
   margin: 0 0 var(--nx-spacing-8x) 0;
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-read-only--grid {

--- a/lib/src/base-styles/_nx-status-indicator.scss
+++ b/lib/src/base-styles/_nx-status-indicator.scss
@@ -57,7 +57,9 @@
   }
 
   // negative styles (default)
-  @include status-indicator-styling("negative");
+  & {
+    @include status-indicator-styling("negative");
+  }
 
   &--intermediate {
     @include status-indicator-styling("intermediate");

--- a/lib/src/base-styles/_nx-system-notice.scss
+++ b/lib/src/base-styles/_nx-system-notice.scss
@@ -13,11 +13,12 @@
 
 .nx-system-notice {
   @include nx-text-helpers.truncate-ellipsis;
-  @include nx-container-helpers.container-horizontal;
 
   background-color: var(--nx-color-system-notice-background);
   color: var(--nx-color-system-notice-text);
   padding: var(--nx-spacing-3x) var(--nx-spacing-6x);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-system-notice--alert {

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -153,12 +153,12 @@
 
     > tbody > :last-child {
       > .nx-cell {
+        border-bottom-style: solid;
+        height: nx-table-variables.$table-cell-min-height;
+
         &:first-child, &:last-child {
           border-radius: 0;
         }
-
-        border-bottom-style: solid;
-        height: nx-table-variables.$table-cell-min-height;
       }
     }
 
@@ -180,8 +180,6 @@
 }
 
 .nx-table-container__footer {
-  @include nx-container-helpers.container-vertical;
-
   background-color: var(--nx-color-component-background);
   border-top: var(--nx-border-default);
   margin-top: auto;
@@ -195,6 +193,8 @@
   position: sticky;
   bottom: 0;
   z-index: 1;
+
+  @include nx-container-helpers.container-vertical;
 }
 
 // nested and located this far down the file for specificity reasons
@@ -224,9 +224,6 @@
 }
 
 .nx-cell {
-  @include nx-container-helpers.container-vertical;
-  @include nx-container-helpers.container-horizontal;
-
   box-sizing: border-box;
 
   // min-height doesn't work on table cells, and height works roughly the way min-height ought to
@@ -253,6 +250,9 @@
       @include nx-button-helpers.small-icon-btn;
     }
   }
+
+  @include nx-container-helpers.container-vertical;
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-cell--label {
@@ -342,8 +342,8 @@
 .nx-cell__sort-btn, .nx-cell__row-btn {
   box-sizing: border-box;
   cursor: pointer;
-
-  @include nx-container-helpers.container-horizontal;
+  text-align: inherit;
+  text-transform: uppercase;
 
   // first-child and last-child added for specificity
   &, &:first-child, &:last-child {
@@ -355,15 +355,14 @@
     padding-bottom: var(--nx-spacing-3x);
   }
 
-  text-align: inherit;
-  text-transform: uppercase;
-
   &, &:hover, &:active, &:focus {
     border: none;
     background: none;
     font: inherit;
     outline: none;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-cell {

--- a/lib/src/base-styles/_nx-tables.scss
+++ b/lib/src/base-styles/_nx-tables.scss
@@ -231,6 +231,9 @@
   padding: nx-table-variables.$table-cell-vertical-padding var(--nx-spacing-3x);
   vertical-align: top;
 
+  @include nx-container-helpers.container-vertical;
+  @include nx-container-helpers.container-horizontal;
+
   &:first-child {
     padding-left: var(--nx-spacing-4x);
   }
@@ -250,9 +253,6 @@
       @include nx-button-helpers.small-icon-btn;
     }
   }
-
-  @include nx-container-helpers.container-vertical;
-  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-cell--label {

--- a/lib/src/base-styles/_nx-text-link.scss
+++ b/lib/src/base-styles/_nx-text-link.scss
@@ -8,8 +8,6 @@
 @use '../scss-shared/nx-text-helpers';
 
 .nx-text-link {
-  @include nx-container-helpers.container-horizontal;
-
   color: var(--nx-color-link);
   cursor: pointer;
   text-decoration: underline;
@@ -64,6 +62,8 @@
       text-decoration: underline;
     }
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 button.nx-text-link {

--- a/lib/src/base-styles/_nx-tile.scss
+++ b/lib/src/base-styles/_nx-tile.scss
@@ -14,8 +14,6 @@
 // Base Tiles
 
 .nx-tile {
-  @include nx-container-helpers.container-vertical;
-
   // the "padding" around the inside edge of the nx-tile
   --nx-tile-spacing: var(--nx-spacing-6x);
 
@@ -27,6 +25,8 @@
   > .nx-footer, > .nx-form > .nx-footer {
     margin-top: var(--nx-spacing-8x);
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 // Tile headers
@@ -74,23 +74,23 @@
 }
 
 .nx-tile__actions {
-  @include nx-container-helpers.container-horizontal;
-
   align-self: start;
   grid-area: actions;
   margin-left: var(--nx-spacing-6x);
   text-align: right;
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-tile__tags {
-  @include nx-container-helpers.container-horizontal;
-
   grid-area: tags;
   margin-left: var(--nx-spacing-4x);
 
   .nx-policy-violation-indicator {
     margin: 0;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-tile-content {
@@ -110,7 +110,6 @@
 
 // On pages with tiles with multiple sections these are lighter weight titles
 .nx-tile-subsection {
-  @include nx-container-helpers.container-vertical;
   margin-top: var(--nx-spacing-8x);
 
   // the first subsection should be separated from preceding non-subsection content by a line. The line should not
@@ -127,8 +126,10 @@
   }
 
   .nx-tile-subsection__header {
-    @include nx-container-helpers.container-vertical;
-
     margin-bottom: var(--nx-spacing-4x);
+
+    @include nx-container-helpers.container-vertical;
   }
+
+  @include nx-container-helpers.container-vertical;
 }

--- a/lib/src/base-styles/_nx-typography.scss
+++ b/lib/src/base-styles/_nx-typography.scss
@@ -92,38 +92,42 @@
 
 .nx-h1 {
   @include nx-text-helpers.bold;
-  @include nx-container-helpers.container-horizontal;
   @extend %nx-heading;
 
   font-size: var(--nx-font-size-heading-1);
   margin-bottom: var(--nx-spacing-6x);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-h2 {
   @include nx-text-helpers.semi-bold;
-  @include nx-container-helpers.container-horizontal;
   @extend %nx-heading;
 
   font-size: var(--nx-font-size-heading-2);
   margin-bottom: var(--nx-spacing-4x);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-h3 {
   @include nx-text-helpers.bold;
-  @include nx-container-helpers.container-horizontal;
   @extend %nx-heading;
 
   font-size: var(--nx-font-size-heading-3);
   margin-bottom: var(--nx-spacing-4x);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-h4 {
   @include nx-text-helpers.semi-bold;
-  @include nx-container-helpers.container-horizontal;
   @extend %nx-heading;
 
   font-size: var(--nx-font-size-heading-4);
   margin-bottom: var(--nx-spacing-2x);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-p {

--- a/lib/src/base-styles/_nx-variables.scss
+++ b/lib/src/base-styles/_nx-variables.scss
@@ -92,9 +92,11 @@
                               0 1px 1px 0 Hsla(var(--nx-swatch-indigo-hs), 5%, 0.75);
   }
 
-  // Deprecated variables
-  --nx-border-subsection: 1px solid var(--nx-color-subsection-border);
-  --nx-box-shadow-focus: 0 0 3px 1px var(--nx-color-interactive-shadow-focus);
-  // similar to box-shadow-focus listed above, but for use in drop-shadow filters rather than box-shadow properties
-  --nx-drop-shadow-focus: 0 0 3px var(--nx-color-interactive-shadow-focus);
+  & {
+    // Deprecated variables
+    --nx-border-subsection: 1px solid var(--nx-color-subsection-border);
+    --nx-box-shadow-focus: 0 0 3px 1px var(--nx-color-interactive-shadow-focus);
+    // similar to box-shadow-focus listed above, but for use in drop-shadow filters rather than box-shadow properties
+    --nx-drop-shadow-focus: 0 0 3px var(--nx-color-interactive-shadow-focus);
+  }
 }

--- a/lib/src/components/NxAccordion/NxAccordion.scss
+++ b/lib/src/components/NxAccordion/NxAccordion.scss
@@ -23,7 +23,6 @@
   }
 
   > .nx-accordion__summary-wrapper {
-    @include nx-container-helpers.container-horizontal;
     align-items: center;
     box-sizing: border-box;
     color: var(--nx-color-text-stark);
@@ -41,6 +40,8 @@
         @include nx-button-helpers.small-icon-btn;
       }
     }
+
+    @include nx-container-helpers.container-horizontal;
   }
 
   &:focus {
@@ -63,12 +64,13 @@
 
 .nx-accordion__subheader {
   @include nx-text-helpers.bold;
-  @include nx-container-helpers.container-horizontal;
 
   color: var(--nx-color-text-stark);
   font-size: var(--nx-font-size-heading-3);
   margin-bottom: var(--nx-spacing-4x);
   max-width: var(--nx-width-text-wrapping);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-accordion__chevron {
@@ -76,7 +78,6 @@
 }
 
 .nx-accordion__content {
-  @include nx-container-helpers.container-vertical;
   $vertical-padding: var(--nx-spacing-6x);
 
   border-top: 1px solid var(--nx-color-accordion-header-divider);
@@ -92,4 +93,6 @@
       }
     }
   }
+
+  @include nx-container-helpers.container-vertical;
 }

--- a/lib/src/components/NxBreadcrumb/NxBreadcrumb.scss
+++ b/lib/src/components/NxBreadcrumb/NxBreadcrumb.scss
@@ -25,8 +25,6 @@
   }
 
   &__list-item {
-    @include nx-container-helpers.container-horizontal;
-
     align-items: baseline;
     display: flex;
 
@@ -45,6 +43,8 @@
       content: none;
     }
 
+
+    @include nx-container-helpers.container-horizontal;
   }
 
   &__link {

--- a/lib/src/components/NxCollapsibleItems/NxCollapsibleItems.scss
+++ b/lib/src/components/NxCollapsibleItems/NxCollapsibleItems.scss
@@ -85,11 +85,11 @@ $-form-child-left-padding: calc(#{$-trigger-side-padding} + #{$-triangle-box-wid
 }
 
 .nx-collapsible-items__action-content {
-  @include nx-container-helpers.container-horizontal;
-
   .nx-btn--icon-only {
     @include nx-button-helpers.small-icon-btn;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 %collapsible-items-focus-style {
@@ -98,7 +98,6 @@ $-form-child-left-padding: calc(#{$-trigger-side-padding} + #{$-triangle-box-wid
 }
 
 .nx-collapsible-items__trigger {
-  @include nx-container-helpers.container-horizontal;
   align-items: center;
   background: none;
   border: 0;
@@ -128,6 +127,8 @@ $-form-child-left-padding: calc(#{$-trigger-side-padding} + #{$-triangle-box-wid
     background-color: var(--nx-color-interactive-background-active);
     outline: none;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-collapsible-items__twisty {
@@ -143,7 +144,6 @@ $-form-child-left-padding: calc(#{$-trigger-side-padding} + #{$-triangle-box-wid
 }
 
 .nx-collapsible-items__text {
-  @include nx-container-helpers.container-horizontal;
   @include nx-text-helpers.truncate-ellipsis;
 
   align-items: center;
@@ -161,6 +161,8 @@ $-form-child-left-padding: calc(#{$-trigger-side-padding} + #{$-triangle-box-wid
     flex-shrink: 0;
     max-width: 110px;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-collapsible-items__child {

--- a/lib/src/components/NxColorPicker/NxColorPicker.scss
+++ b/lib/src/components/NxColorPicker/NxColorPicker.scss
@@ -8,8 +8,6 @@
 @use "../../scss-shared/nx-container-helpers";
 
 .nx-color-picker {
-  @include nx-container-helpers.container-horizontal;
-
   .nx-legend__text {
     margin-bottom: var(--nx-spacing-base);
   }
@@ -67,4 +65,6 @@
     opacity: 0;
     position: absolute;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }

--- a/lib/src/components/NxCombobox/NxCombobox.scss
+++ b/lib/src/components/NxCombobox/NxCombobox.scss
@@ -20,7 +20,6 @@
   }
 
   &__alert {
-    @include nx-container-helpers.container-vertical;
     position: absolute;
     width: 100%;
     border-radius: var(--nx-border-radius);
@@ -36,6 +35,8 @@
     &--error {
       padding: 0;
     }
+
+    @include nx-container-helpers.container-vertical;
   }
 
   &__empty-message {

--- a/lib/src/components/NxDrawer/NxDrawer.scss
+++ b/lib/src/components/NxDrawer/NxDrawer.scss
@@ -44,12 +44,6 @@
   padding: initial;
   width: initial;
 
-  &::backdrop {
-    // Chrome tries to add its own subtle mask here which doubles up with our own
-    display: none;
-    pointer-events: auto;
-  }
-
   background-color: var(--nx-color-drawer-background);
   // A spread of -32px sets the spread inward to create the effect of a smaller, vertically centered
   // element behind the drawer, as displayed in the mocks. The x-offset counteracts the shadow’s spread
@@ -68,6 +62,12 @@
   padding: $padding;
   padding-bottom: 0;
   width: 520px;
+
+  &::backdrop {
+    // Chrome tries to add its own subtle mask here which doubles up with our own
+    display: none;
+    pointer-events: auto;
+  }
 
   &--narrow {
     width: 348px;
@@ -98,13 +98,13 @@
   }
 
   .nx-drawer-content {
-    @include nx-container-helpers.container-vertical;
-
     overflow: auto;
     padding: $padding;
     margin-right: calc(0px - #{$padding});
     margin-left: calc(0px - #{$padding});
     width: auto;
+
+    @include nx-container-helpers.container-vertical;
   }
 
   .nx-footer {
@@ -114,8 +114,6 @@
 }
 
 .nx-drawer-header {
-  @include nx-container-helpers.container-vertical;
-
   align-items: start;
   border-bottom: var(--nx-border-default);
   display: grid;
@@ -149,4 +147,6 @@
     grid-area: description;
     margin: var(--nx-spacing-4x) 0 0 0;
   }
+
+  @include nx-container-helpers.container-vertical;
 }

--- a/lib/src/components/NxDropdown/NxDropdown.scss
+++ b/lib/src/components/NxDropdown/NxDropdown.scss
@@ -57,10 +57,11 @@
   }
 
   .nx-dropdown__toggle-label {
-    @include nx-container-helpers.container-horizontal;
     @include nx-text-helpers.truncate-ellipsis;
 
     flex-grow: 1;
+
+    @include nx-container-helpers.container-horizontal;
   }
 
   .nx-dropdown__toggle-caret {

--- a/lib/src/components/NxDropdownMenu/NxDropdownMenu.scss
+++ b/lib/src/components/NxDropdownMenu/NxDropdownMenu.scss
@@ -10,8 +10,6 @@
 @use '../../scss-shared/nx-button-helpers';
 
 .nx-dropdown-menu {
-  @include nx-container-helpers.container-vertical;
-
   background: var(--nx-color-dropdown-menu-background);
   border-radius: var(--nx-border-radius);
   box-shadow: var(--nx-box-shadow-dropdown);
@@ -25,10 +23,11 @@
   top: 100%;
   width: nx-dropdown-variables.$dropdown-width;
   z-index: 1;
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-dropdown-link, .nx-dropdown-button {
-  @include nx-container-helpers.container-horizontal;
   @include nx-text-helpers.truncate-ellipsis;
   @include nx-text-helpers.regular;
 
@@ -43,6 +42,8 @@
   text-align: left;
   text-decoration: none;
   width: 100%;
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-dropdown-button {

--- a/lib/src/components/NxFieldset/NxFieldset.scss
+++ b/lib/src/components/NxFieldset/NxFieldset.scss
@@ -11,8 +11,6 @@
 // be used, but you'll still typically want the <legend> styled the way a <label> on a text field would be using
 // .nx-label.
 .nx-fieldset {
-  @include nx-container-helpers.container-vertical;
-
   border: 0;
   margin: 0 0 var(--nx-spacing-8x) 0;
   min-inline-size: auto;
@@ -23,4 +21,6 @@
   &.invalid > :nth-last-child(2) {
     margin-bottom: 0;
   }
+
+  @include nx-container-helpers.container-vertical;
 }

--- a/lib/src/components/NxFileUpload/NxFileUpload.scss
+++ b/lib/src/components/NxFileUpload/NxFileUpload.scss
@@ -10,8 +10,6 @@
 @use '../../scss-shared/nx-button-helpers';
 
 .nx-file-upload {
-  @include nx-container-helpers.container-horizontal;
-
   position: relative; // correctly position validation error when scrolling
   margin-bottom: var(--nx-spacing-8x);
 
@@ -31,8 +29,6 @@
   }
 
   &__no-file-message {
-    @include nx-container-helpers.container-horizontal;
-
     > .nx-icon {
       display: none;
     }
@@ -49,7 +45,11 @@
     &.hidden {
       display: none;
     }
+
+    @include nx-container-helpers.container-horizontal;
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-selected-file {
@@ -90,8 +90,6 @@
   }
 
   &__dismiss-btn {
-    @include nx-container-helpers.container-horizontal;
-
     align-items: center;
     background: transparent;
     border-color: transparent;
@@ -130,5 +128,7 @@
           var(--nx-color-file-upload-selected-border);
       background-color: var(--nx-color-file-upload-selected-dismiss-background-active);
     }
+
+    @include nx-container-helpers.container-horizontal;
   }
 }

--- a/lib/src/components/NxFilterInput/NxFilterInput.scss
+++ b/lib/src/components/NxFilterInput/NxFilterInput.scss
@@ -8,8 +8,6 @@
 @use '../../scss-shared/nx-button-helpers';
 
 .nx-filter-input {
-  @include nx-container-helpers.container-horizontal;
-
   margin-bottom: 0;
   white-space: nowrap;
 
@@ -45,4 +43,6 @@
       visibility: hidden;
     }
   }
+
+  @include nx-container-helpers.container-horizontal;
 }

--- a/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
+++ b/lib/src/components/NxGlobalSidebar/NxGlobalSidebar.scss
@@ -18,8 +18,6 @@ $-text-color: var(--nx-swatch-white);
 $-button-border-width: 2px;
 
 .nx-global-sidebar {
-  @include nx-container-helpers.container-vertical;
-
   background-color: var(--nx-color-global-sidebar-background);
   border-right: var(--nx-border-width-global-sidebar) solid var(--nx-color-global-sidebar-border);
   box-sizing: border-box;
@@ -37,6 +35,8 @@ $-button-border-width: 2px;
   .nx-text-link {
     margin: 0;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-global-sidebar__header {
@@ -114,7 +114,6 @@ $-button-border-width: 2px;
 }
 
 .nx-global-sidebar__navigation-link {
-  @include nx-container-helpers.container-horizontal;
   @include nx-text-helpers.truncate-ellipsis;
 
   border: $-button-border-width solid transparent;
@@ -169,6 +168,8 @@ $-button-border-width: 2px;
       outline: none;
     }
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-global-sidebar__navigation-text {
@@ -221,17 +222,15 @@ $-button-border-width: 2px;
 }
 
 .nx-global-sidebar__other-content {
-  @include nx-container-helpers.container-vertical;
-
   border-bottom: 1px solid var(--nx-color-global-sidebar-separator);
   flex: 1;
   padding: var(--nx-spacing-4x) $-left-right-spacing;
   max-height: unset;
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-global-sidebar__footer {
-  @include nx-container-helpers.container-vertical;
-
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -242,6 +241,8 @@ $-button-border-width: 2px;
   &:empty {
     padding-top: 0;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-global-sidebar__support {

--- a/lib/src/components/NxLoadError/NxLoadError.scss
+++ b/lib/src/components/NxLoadError/NxLoadError.scss
@@ -8,11 +8,12 @@
 
 .nx-load-error {
   &__content {
-    @include nx-container-helpers.container-horizontal;
     align-items: first baseline;
     display: flex;
     flex-wrap: wrap;
     row-gap: var(--nx-spacing-6x);
+
+    @include nx-container-helpers.container-horizontal;
   }
 
   &__message {

--- a/lib/src/components/NxLoadingSpinner/NxLoadingSpinner.scss
+++ b/lib/src/components/NxLoadingSpinner/NxLoadingSpinner.scss
@@ -7,6 +7,7 @@
 @use '../../scss-shared/nx-container-helpers';
 
 .nx-loading-spinner {
-  @include nx-container-helpers.container-horizontal;
   margin: 8px 0;
+
+  @include nx-container-helpers.container-horizontal;
 }

--- a/lib/src/components/NxModal/NxModal.scss
+++ b/lib/src/components/NxModal/NxModal.scss
@@ -22,6 +22,8 @@
   padding: var(--nx-modal-padding);
   width: 800px;
 
+  @include nx-container-helpers.container-vertical;
+
   &, > .nx-form {
     display: flex;
     flex-basis: auto;
@@ -39,8 +41,6 @@
   .nx-footer {
     margin: 0;
   }
-
-  @include nx-container-helpers.container-vertical;
 }
 
 .nx-modal--narrow {

--- a/lib/src/components/NxModal/NxModal.scss
+++ b/lib/src/components/NxModal/NxModal.scss
@@ -9,8 +9,6 @@
 @use '../../scss-shared/nx-mask-helpers';
 
 .nx-modal {
-  @include nx-container-helpers.container-vertical;
-
   // the "padding" around the interior of nx-modal. In order to get borders and scrollbars to appear
   // in the desired locations, this can't actually be implemented as padding on .nx-modal, but must instead be
   // a mix of padding and margin on the .nx-modal, .nx-modal-header, .nx-modal-content, and .nx-footer elements
@@ -41,6 +39,8 @@
   .nx-footer {
     margin: 0;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-modal--narrow {
@@ -52,8 +52,6 @@
 }
 
 .nx-modal-header {
-  @include nx-container-helpers.container-vertical;
-
   border-bottom: var(--nx-border-default);
   padding-bottom: var(--nx-spacing-6x);
 
@@ -61,6 +59,8 @@
     @include nx-text-helpers.truncate-ellipsis;
     max-width: unset;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-modal-backdrop {
@@ -85,7 +85,6 @@
 }
 
 .nx-modal-content {
-  @include nx-container-helpers.container-vertical;
   flex-shrink: 1;
   flex-basis: auto;
 
@@ -96,6 +95,8 @@
   margin-left: calc(0px - var(--nx-modal-padding));
   padding: var(--nx-spacing-6x) var(--nx-modal-padding) var(--nx-spacing-8x) var(--nx-modal-padding);
   overflow-y: auto;
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-modal-content--tabs {

--- a/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
+++ b/lib/src/components/NxSearchDropdown/NxSearchDropdown.scss
@@ -22,10 +22,10 @@
   }
 
   &__empty-message {
-    @include nx-container-helpers.container-horizontal;
-
     padding: var(--nx-spacing-base) var(--nx-spacing-4x);
     text-align: center;
+
+    @include nx-container-helpers.container-horizontal;
   }
 
   &--dropdown-showable {

--- a/lib/src/components/NxSearchTransferList/NxSearchTransferList.scss
+++ b/lib/src/components/NxSearchTransferList/NxSearchTransferList.scss
@@ -7,8 +7,6 @@
 @use '../../scss-shared/nx-container-helpers';
 
 .nx-search-transfer-list {
-  @include nx-container-helpers.container-vertical;
-
   display: flex;
   flex-direction: column;
   width: max-content;
@@ -20,4 +18,6 @@
   .nx-search-dropdown__input {
     width: 100%;
   }
+
+  @include nx-container-helpers.container-vertical;
 }

--- a/lib/src/components/NxSubmitMask/NxSubmitMask.scss
+++ b/lib/src/components/NxSubmitMask/NxSubmitMask.scss
@@ -17,8 +17,6 @@
 }
 
 .nx-submit-mask__message {
-  @include nx-container-helpers.container-horizontal;
-  @include nx-container-helpers.container-vertical;
   @include nx-text-helpers.semi-bold;
 
   background-color: var(--nx-color-component-background);
@@ -29,6 +27,9 @@
   text-align: center;
   min-width: 124px;
   max-width: 250px;
+
+  @include nx-container-helpers.container-horizontal;
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-submit-mask--success {

--- a/lib/src/components/NxTabs/NxTabs.scss
+++ b/lib/src/components/NxTabs/NxTabs.scss
@@ -12,21 +12,21 @@
 }
 
 .nx-tab-list {
-  @include nx-container-helpers.container-horizontal;
-
   border-bottom: var(--nx-border-default);
   display: flex;
   margin: 0 0 var(--nx-spacing-6x) 0;
   padding: 0;
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-tab-panel {
-  @include nx-container-helpers.container-vertical;
-
   &:focus {
     outline: solid 1px var(--nx-color-interactive-border-focus);
     outline-offset: -1px;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-tab {

--- a/lib/src/components/NxTag/NxTag.scss
+++ b/lib/src/components/NxTag/NxTag.scss
@@ -11,7 +11,6 @@
 
 .nx-tag {
   @include nx-text-helpers.semi-bold;
-  @include nx-container-helpers.container-horizontal;
 
   align-items: center;
   background-color: var(--nx-selectable-color-dark);
@@ -30,6 +29,8 @@
   user-select: none;
   // Uppercase Min so SCSS ignores it and uses CSS min, not SCSS min
   max-width: Min(100%, 320px);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-tag--selectable {

--- a/lib/src/components/NxTextInput/NxTextInput.scss
+++ b/lib/src/components/NxTextInput/NxTextInput.scss
@@ -19,8 +19,6 @@ $-border-width: 1px;
   margin-bottom: var(--nx-spacing-8x);
 
   &__box {
-    @include nx-container-helpers.container-horizontal;
-
     align-items: center;
     background-color: var(--nx-color-component-background);
     border: $-border-width solid var(--nx-color-interactive-border);
@@ -46,6 +44,8 @@ $-border-width: 1px;
     &::before {
       content: '\200B';
     }
+
+    @include nx-container-helpers.container-horizontal;
   }
 
   &__input {

--- a/lib/src/components/NxThreatIndicatorLegend/NxThreatIndicatorLegend.scss
+++ b/lib/src/components/NxThreatIndicatorLegend/NxThreatIndicatorLegend.scss
@@ -24,9 +24,10 @@
   }
 
   .nx-threat-indicator-legend__threat-container {
-    @include nx-container-helpers.container-horizontal;
     @include nx-text-helpers.semi-bold;
     color: var(--nx-color-threat-level-text);
+
+    @include nx-container-helpers.container-horizontal;
   }
 }
 

--- a/lib/src/components/NxToast/NxToast.scss
+++ b/lib/src/components/NxToast/NxToast.scss
@@ -33,8 +33,6 @@
 }
 
 .nx-toast {
-  @include nx-container-helpers.container-vertical;
-  
   position: relative;
   right: 0;
   opacity: 1;
@@ -46,6 +44,8 @@
   &.nx-toast--closing {
     animation: nx-toast-animation-out 250ms ease-in;
   }
+
+  @include nx-container-helpers.container-vertical;
 }
 
 // Setting the max-height of each toast to $nx-toast-height in both animations allows for each 

--- a/lib/src/components/NxTransferListHalf/NxTransferListHalf.scss
+++ b/lib/src/components/NxTransferListHalf/NxTransferListHalf.scss
@@ -45,8 +45,6 @@ $-visible-item-count: 10;
 }
 
 .nx-transfer-list__move-all {
-  @include nx-container-helpers.container-horizontal;
-
   align-self: start;
   background: initial;
   border: initial;
@@ -67,12 +65,12 @@ $-visible-item-count: 10;
   + .nx-transfer-list__item-list {
     margin-top: var(--nx-spacing-4x);
   }
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-transfer-list__item-list {
   $item-height: '(1em * var(--nx-line-height) + 2 * #{$-item-vertical-padding})';
-
-  @include nx-container-helpers.container-vertical;
 
   background-color: var(--nx-color-transfer-list-item-list-background);
   border-top: var(--nx-border-default);
@@ -89,6 +87,8 @@ $-visible-item-count: 10;
   overflow-y: auto;
   padding: var(--nx-spacing-6x) $-control-box-side-spacing;
   margin-top: var(--nx-spacing-6x);
+
+  @include nx-container-helpers.container-vertical;
 }
 
 .nx-transfer-list__item {
@@ -100,7 +100,6 @@ $-visible-item-count: 10;
 }
 
 .nx-transfer-list__select {
-  @include nx-container-helpers.container-horizontal;
   @include nx-text-helpers.truncate-ellipsis;
 
   border-radius: var(--nx-border-radius);
@@ -108,6 +107,8 @@ $-visible-item-count: 10;
   flex: auto;
   padding: calc(var(--nx-spacing-2x) - 1px);
   padding-left: var(--nx-spacing-4x);
+
+  @include nx-container-helpers.container-horizontal;
 }
 
 .nx-transfer-list__item--movable {

--- a/lib/src/components/NxTree/NxTree.scss
+++ b/lib/src/components/NxTree/NxTree.scss
@@ -134,7 +134,6 @@
   }
 
   &__item-label {
-    @include nx-container-helpers.container-horizontal;
     @include nx-text-helpers.truncate-ellipsis;
 
     grid-area: label;
@@ -144,6 +143,8 @@
     .nx-icon:not(.nx-tree__colored-icon, .nx-icon--colorful) {
       color: var(--nx-color-text-stark);
     }
+
+    @include nx-container-helpers.container-horizontal;
   }
 
   &--no-gutter > .nx-tree__item {

--- a/lib/src/scss-shared/_nx-text-helpers.scss
+++ b/lib/src/scss-shared/_nx-text-helpers.scss
@@ -121,7 +121,6 @@
 }
 
 %nx-blockquote {
-  @include nx-container-helpers.container-vertical;
   background-color: var(--nx-color-blockquote-background);
   border: var(--nx-border-default);
   border-left-width: 8px;
@@ -129,6 +128,8 @@
   margin: var(--nx-spacing-4x) 0 var(--nx-spacing-6x) 0;
   padding: var(--nx-spacing-6x);
   max-width: var(--nx-width-text-wrapping);
+
+  @include nx-container-helpers.container-vertical;
 }
 
 //Class that allows making content visible only to screen readers

--- a/lib/yarn.lock
+++ b/lib/yarn.lock
@@ -5526,10 +5526,10 @@ sass-loader@^13.2.2:
     klona "^2.0.6"
     neo-async "^2.6.2"
 
-sass@^1.62.1:
-  version "1.62.1"
-  resolved "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz#caa8d6bf098935bc92fc73fa169fb3790cacd029"
-  integrity sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==
+sass@^1.77.8:
+  version "1.77.8"
+  resolved "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz#9f18b449ea401759ef7ec1752a16373e296b52bd"
+  integrity sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"


### PR DESCRIPTION
When upgrading all dependencies of the SAB, the frontend build was found to emit an enormous number of warnings about https://sass-lang.com/d/mixed-decls .  These need to be fixed at the RSC level.  This PR updates `sass` to the latest version in order to trigger these deprecation warnings, and then fixes them by reordering declarations.