### PR TITLE
Force prismjs upgrade to fix CVE-2024-53382

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "12.18.4",
+  "version": "12.18.5",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -94,5 +94,8 @@
     "react-router": "^6.11.2",
     "react-router-dom": "^6.11.2",
     "react-syntax-highlighter": "^15.5.0"
+  },
+  "resolutions": {
+    "prismjs": "^1.30.0"
   }
 }

--- a/gallery/yarn.lock
+++ b/gallery/yarn.lock
@@ -7061,15 +7061,10 @@ pretty-format@^29.5.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prismjs@^1.27.0:
-  version "1.29.0"
-  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
-  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
-
-prismjs@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
-  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+prismjs@^1.27.0, prismjs@^1.30.0, prismjs@~1.27.0:
+  version "1.30.0"
+  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
+  integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "12.18.4",
+  "version": "12.18.5",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This fixes the prismjs violation that recently came up in the 12.x-backports branch of RSC: https://sonatype.sonatype.app/platform/assets/index.html#/applicationReport/sonatype-react-shared-components/0926d7360ef8496187cddb7849058857/componentDetails/4494db17b093e8659407/violations