### PR TITLE
Create a reusable build image for RSC - CLM-1797

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     apt-get install jq -y && \
     apt-get install chromium libatk-bridge2.0-0 libxkbcommon0 libgbm1 -y
 
-ENV PUPPETEER_EXECUTABLE_PATH /usr/bin/chromium
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 RUN useradd -u 1002 -g 100 jenkins
 RUN mkdir -p /home/jenkins/.npm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,8 @@
  */
 @Library(['private-pipeline-library', 'jenkins-shared']) _
 
+// Selenium is only used for the SSR tests.  The visual tests use puppeteer, which accesses Chromium in the local
+// environment
 def seleniumDockerImage = 'docker-all.repo.sonatype.com/selenium/standalone-chrome'
 def seleniumDockerVersion = '132.0-20250202'
 
@@ -17,6 +19,9 @@ def isMainBranch() {
 
 dockerizedBuildPipeline(
   deployBranch: deployBranch,
+
+  dockerImageId: 'docker-internal.repo.sonatype.com/sonatype/react-shared-components-ci:latest',
+
   // expose gallery port and nextjs dev port on host so selenium container can hit it
   dockerArgs: '-p 4043:4043 -p 3000:3000',
 

--- a/Jenkinsfile.build-image
+++ b/Jenkinsfile.build-image
@@ -36,11 +36,5 @@ dockerizedBuildPipeline(
           "--tag ${sonatypeDockerRegistryId()}/${imageName}:latest " +
           "--tag ${sonatypeDockerRegistryId()}/${imageName}:${env.VERSION} ."
     }
-  },
-  onUnstable: {
-    notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
-  },
-  onFailure: {
-    notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
   }
 )

--- a/Jenkinsfile.build-image
+++ b/Jenkinsfile.build-image
@@ -38,13 +38,6 @@ withCredentials([string(credentialsId: 'zion-nexus-cache', variable: 'ZION_AGENT
             "--tag ${sonatypeDockerRegistryId()}/${imageName}:${env.VERSION} ."
       }
     },
-    postDeploy: {
-      sshagent(credentials: [sonatypeZionCredentialsId()]) {
-        runSafely "git config user.email 'sonatype-zion@sonatype.com'"
-        runSafely "git tag release-${env.VERSION}"
-        runSafely "git push origin release-${env.VERSION}"
-      }
-    },
     onUnstable: {
       notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
     },

--- a/Jenkinsfile.build-image
+++ b/Jenkinsfile.build-image
@@ -27,6 +27,8 @@ dockerizedBuildPipeline(
         new Expectation('chromium', 'chromium', '--version', /Chromium/)
     ])
   },
+  // This image is only used in the build of this repo, it doesn't need a vuln scan
+  skipVulnerabilityScan: true,
   deploy: {
     withSonatypeDockerRegistry() {
       sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"

--- a/Jenkinsfile.build-image
+++ b/Jenkinsfile.build-image
@@ -17,32 +17,28 @@ String deployBranch = 'main'
  * is not constantly changing and affecting the visual tests.
  * This Jenkinsfile is based off of https://github.com/sonatype/bnr-license-check/blob/main/Jenkinsfile
  */
-withCredentials([string(credentialsId: 'zion-nexus-cache', variable: 'ZION_AGENT_TOKEN')]) {
-  dockerizedBuildPipeline(
-    dockerSecrets: ['id=ZION_AGENT_TOKEN'],
-    deployBranch: deployBranch,
-    retentionPolicy: RetentionPolicy.TEN_BUILDS,
-    setVersion: { env['VERSION'] = "${env.BUILD_NUMBER}" },
-    buildAndTest: {
-      // Note that we don't want to expect a specific chromium version, as that it what is likely to change
-      validateExpectations([
-          new Expectation('chromium', 'chromium', '--version', /Chromium/)
-      ])
-    },
-    deploy: {
-      withSonatypeDockerRegistry() {
-        sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"
-        sh "docker buildx build --platform linux/amd64,linux/arm64 --push " +
-            "--secret id=ZION_AGENT_TOKEN " +
-            "--tag ${sonatypeDockerRegistryId()}/${imageName}:latest " +
-            "--tag ${sonatypeDockerRegistryId()}/${imageName}:${env.VERSION} ."
-      }
-    },
-    onUnstable: {
-      notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
-    },
-    onFailure: {
-      notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
+dockerizedBuildPipeline(
+  deployBranch: deployBranch,
+  retentionPolicy: RetentionPolicy.TEN_BUILDS,
+  setVersion: { env['VERSION'] = "${env.BUILD_NUMBER}" },
+  buildAndTest: {
+    // Note that we don't want to expect a specific chromium version, as that it what is likely to change
+    validateExpectations([
+        new Expectation('chromium', 'chromium', '--version', /Chromium/)
+    ])
+  },
+  deploy: {
+    withSonatypeDockerRegistry() {
+      sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"
+      sh "docker buildx build --platform linux/amd64,linux/arm64 --push " +
+          "--tag ${sonatypeDockerRegistryId()}/${imageName}:latest " +
+          "--tag ${sonatypeDockerRegistryId()}/${imageName}:${env.VERSION} ."
     }
-  )
-}
+  },
+  onUnstable: {
+    notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
+  },
+  onFailure: {
+    notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
+  }
+)

--- a/Jenkinsfile.build-image
+++ b/Jenkinsfile.build-image
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/.
+ */
+import com.sonatype.jenkins.shared.Expectation
+
+@Library(['private-pipeline-library', 'jenkins-shared']) _
+
+String imageName = 'sonatype/react-shared-components-ci'
+String deployBranch = 'main'
+
+/**
+ * This build builds the docker image within which the actual RSC build (defined in `Jenkinsfile`) executes.
+ * The docker image is build separately, on-demand, so that the version of chromium used in the RSC build
+ * is not constantly changing and affecting the visual tests.
+ * This Jenkinsfile is based off of https://github.com/sonatype/bnr-license-check/blob/main/Jenkinsfile
+ */
+withCredentials([string(credentialsId: 'zion-nexus-cache', variable: 'ZION_AGENT_TOKEN')]) {
+  dockerizedBuildPipeline(
+    dockerSecrets: ['id=ZION_AGENT_TOKEN'],
+    deployBranch: deployBranch,
+    retentionPolicy: RetentionPolicy.TEN_BUILDS,
+    setVersion: { env['VERSION'] = "${env.BUILD_NUMBER}" },
+    buildAndTest: {
+      // Note that we don't want to expect a specific chromium version, as that it what is likely to change
+      validateExpectations([
+          new Expectation('chromium', 'chromium', '--version', /Chromium/)
+      ])
+    },
+    deploy: {
+      withSonatypeDockerRegistry() {
+        sh "docker buildx create --driver-opt=\"image=${sonatypeDockerRegistryId()}/moby/buildkit\" --use"
+        sh "docker buildx build --platform linux/amd64,linux/arm64 --push " +
+            "--secret id=ZION_AGENT_TOKEN " +
+            "--tag ${sonatypeDockerRegistryId()}/${imageName}:latest " +
+            "--tag ${sonatypeDockerRegistryId()}/${imageName}:${env.VERSION} ."
+      }
+    },
+    postDeploy: {
+      sshagent(credentials: [sonatypeZionCredentialsId()]) {
+        runSafely "git config user.email 'sonatype-zion@sonatype.com'"
+        runSafely "git tag release-${env.VERSION}"
+        runSafely "git push origin release-${env.VERSION}"
+      }
+    },
+    onUnstable: {
+      notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
+    },
+    onFailure: {
+      notifyChat(env: env, currentBuild: currentBuild, room: 'react-components')
+    }
+  )
+}


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/RSC-1797

This PR creates a separate Jenkins build which can be run manually to update the docker container within which the main RSC build runs.  This is in contrast to the current situation, where the docker container is recreated at the beginning of every RSC build.  The goal here is to stabilize the version of Chromium being used, which should significantly help stabilize the visual tests.  The Chromium version in a given docker container build is whatever's current at the time that the container is built.  The build for the docker container can be found at https://jenkins.ci.sonatype.dev/job/uxui/job/RSC%20CI%20docker%20container/