### PR TITLE
CSDI-2092 Remove deprecated ~                                                                                               

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "13.4.0",
+  "version": "13.3.1",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "13.4.0",
+  "version": "13.3.1",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_base.scss
+++ b/lib/src/base-styles/_base.scss
@@ -9,7 +9,7 @@
  * any consumer of the react-shared-components lib
  */
 
-@use '~@fortawesome/fontawesome-svg-core/styles';
+@use '@fortawesome/fontawesome-svg-core/styles';
 
 @use 'nx-variables';
 @use 'nx-colors';


### PR DESCRIPTION
This change is for two reasons:
1. Building of RSC was failing in Vite environment with `Can't find stylesheet to import`
1. Webpack has deprecated `~` in `@use` (see [resolving import at rules](https://webpack.js.org/loaders/sass-loader/#resolving-import-at-rules)).

This PR addresses both these issues