### PR TITLE
Fix nx-page-main stretch-to-fit in footer container - RSC-1975

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components-gallery",
-  "version": "14.0.12",
+  "version": "14.0.13",
   "description": "Gallery application to demonstrate usage and look of Sonatype shared UI components",
   "main": "src/main.ts",
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sonatype/react-shared-components",
-  "version": "14.0.12",
+  "version": "14.0.13",
   "description": "Sonatype shared UI components and utilities written in React",
   "main": "index.js",
   "repository": {

--- a/lib/src/base-styles/_nx-global-footer-2.scss
+++ b/lib/src/base-styles/_nx-global-footer-2.scss
@@ -24,14 +24,13 @@
   overflow-y: auto;
 
   > .nx-page-main {
-    flex: 0 0 auto;
+    flex: 1 0 auto;
   }
 
   &.nx-viewport-sized {
     overflow: hidden;
 
     > .nx-page-main {
-      flex-grow: 1;
       flex-shrink: 1;
     }
   }


### PR DESCRIPTION
As seen in 
<img width="1440" height="577" alt="image" src="https://github.com/user-attachments/assets/b93b8a31-e5f7-40a3-a356-e995ff070e91" />, the `.nx-page-main` does not stretch vertically to fill the available space when it is wrapped in an `.nx-global-footer-2-container`.  This is inconsistent with `.nx-page-main`'s behavior outside of `.nx-global-footer-2-container`, and so is unexpected.  This PR makes it stretch to fill the available space in this scenario.